### PR TITLE
Organize pyproject.toml, don't accidentally include `data/` in commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ _html/
 
 # Project initialization script
 .initialize_new_project.sh
+
+# General purposes data
+data/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ requires-python = ">=3.9"
 dependencies = [
     "astropy", # Used to load fits files of sources to query HSC cutout server
     "toml", # Used to load configuration files as dictionaries
-    "torch", # Used in example model
-    "torchvision", # Used in example model
+    "torch", # Used for CNN model and in train.py
 ]
 
 [project.scripts]
@@ -30,6 +29,10 @@ fibad = "fibad_cli.main:main"
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
+examples = [
+    "torchvision", # Used for CNN model data set
+]
+
 dev = [
     "asv==0.6.3", # Used to compute performance benchmarks
     "jupyter", # Clears output from Jupyter notebooks


### PR DESCRIPTION
Moving torchvision out of core dependencies in pyproject.toml. Now in an optional dependency section, `examples`. 
Users can install from source with `pip install -e .[dev,examples]`.

Added `data/` to .gitignore so that we don't accidentally commit something in there to the repo. 
