### PR TITLE
Remove Michael's password from default config file

### DIFF
--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -4,6 +4,7 @@ from typing import Union
 import toml
 
 DEFAULT_CONFIG_FILEPATH = Path(__file__).parent.resolve() / "fibad_default_config.toml"
+DEFAULT_USER_CONFIG_FILEPATH = Path.cwd() / "fibad_config.toml"
 
 
 def get_runtime_config(
@@ -37,6 +38,10 @@ def get_runtime_config(
 
     with open(default_config_filepath, "r") as f:
         default_runtime_config = toml.load(f)
+
+    # If a named config exists in cwd, and no config specified on cmdline, use cwd.
+    if runtime_config_filepath is None and DEFAULT_USER_CONFIG_FILEPATH.exists():
+        runtime_config_filepath = DEFAULT_USER_CONFIG_FILEPATH
 
     if runtime_config_filepath is not None:
         if not runtime_config_filepath.exists():

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -22,11 +22,9 @@ sh = "22asec"
 filter = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
 type = "coadd"
 rerun = "pdr3_wide"
-username = "mtauraso@local"
-password = "cCw+nX53lmNLHMy+JbizpH/dl4t7sxljiNm6a7k1"
 max_connections = 2
-fits_file = "../hscplay/temp.fits"
-cutout_dir = "../hscplay/cutouts/"
+fits_file = "./catalog.fits"
+cutout_dir = "./data"
 offset = 0
 num_sources = 500
 


### PR DESCRIPTION
- Also make it easier to run fibad commands by using ./fibad_config.toml as the user-supplied config in situations where no config is specified explicitly

An example config you will probably need after this change merges looks something like:
```
[download]
username = "mtauraso@local"
password = "cCw+nX53lmNLHMy+JbizpH/dl4t7sxljiNm6a7k1"
fits_file = "../hscplay/temp.fits"
cutout_dir = "../hscplay/cutouts/"

[data_loader]
name = "HSCDataLoader"
path = "../hscplay/cutouts"
```

For downloader and data loader.

If this merges I'm planning to reset my HSC password shortly thereafter in order to avoid the current situation where our pubic repo has live credentials to their system.