### PR TITLE
Move config parameters to a different table so that we can define a dataloader easier

### DIFF
--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -25,8 +25,8 @@ class HSCDataSet(Dataset):
         # Because it goes from unbounded NN output space -> [-1,1] with tanh in its decode step.
         transform = Lambda(lambd=np.tanh)
 
-        crop_to = config["data_loader"]["crop_to"]
-        filters = config["data_loader"]["filters"]
+        crop_to = config["data_set"]["crop_to"]
+        filters = config["data_set"]["filters"]
 
         self._init_from_path(
             config["general"]["data_dir"],

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -66,7 +66,6 @@ latent_dim =64
 # e.g. "user_package.submodule.ExternalDataLoader" or "HSCDataLoader"
 name = "CifarDataSet"
 
-[data_loader]
 # Pixel dimensions used to crop all images prior to loading. Will prune any images that are too small.
 #
 # If not provided by user, the default of 'false' scans the directory for the smallest dimensioned files, and 
@@ -83,6 +82,7 @@ crop_to = false
 #filters = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
 filters = false
 
+[data_loader]
 # Default PyTorch DataLoader parameters
 batch_size = 4
 shuffle = true

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -57,16 +57,9 @@ def dist_data_loader(data_set: Dataset, config: ConfigDict):
     Dataloader (or an ignite-wrapped equivalent)
         This is the distributed dataloader, formed by calling ignite.distributed.auto_dataloader
     """
-    # ~ idist.auto_dataloader will accept a **kwargs parameter, and pass values
-    # ~ through to the underlying pytorch DataLoader.
-    # ~ Currently, our config includes unexpected keys like `name`, that cause
-    # ~ an exception. It would be nice to reduce this to:
-    # ~ `data_loader = idist.auto_dataloader(data_set, **config)`
     return idist.auto_dataloader(
         data_set,
-        batch_size=config["data_loader"]["batch_size"],
-        shuffle=config["data_loader"]["shuffle"],
-        num_workers=config["data_loader"]["num_workers"],
+        **config["data_loader"]
     )
 
 

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -57,10 +57,7 @@ def dist_data_loader(data_set: Dataset, config: ConfigDict):
     Dataloader (or an ignite-wrapped equivalent)
         This is the distributed dataloader, formed by calling ignite.distributed.auto_dataloader
     """
-    return idist.auto_dataloader(
-        data_set,
-        **config["data_loader"]
-    )
+    return idist.auto_dataloader(data_set, **config["data_loader"])
 
 
 def create_engine(funcname: str, device: torch.device, model: torch.nn.Module):

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -57,7 +57,7 @@ def mkconfig(crop_to=False, filters=False):
     """
     return {
         "general": {"data_dir": "thispathdoesnotexist"},
-        "data_loader": {
+        "data_set": {
             "crop_to": crop_to,
             "filters": filters,
         },


### PR DESCRIPTION
Moving `filter` and `crop_to` to the `[data_set]` table in the default config to make defining the dataloader easier.

Now the pytorch ignite dataloader can be defined with **kwargs instead of a bunch of hardcoded config parameters.
