### PR TITLE
Add a fibad top-level method to get the dimensions of downloaded files

### DIFF
--- a/example_notebooks/GettingStartedDownloader.ipynb
+++ b/example_notebooks/GettingStartedDownloader.ipynb
@@ -45,10 +45,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fibad_instance = fibad.Fibad(config_file=fibad_config)\n",
+    "import fibad\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# os.chdir(Path(fibad.__file__).parent/\"..\"/\"..\")\n",
+    "fibad_instance = fibad.Fibad(config_file=\"fibad_config.toml\")\n",
     "\n",
     "fibad_instance.download()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "widths, heights = fibad_instance.raw_data_dimensions()\n",
+    "\n",
+    "fig, axs = plt.subplots(1, 2)\n",
+    "fig.set_figwidth(12)\n",
+    "\n",
+    "_, _, _ = axs[0].hist(heights, range=(260, 270), bins=10)\n",
+    "_, _, _ = axs[1].hist(widths, range=(260, 270), bins=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ examples = [
 dev = [
     "asv==0.6.4", # Used to compute performance benchmarks
     "jupyter", # Clears output from Jupyter notebooks
+    "matplotlib", # For example notebooks
     "pre-commit", # Used to run checks before finalizing a git commit
     "pytest",
     "pytest-cov", # Used to report total code coverage

--- a/src/fibad/download.py
+++ b/src/fibad/download.py
@@ -140,13 +140,6 @@ class Downloader:
         """Prunes already downloaded rects using the manifest in `cutout_path`. `rects` passed in is
         mutated by this operation
 
-        Parameters
-        ----------
-        cutout_path : Path
-            Where on the filesystem to find the manifest
-        rects : list[dC.Rect]
-            List of rects from which we want to prune previously downloaded rects
-
         Returns
         -------
         list[dC.Rect]

--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -135,6 +135,23 @@ class Fibad:
         formatter = logging.Formatter("[%(asctime)s %(name)s:%(levelname)s] %(message)s")
         handler.setFormatter(formatter)
 
+    def raw_data_dimensions(self) -> tuple[list[int], list[int]]:
+        """Gives the dimensions of underlying data that forms input to the training, and inference
+        steps. This is the raw data that the data loader must normalize to the model
+
+        Returns
+        -------
+        tuple[list[int],list[int]]
+            widths and heights of all images available locally.
+        """
+        from .download import Downloader
+
+        downloader = Downloader(config=self.config)
+        manifest = downloader.get_manifest()
+        widths = [int(dim[0]) for dim in manifest["dim"]]
+        heights = [int(dim[1]) for dim in manifest["dim"]]
+        return widths, heights
+
     def train(self, **kwargs):
         """
         See Fibad.train.run()
@@ -149,7 +166,8 @@ class Fibad:
         """
         from .download import Downloader
 
-        return Downloader.run(config=self.config, **kwargs)
+        downloader = Downloader(config=self.config)
+        return downloader.run(**kwargs)
 
     def predict(self, **kwargs):
         """


### PR DESCRIPTION
- Rects in downloadCutout.py now track dimension of the file
- Downloader now is a proper object and holds more of its rect bookkeeping as instance state.
- Downloader creation is lightweight, and most work is still in .run()
- Example downloader notebook has been updated to use the new interface to generate histograms of downloaded data.