### PR TITLE
Include all immutable dc.Rect fields in manifest so Resume works in all configs.

### DIFF
--- a/src/fibad/download.py
+++ b/src/fibad/download.py
@@ -22,7 +22,11 @@ class Downloader:
     VARIABLE_FIELDS = ["tract", "ra", "dec"]
 
     # These are the column names we retain when writing a rect out to the manifest.fits file
-    RECT_COLUMN_NAMES = VARIABLE_FIELDS + ["filter", "sw", "sh", "rerun", "type", "dim"]
+    #
+    # The construction list(dict.fromkeys()) is to de-duplicate keys that exist in VARIBLE_FIELDS and
+    # dC.Rect.immutable_fields but keep the ordering of keys so that VARIABLE_FIELDS are first and all
+    # of the immutable fields that we rely on for hash checks are also included.
+    RECT_COLUMN_NAMES = list(dict.fromkeys(VARIABLE_FIELDS + dC.Rect.immutable_fields + ["dim"]))
 
     MANIFEST_FILE_NAME = "manifest.fits"
 


### PR DESCRIPTION
This is a breaking change for the manifest file format, in that downloads started before this change will not be able to resume if resumed using a version of fibad after this change.

Prior to this change If you have a config that downloads mask or variance, resume would simply fail (issue #98)

The cause was that the image, variance, and mask rect parameters weren't saved to the manifest file, so on resume _prune_downloaded_rects() could not match the  manifest with the rects generated from the catalog.

In this case the rects generated from the catalog had config-provided values for image, mask and variance. The rects generated from reading the manifest had the dc.Rect default values of image=True, mask=False and variance=False.

This change ensures that all the dc.Rect immutable fields, which are used in equality and hash checking are written out to the manifest.