### PR TITLE
Adding bandwith measurement to downloadCutout

### DIFF
--- a/src/fibad/download.py
+++ b/src/fibad/download.py
@@ -22,8 +22,12 @@ variable_fields = ["tract", "ra", "dec"]
 def working_directory(path: Path):
     """
     Context Manager to change our working directory.
-
     Supports downloadCutouts which always writes to cwd.
+
+    Parameters
+    ----------
+    path : Path
+        Path that we change `Path.cwd()` while we are active.
     """
     old_cwd = Path.cwd()
     os.chdir(path)
@@ -36,6 +40,13 @@ def working_directory(path: Path):
 def run(args, config):
     """
     Main entrypoint for downloading cutouts from HSC for use with fibad
+
+    Parameters
+    ----------
+    args : list
+        Command line arguments (unused)
+    config : dict
+        Runtime configuration, which is only read by this function
     """
 
     config = config.get("download", {})
@@ -72,12 +83,23 @@ def run(args, config):
 
 # TODO add error checking
 def filterfits(filename: str, column_names: list[str]) -> Table:
-    """
-    Read a fits file with the required column names for making cutouts
+    """Read a fits file with the required column names for making cutouts
 
-    Returns an astropy table containing only the necessary fields
 
-    The easiest way to make one of these is to select from the main HSC catalog
+
+    The easiest way to make such a fits file is to select from the main HSC catalog
+
+    Parameters
+    ----------
+    filename : str
+        The fits file to read in
+    column_names : list[str]
+        The columns that are filtered out
+
+    Returns
+    -------
+    Table
+       Returns an astropy table containing only the fields specified in column_names
     """
     t = Table.read(filename)
     columns = [t[column] for column in column_names]
@@ -85,9 +107,18 @@ def filterfits(filename: str, column_names: list[str]) -> Table:
 
 
 def rect_from_config(config: dict) -> dC.Rect:
-    """
-    Takes our Download config and loads cutout config
+    """Takes our runtime config and loads cutout config
     common to all cutouts into a prototypical Rect for downloading
+
+    Parameters
+    ----------
+    config : dict
+        Runtime config, only the download section
+
+    Returns
+    -------
+    dC.Rect
+        A single rectangle with fields `sw`, `sh`, `filter`, `rerun`, and `type` populated from the config
     """
     return dC.Rect.create(
         sw=config["sw"],
@@ -99,8 +130,7 @@ def rect_from_config(config: dict) -> dC.Rect:
 
 
 def create_rects(locations: Table, offset: int = 0, default: dC.Rect = None) -> list[dC.Rect]:
-    """
-    Create the rects we will need to pass to the downloader.
+    """Create the rects we will need to pass to the downloader.
     One Rect per location in our list of sky locations.
 
     Rects are created with all fields in the default rect pre-filled
@@ -108,6 +138,24 @@ def create_rects(locations: Table, offset: int = 0, default: dC.Rect = None) -> 
     Offset here is to allow multiple downloads on different sections of the source list
     without file name clobbering during the download phase. The offset is intended to be
     the index of the start of the locations table within some larger fits file.
+
+    Parameters
+    ----------
+    locations : Table
+        Table containing ra, dec locations in the sky
+    offset : int, optional
+        Index to start the `lineno` field in the rects at, by default 0. The purpose of this is to allow
+        multiple downloads on different sections of a larger source list without file name clobbering during
+        the download phase. This is important because `lineno` in a rect can becomes a file name parameter
+        The offset is intended to be the index of the start of the locations table within some larger fits
+        file.
+    default : dC.Rect, optional
+        The default Rect that contains properties common to all sky locations, by default None
+
+    Returns
+    -------
+    list[dC.Rect]
+        Rects populated with sky locations from the table
     """
     rects = []
     for index, location in enumerate(locations):
@@ -130,11 +178,25 @@ stats = {
 
 
 def _stat_accumulate(name: str, value: Union[int, datetime.timedelta]):
+    """Accumulate a sum into the global stats dict
+
+    Parameters
+    ----------
+    name : str
+        Name of the stat. Assumed to exist in the dict already.
+    value : Union[int, datetime.timedelta]
+        How much time or count to add to the stat
+    """
     global stats
     stats[name] += value
 
 
 def _print_stats():
+    """Print the accumulated stats including bandwidth calculated from duration and sizes
+
+    This prints out multiple lines with `\r` at the end in order to create a continuously updating
+    line of text during download if your terminal supports it.
+    """
     global stats
 
     total_dur_s = (stats["request_duration"] + stats["response_duration"]).total_seconds()
@@ -162,15 +224,22 @@ def request_hook(
     response_size: int,
     chunk_size: int,
 ):
-    """
-    Called on each chunk of snapshots downloaded.
-    Called immediately after the server has finished responding to the
+    """This hook is called on each chunk of snapshots downloaded.
+    It is called immediately after the server has finished responding to the
     request, so datetime.datetime.now() is the end moment of the request
 
-    request: Our request object
-    request_start: datetime when we started sending the request
-    response_start: when the server responded to the request
-    response_size: Size in bytes of the response from the server.
+    Parameters
+    ----------
+    request : urllib.request.Request
+        The request object relevant to this call
+    request_start : datetime.datetime
+        The moment the request was handed off to urllib.request.urlopen()
+    response_start : datetime.datetime
+        The moment there were bytes from the server to process
+    response_size : int
+        The size of the response from the server in bytes
+    chunk_size : int
+        The number of cutout files recieved in this request
     """
 
     now = datetime.datetime.now()
@@ -185,10 +254,20 @@ def request_hook(
 
 
 def download_cutout_group(rects: list[dC.Rect], cutout_dir: Union[str, Path], user, password):
-    """
-    Download cutouts to the given directory
+    """Download cutouts to the given directory
 
-    Calls downloadCutout.download, so supports long lists of rects and
+    Calls downloadCutout.download, so supports long lists of rects beyond the limits of the HSC API
+
+    Parameters
+    ----------
+    rects : list[dC.Rect]
+        The rects we would like to download
+    cutout_dir : Union[str, Path]
+        The directory to put the files
+    user : _type_
+        Username for HSC's download service to use
+    password : _type_
+        Password for HSC's download service to use
     """
     with working_directory(Path(cutout_dir)):
         dC.download(rects, user=user, password=password, onmemory=True, request_hook=request_hook)

--- a/src/fibad_cli/main.py
+++ b/src/fibad_cli/main.py
@@ -8,7 +8,7 @@ from importlib.metadata import version
 download_config = {
     "sw": "22asec",
     "sh": "22asec",
-    "filter": "all",
+    "filter": ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"],
     "type": "coadd",
     "rerun": "pdr3_wide",
     "username": "mtauraso@local",
@@ -16,6 +16,8 @@ download_config = {
     "max_connections": 2,
     "fits_file": "../hscplay/temp.fits",
     "cutout_dir": "../hscplay/cutouts/",
+    "offset": 0,
+    "num_sources": 10,
 }
 
 config = {"download": download_config}


### PR DESCRIPTION
- Stats tracking of timing, data size, and bandwidth for cutout transfer
- Ability to specify an arbitrary list of filters to the downloader
- Configurable offset and extent for downloading from a large .fits catalog
- download() helper function codepath now supports kwargs passed from download() -> _download() -> _download_chunk() -> urllib.request.urlopen()
- Timout and chunk size for downloadCutout.py are configurable via this kwargs system.