### PR TITLE
Centralize config defaults, add safety for Config updates

### DIFF
--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -108,6 +108,10 @@ def _validate_runtime_config(runtime_config: ConfigDict, default_config: ConfigD
             raise RuntimeError(msg)
 
         if isinstance(runtime_config[key], dict):
+            if not isinstance(default_config[key], dict):
+                msg = f"Runtime config contains a section named {key} which is the name of a value in the "
+                msg += "default config. Please choose another name for this section."
+                raise RuntimeError(msg)
             _validate_runtime_config(runtime_config[key], default_config[key])
 
 

--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Union
 
@@ -5,6 +6,160 @@ import toml
 
 DEFAULT_CONFIG_FILEPATH = Path(__file__).parent.resolve() / "fibad_default_config.toml"
 DEFAULT_USER_CONFIG_FILEPATH = Path.cwd() / "fibad_config.toml"
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigDict(dict):
+    """The purpose of this class is to ensure key errors on config dictionaries return something helpful.
+    and to discourage mutation actions on config dictionaries that should not happen at runtime.
+    """
+
+    # TODO: Should there be some sort of "bake" method which occurs after config processing, and
+    # percolates down to nested ConfigDicts and prevents __setitem__ and other mutations of dictionary
+    # values? i.e. a method to make a config dictionary fully immutable (or very difficult/annoying to
+    # mutuate) before we pass control to possibly external module code that is relying on the dictionary
+    # to be static througout the run.
+
+    __slots__ = ()  # we don't need __dict__ on this object at all.
+
+    def __init__(self, map: dict, **kwargs):
+        super().__init__(map, **kwargs)
+
+        # Replace all dictionary keys with values recursively.
+        for key in self:
+            if isinstance(self[key], dict) and not isinstance(self[key], ConfigDict):
+                self[key] = ConfigDict(map=self[key])
+
+    def __missing__(self, key):
+        msg = f"Accessed configuration key/section {key} which has not been defined. "
+        msg += "All configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
+        logger.fatal(msg)
+        raise RuntimeError(msg)
+
+    def get(self, key, default=None):
+        """Nonfunctional stub of dict.get() which errors always"""
+        msg = f"ConfigDict.get({key},{default}) called. "
+        msg += "Please index config dictionaries with [] or __getitem__() only. "
+        msg += "Configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
+        logger.fatal(msg)
+        raise RuntimeError(msg)
+
+    def __delitem__(self, key):
+        raise RuntimeError("Removing keys or sections from a ConfigDict using del is not supported")
+
+    def pop(self, key, default):
+        """Nonfunctional stub of dict.pop() which errors always"""
+        raise RuntimeError("Removing keys or sections from a ConfigDict using pop() is not supported")
+
+    def popitem(self):
+        """Nonfunctional stub of dict.popitem() which errors always"""
+        raise RuntimeError("Removing keys or sections from a ConfigDict using popitem() is not supported")
+
+    def clear(self):
+        """Nonfunctional stub of dict.clear() which errors always"""
+        raise RuntimeError("Removing keys or sections from a ConfigDict using clear() is not supported")
+
+
+def validate_runtime_config(runtime_config: ConfigDict):
+    """Validates that defaults exist for every config value before we begin to use a config.
+
+    This should be called at the moment the runtime config is fully baked for science calculations. Meaning
+    that all sources of config info have been combined in `runtime_config` and there are no further
+    config altering operations that will be performed.
+
+    Parameters
+    ----------
+    runtime_config : ConfigDict
+        The current runtime config dictionary.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if any config that exists in the runtime config does not have a default defined
+    """
+    default_config = _read_runtime_config(DEFAULT_CONFIG_FILEPATH)
+    _validate_runtime_config(runtime_config, default_config)
+
+
+def _validate_runtime_config(runtime_config: ConfigDict, default_config: ConfigDict):
+    """Recursive helper for validate_runtime_config.
+
+    The two arguments passed in must represent the same nesting level of the runtime config and all
+    default config parameters respectively.
+
+    Parameters
+    ----------
+    runtime_config : ConfigDict
+        Nested config dictionary representing the runtime config.
+    default_config : ConfigDict
+        Nested config dictionary representing the defaults
+
+    Raises
+    ------
+    RuntimeError
+        Raised if any config that exists in the runtime config does not have a default defined in
+        default_config
+    """
+    for key in runtime_config:
+        if key not in default_config:
+            msg = f"Runtime config contains key or section {key} which has no default defined."
+            msg += f"All configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
+            raise RuntimeError(msg)
+
+        if isinstance(runtime_config[key], dict):
+            _validate_runtime_config(runtime_config[key], default_config[key])
+
+
+def _read_runtime_config(config_filepath: Union[Path, str] = DEFAULT_CONFIG_FILEPATH) -> ConfigDict:
+    """Read a single toml file and return a config dictionary
+
+    Parameters
+    ----------
+    config_filepath : Union[Path, str], optional
+        What file is to be read, by default DEFAULT_CONFIG_FILEPATH
+
+    Returns
+    -------
+    ConfigDict
+        The contents of that toml file as nested ConfigDicts
+    """
+    with open(config_filepath, "r") as f:
+        parsed_dict = toml.load(f)
+        return ConfigDict(parsed_dict)
+
+
+def resolve_runtime_config(runtime_config_filepath: Union[Path, str, None] = None) -> Path:
+    """Resolve a user-supplied runtime config to where we will actually pull config from.
+
+    1) If a runtime config file is specified, we will use that file
+    2) If not file is specified and there is a file named "fibad_config.toml" in the cwd we will use that file
+    3) If no file is specified and there is no file named "fibad_config.toml" in the current working directory
+       we will exclusively work off the configuration defaults in the packaged "fibad_default_config.toml"
+       file.
+
+    Parameters
+    ----------
+    runtime_config_filepath : Union[Path, str, None], optional
+        Location of the supplied config file, by default None
+
+    Returns
+    -------
+    Path
+        Path to the configuration file ultimately used for config resolution. When we fall back to the
+        package supplied default config file, the Path to that file is returned.
+    """
+    if isinstance(runtime_config_filepath, str):
+        runtime_config_filepath = Path(runtime_config_filepath)
+
+    # If a named config exists in cwd, and no config specified on cmdline, use cwd.
+    if runtime_config_filepath is None and DEFAULT_USER_CONFIG_FILEPATH.exists():
+        runtime_config_filepath = DEFAULT_USER_CONFIG_FILEPATH
+
+    if runtime_config_filepath is None:
+        runtime_config_filepath = DEFAULT_CONFIG_FILEPATH
+
+    return runtime_config_filepath
 
 
 def get_runtime_config(
@@ -33,24 +188,14 @@ def get_runtime_config(
         The parsed runtime configuration.
     """
 
-    if isinstance(runtime_config_filepath, str):
-        runtime_config_filepath = Path(runtime_config_filepath)
+    runtime_config_filepath = resolve_runtime_config(runtime_config_filepath)
+    default_runtime_config = _read_runtime_config(default_config_filepath)
 
-    with open(default_config_filepath, "r") as f:
-        default_runtime_config = toml.load(f)
-
-    # If a named config exists in cwd, and no config specified on cmdline, use cwd.
-    if runtime_config_filepath is None and DEFAULT_USER_CONFIG_FILEPATH.exists():
-        runtime_config_filepath = DEFAULT_USER_CONFIG_FILEPATH
-
-    if runtime_config_filepath is not None:
+    if runtime_config_filepath is not DEFAULT_CONFIG_FILEPATH:
         if not runtime_config_filepath.exists():
             raise FileNotFoundError(f"Runtime configuration file not found: {runtime_config_filepath}")
-
-        with open(runtime_config_filepath, "r") as f:
-            users_runtime_config = toml.load(f)
-
-            final_runtime_config = merge_configs(default_runtime_config, users_runtime_config)
+        users_runtime_config = _read_runtime_config(runtime_config_filepath)
+        final_runtime_config = merge_configs(default_runtime_config, users_runtime_config)
     else:
         final_runtime_config = default_runtime_config
 
@@ -80,7 +225,7 @@ def merge_configs(default_config: dict, user_config: dict) -> dict:
     final_config = default_config.copy()
     for k, v in user_config.items():
         if k in final_config and isinstance(final_config[k], dict) and isinstance(v, dict):
-            final_config[k] = merge_configs(default_config.get(k, {}), v)
+            final_config[k] = merge_configs(default_config[k], v)
         else:
             final_config[k] = v
 

--- a/src/fibad/data_loaders/data_loader_registry.py
+++ b/src/fibad/data_loaders/data_loader_registry.py
@@ -36,7 +36,7 @@ def fetch_data_loader_class(runtime_config: dict) -> type:
         If no data loader was specified in the runtime configuration.
     """
 
-    data_loader_config = runtime_config.get("data_loader", {})
+    data_loader_config = runtime_config["data_loader"]
     data_loader_cls = None
 
     try:

--- a/src/fibad/data_loaders/example_cifar_data_loader.py
+++ b/src/fibad/data_loaders/example_cifar_data_loader.py
@@ -9,8 +9,8 @@ from .data_loader_registry import fibad_data_loader
 
 @fibad_data_loader
 class CifarDataLoader:
-    def __init__(self, data_loader_config):
-        self.config = data_loader_config
+    def __init__(self, config):
+        self.config = config
 
     def shape(self):
         return (3, 32, 32)
@@ -31,13 +31,13 @@ class CifarDataLoader:
         )
 
         return torchvision.datasets.CIFAR10(
-            root=self.config.get("path", "./data"), train=True, download=True, transform=transform
+            root=self.config["general"]["data_dir"], train=True, download=True, transform=transform
         )
 
     def data_loader(self, data_set):
         return torch.utils.data.DataLoader(
             data_set,
-            batch_size=self.config.get("batch_size", 4),
-            shuffle=self.config.get("shuffle", True),
-            num_workers=self.config.get("num_workers", 2),
+            batch_size=self.config["data_loader"]["batch_size"],
+            shuffle=self.config["data_loader"]["shuffle"],
+            num_workers=self.config["data_loader"]["num_workers"],
         )

--- a/src/fibad/data_loaders/hsc_data_loader.py
+++ b/src/fibad/data_loaders/hsc_data_loader.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 
 @fibad_data_loader
 class HSCDataLoader:
-    def __init__(self, data_loader_config):
-        self.config = data_loader_config
+    def __init__(self, config):
+        self.config = config
         self._data_set = self.data_set()
 
     def get_data_loader(self):
@@ -37,27 +37,28 @@ class HSCDataLoader:
         if self.__dict__.get("_data_set", None) is not None:
             return self._data_set
 
-        self.config.get("path", "./data")
-
         # TODO: What will be a reasonable set of tranformations?
         # For now tanh all the values so they end up in [-1,1]
         # Another option might be sinh, but we'd need to mess with the example autoencoder module
         # Because it goes from unbounded NN output space -> [-1,1] with tanh in its decode step.
         transform = Lambda(lambd=np.tanh)
 
+        crop_to = self.config["data_loader"]["crop_to"]
+        filters = self.config["data_loader"]["filters"]
+
         return HSCDataSet(
-            self.config.get("path", "./data"),
+            self.config["general"]["data_dir"],
             transform=transform,
-            cutout_shape=self.config.get("crop_to", None),
-            filters=self.config.get("filters", None),
+            cutout_shape=crop_to if crop_to else None,
+            filters=filters if filters else None,
         )
 
     def data_loader(self, data_set):
         return torch.utils.data.DataLoader(
             data_set,
-            batch_size=self.config.get("batch_size", 4),
-            shuffle=self.config.get("shuffle", True),
-            num_workers=self.config.get("num_workers", 2),
+            batch_size=self.config["data_loader"]["batch_size"],
+            shuffle=self.config["data_loader"]["shuffle"],
+            num_workers=self.config["data_loader"]["num_workers"],
         )
 
     def shape(self):

--- a/src/fibad/download.py
+++ b/src/fibad/download.py
@@ -101,7 +101,12 @@ class Downloader:
             while batch := tuple(itertools.islice(iterator, n)):
                 yield batch
 
-        num_threads = num_threads if len(self.rects) > num_threads else 1
+        if len(self.rects) > num_threads:
+            msg = f"Only {len(self.rects)} sky locations, which is less than the number of threads, so we "
+            msg += "will use only one thread."
+            logger.info(msg)
+            num_threads = 1
+
         logger.info(f"Dividing {len(self.rects)} sky locations among {num_threads} threads...")
         thread_rects = (
             list(_batched(self.rects, int(len(self.rects) / num_threads)))

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -16,16 +16,21 @@ log_destination = "stderr"
 log_level = "info"     # Emit informational messages, warnings and all errors
 # log_level = "debug"    # Very verbose, emit all log messages.
 
+data_dir = "./data"
+
 [download]
 sw = "22asec"
 sh = "22asec"
 filter = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
 type = "coadd"
 rerun = "pdr3_wide"
-concurrent_connections = 1
-stats_print_interval = 30
+username = false
+password = false
+num_sources = -1 # Values below 1 here indicate all sources in the catalog will be downloaded
+offset = 0
+concurrent_connections = 4
+stats_print_interval = 60
 fits_file = "./catalog.fits"
-cutout_dir = "./data"
 
 # These control the downloader's HTTP requests and retries
 # `retry_wait` How long to wait before retrying a failed HTTP request in seconds. Default 30s
@@ -37,6 +42,13 @@ timeout = 3600
 # `chunksize` How many sky location rectangles should we request in a single request. Default is 990
 chunk_size = 990
 
+# Whether to retrieve the image layer
+image = true
+# Whether to retrieve the variance layer
+variance = false
+# Whether to retrieve the mask layer
+mask = false
+
 [model]
 name = "ExampleAutoencoder"
 
@@ -46,6 +58,9 @@ name = "ExampleAutoencoder"
 weights_filepath = "example_model.pth"
 epochs = 10
 
+base_channel_size = 32
+latent_dim =64
+
 [data_loader]
 # Name of data loader to use
 name = "HSCDataLoader"
@@ -53,27 +68,26 @@ name = "HSCDataLoader"
 # An example of requesting an external data loader class
 # external_class = "user_package.submodule.ExternalDataLoader"
 
-# Directory path where the data is stored
-path = "./data"
-
 # Pixel dimensions used to crop all images prior to loading. Will prune any images that are too small.
 #
-# If not provided, the default is to scan the directory for the smallest dimensioned files, and use 
-# those pixel dimensions as the crop size.
+# If not provided by user, the default of 'false' scans the directory for the smallest dimensioned files, and 
+# uses those pixel dimensions as the crop size.
 #
 #crop_to = [100,100]
+crop_to = false
 
 # Limit data loader to only particular filters when there are more in the data set.
 #
-# When not provided, the number of filters will be automatically gleaned from the data set.
-# Defaults to not provided.
+# When not provided by the user, the number of filters will be automatically gleaned from the data set.
+# Defaults behavior is produced by the false value.
 #
 #filters = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
+filters = false
 
 # Default PyTorch DataLoader parameters
-batch_size = 500
+batch_size = 4
 shuffle = true
-num_workers = 10
+num_workers = 2
 
 [predict]
 batch_size = 32

--- a/src/fibad/models/example_autoencoder.py
+++ b/src/fibad/models/example_autoencoder.py
@@ -18,15 +18,15 @@ from fibad.models.model_registry import fibad_model
 
 @fibad_model
 class ExampleAutoencoder(nn.Module):
-    def __init__(self, model_config, shape=(5, 250, 250)):
+    def __init__(self, config, shape=(5, 250, 250)):
         super().__init__()
-        self.config = model_config
+        self.config = config
 
         # TODO xcxc config-ize or get from data loader somehow
         self.num_input_channels, self.image_width, self.image_height = shape
 
-        self.c_hid = self.config.get("base_channel_size", 32)
-        self.latent_dim = self.config.get("latent_dim", 64)
+        self.c_hid = self.config["model"]["base_channel_size"]
+        self.latent_dim = self.config["model"]["latent_dim"]
 
         # Calculate how much our convolutional layers will affect the size of final convolution
         # Formula evaluated from: https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
@@ -140,4 +140,4 @@ class ExampleAutoencoder(nn.Module):
         return optim.Adam(self.parameters(), lr=1e-3)
 
     def save(self):
-        torch.save(self.state_dict(), self.config.get("weights_filepath", "example_autoencoder.pth"))
+        torch.save(self.state_dict(), self.config["model"]["weights_filepath"])

--- a/src/fibad/models/example_cnn_classifier.py
+++ b/src/fibad/models/example_cnn_classifier.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @fibad_model
 class ExampleCNN(nn.Module):
-    def __init__(self, model_config, shape):
+    def __init__(self, config, shape):
         super().__init__()
         self.conv1 = nn.Conv2d(3, 6, 5)
         self.pool = nn.MaxPool2d(2, 2)
@@ -25,7 +25,7 @@ class ExampleCNN(nn.Module):
         self.fc2 = nn.Linear(120, 84)
         self.fc3 = nn.Linear(84, 10)
 
-        self.config = model_config
+        self.config = config
 
         # Optimizer and criterion could be set directly, i.e. `self.optimizer = optim.SGD(...)`
         # but we define them as methods as a way to allow for more flexibility in the future.
@@ -71,4 +71,4 @@ class ExampleCNN(nn.Module):
         return optim.SGD(self.parameters(), lr=0.001, momentum=0.9)
 
     def save(self):
-        torch.save(self.state_dict(), self.config.get("weights_filepath", "example_cnn.pth"))
+        torch.save(self.state_dict(), self.config["model"]["weights_filepath"])

--- a/src/fibad/models/model_registry.py
+++ b/src/fibad/models/model_registry.py
@@ -36,7 +36,7 @@ def fetch_model_class(runtime_config: dict) -> type:
         If no model was specified in the runtime configuration.
     """
 
-    model_config = runtime_config.get("model", {})
+    model_config = runtime_config["model"]
     model_cls = None
 
     try:

--- a/src/fibad/plugin_utils.py
+++ b/src/fibad/plugin_utils.py
@@ -29,7 +29,7 @@ def get_or_load_class(config: dict, registry: dict) -> type:
 
     # User specifies one of the built in classes by name
     if "name" in config:
-        class_name = config.get("name")
+        class_name = config["name"]
 
         if class_name not in registry:
             raise ValueError(f"Could not find {class_name} in registry: {registry.keys()}")

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -22,21 +22,21 @@ def run(config):
 
     # Fetch data loader class specified in config and create an instance of it
     data_loader_cls = fetch_data_loader_class(config)
-    data_loader = data_loader_cls(config.get("data_loader", {}))
+    data_loader = data_loader_cls(config)
 
     # Get the pytorch.dataset from dataloader, and use it to create a distributed dataloader
     data_set = data_loader.data_set()
-    dist_data_loader = _train_data_loader(data_set, config.get("data_loader", {}))
+    dist_data_loader = _train_data_loader(data_set, config)
 
     # Fetch model class specified in config and create an instance of it
     model_cls = fetch_model_class(config)
-    model = model_cls(model_config=config.get("model", {}), shape=data_loader.shape())
+    model = model_cls(config=config, shape=data_loader.shape())
 
     # Create trainer, a pytorch-ignite `Engine` object
     trainer = _create_trainer(model)
 
     # Run the training process
-    trainer.run(dist_data_loader, max_epochs=config.get("model", {}).get("epochs", 2))
+    trainer.run(dist_data_loader, max_epochs=config["model"]["epochs"])
 
     # Save the trained model
     model.save()
@@ -51,9 +51,9 @@ def _train_data_loader(data_set, config):
     # ~ `data_loader = idist.auto_dataloader(data_set, **config)`
     data_loader = idist.auto_dataloader(
         data_set,
-        batch_size=config.get("batch_size", 4),
-        shuffle=config.get("shuffle", True),
-        num_workers=config.get("num_workers", 2),
+        batch_size=config["data_loader"]["batch_size"],
+        shuffle=config["data_loader"]["shuffle"],
+        num_workers=config["data_loader"]["num_workers"],
     )
 
     return data_loader


### PR DESCRIPTION
- All configuration dicts are now ConfigDict. A ConfigDict is a version of dict that raises RuntimeError quite a lot when you try to mutate it or when you access values that weren't set at construction time.
- There is a new validate step for runtime config that ensures every config key that appears at runtime has a default defined in fibad_default_config.toml.
- Usages of .get() on config dictionaries have been removed, so all defaults now live in fibad_default_config.toml. Config access is entirely via __getitem__ / [].
- The sum total of the above means that we expect any new config which is missing a default value to generate a runtime error as early as possible if it is referenced anywhere in code, or in a user-supplied configuration.
- Several config values have changed representation, because "not specified" was their default. toml does not support "None" so all of these values have been set to false in fibad_default_config.toml. Accesses to these configs have been updated to be aware that the default value of 'false' either triggers modal behavior (data_loader/crop_to, data_loader/filters) or triggers a RuntimeError to prompt the user to provide it (download/username, download/password).
- Except where necessary for model/dataloader class loading, passsing of individual config sections has been removed. For the most part all parts of the code now have access to the entire runtime configuration.
- The data_loader/data and download/cutout_dir configs have been combined into general/data_dir, to avoid an invalid configuration state where the downloader and data loader are looking at different directories for data.
