### PR TITLE
Initial version of logging for fibad.

### DIFF
--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -1,3 +1,5 @@
+import logging
+import sys
 from pathlib import Path
 from typing import Union
 
@@ -23,8 +25,61 @@ class Fibad:
             filename or pathlib.Path to a config file, by default None
         """
         self.config = get_runtime_config(runtime_config_filepath=config_file)
+        general_config = self.config.get("general", {})
 
-        # TODO Logging gets set up here
+        # Configure our logger. We do not use __name__ here because that would give us a "fibad.fibad" logger
+        # which would not aggregate logs from fibad.downloadCutout which creates its own logger
+        # for backwards compatibility with its CLI.
+        #
+        # Choosing "fibad" as our log name also means that modules like fibad.models, or fibad.dataloaders
+        # can get a logger with logging.getLogger(__name__) and will automatically roll up to us.
+        #
+        # A downside is that multiple Fibad objects all log the same place and have the ability to clobber
+        # one another's settings, and combine logs with one another.
+        self.logger = logging.getLogger("fibad")
+
+        # default to warning level
+        level = general_config.get("log_level", "warning")
+        if not isinstance(level, str):
+            self.logger.setLevel(logging.WARNING)
+        else:
+            # In python 3.11 and above you can do this:
+            #
+            # level_map = logging.getLevelNamesMapping()
+            #
+            # but for now we do this:
+            level_map = {
+                "critical": logging.CRITICAL,
+                "error": logging.ERROR,
+                "warning": logging.WARNING,
+                "warn": logging.WARNING,
+                "info": logging.INFO,
+                "debug": logging.DEBUG,
+            }
+            level = level_map.get(level.lower(), logging.WARNING)
+            self.logger.setLevel(level)
+
+        # Default to stderr for destination
+        log_destination = general_config.get("log_destination", "stderr")
+
+        if not isinstance(log_destination, str):
+            # Default to stderr in cases where configured log_destination has a non string object
+            handler = logging.StreamHandler(stream=sys.stderr)
+        else:
+            if log_destination.lower() == "stdout":
+                handler = logging.StreamHandler(stream=sys.stdout)
+            elif log_destination.lower() == "stderr":
+                handler = logging.StreamHandler(stream=sys.stderr)
+            else:
+                handler = logging.FileHandler(log_destination)
+
+        self.logger.addHandler(handler)
+
+        # Format our log messages
+        formatter = logging.Formatter("[%(asctime)s %(name)s:%(levelname)s] %(message)s")
+        handler.setFormatter(formatter)
+
+        self.logger.info(f"Runtime Config read from: {config_file}")
 
     def train(self, **kwargs):
         """

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -1,6 +1,21 @@
 [general]
 use_gpu = true
 
+# Destination of log messages
+# 'stderr' and 'stdout' specify the console.
+log_destination = "stderr"
+# A path name specifies a file e.g.
+# log = "fibad_log.txt"
+
+# Lowest log level to emit.
+# As you go down the list, fibad will become more verbose in the log.
+#
+# log_level = "critical" # Only emit the most severe of errors
+# log_level = "error"    # Emit all errors
+# log_level = "warning"  # Emit warnings and all errors
+log_level = "info"     # Emit informational messages, warnings and all errors
+# log_level = "debug"    # Very verbose, emit all log messages.
+
 [download]
 sw = "22asec"
 sh = "22asec"

--- a/src/fibad/models/example_cnn_classifier.py
+++ b/src/fibad/models/example_cnn_classifier.py
@@ -2,6 +2,7 @@
 
 # This example model is taken from the PyTorch CIFAR10 tutorial:
 # https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html#define-a-convolutional-neural-network
+import logging
 
 import torch
 import torch.nn as nn
@@ -10,6 +11,8 @@ import torch.optim as optim
 
 # extra long import here to address a circular import issue
 from .model_registry import fibad_model
+
+logger = logging.getLogger(__name__)
 
 
 @fibad_model
@@ -51,7 +54,7 @@ class ExampleCNN(nn.Module):
                 self.optimizer.step()
                 running_loss += loss.item()
                 if i % 2000 == 1999:
-                    print(f"[{epoch + 1}, {i + 1}] loss: {running_loss / 2000}")
+                    logger.info(f"[{epoch + 1}, {i + 1}] loss: {running_loss / 2000}")
                     running_loss = 0.0
 
     def _criterion(self):

--- a/src/fibad/predict.py
+++ b/src/fibad/predict.py
@@ -1,4 +1,7 @@
 """Scaffolding placeholder for prediction code."""
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def run(config):
@@ -11,6 +14,6 @@ def run(config):
         dict
     """
 
-    print("Prending to run prediction...")
-    print("Dumping configuration:")
-    print(config)
+    logger.info("Prending to run prediction...")
+    logger.debug("Dumping configuration:")
+    logger.debug(config)

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -1,7 +1,11 @@
+import logging
+
 import torch
 
 from fibad.data_loaders.data_loader_registry import fetch_data_loader_class
 from fibad.models.model_registry import fetch_model_class
+
+logger = logging.getLogger(__name__)
 
 
 def run(config):
@@ -34,4 +38,4 @@ def run(config):
     model.train(data_loader, device=device)
 
     model.save()
-    print("Finished Training")
+    logger.info("Finished Training")

--- a/src/fibad_cli/main.py
+++ b/src/fibad_cli/main.py
@@ -22,8 +22,6 @@ def main():
 
     args = parser.parse_args()
 
-    print(f"Runtime config: {args.runtime_config}")
-
     if args.version:
         print(version("fibad"))
         return


### PR DESCRIPTION
* Almost all print statements have been changed to logs.
* Logging is initialized in the Fibad object, where the config is parsed
* The logger name is 'fibad' which allows automatic roll-up from other modules within fibad (but not fibad_cli) by simply creating a local logging handle with:

  import logging logger = logging.getLogger(__name__)

* This mechanism also works for the downloadCutout code, which has been converted to logging.
* Added documentation to the default config about the log levels and configurable destinations.