### PR TITLE
Handle externally defined default configuration files 

### DIFF
--- a/src/fibad/__init__.py
+++ b/src/fibad/__init__.py
@@ -1,10 +1,8 @@
-from .config_utils import get_runtime_config, log_runtime_config, merge_configs
+from .config_utils import log_runtime_config
 from .fibad import Fibad
 from .plugin_utils import get_or_load_class, import_module_from_string, update_registry
 
 __all__ = [
-    "get_runtime_config",
-    "merge_configs",
     "log_runtime_config",
     "get_or_load_class",
     "import_module_from_string",

--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -135,7 +135,7 @@ class ConfigManager:
             if isinstance(value, dict):
                 default_configs |= ConfigManager._find_external_library_default_config_paths(value)
             else:
-                if key == "name" and "." in key:
+                if key == "name" and "." in value:
                     external_library = value.split(".")[0]
                     if importlib.util.find_spec(external_library) is not None:
                         try:

--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import Union
 
-from .config_utils import get_runtime_config, resolve_runtime_config, validate_runtime_config
+from .config_utils import ConfigManager, resolve_runtime_config
 
 
 class Fibad:
@@ -43,12 +43,14 @@ class Fibad:
             - You have a single Fibad object in use at any time. This is true in most notebook like
               environments.
         """
-        self.config = get_runtime_config(runtime_config_filepath=config_file)
+        self.config_manager = ConfigManager(runtime_config_filepath=config_file)
+        self.config = self.config_manager.config
+        # self.config = get_runtime_config(runtime_config_filepath=config_file)
 
         # TODO: For now this is part of Fibad.__init__() In future when external modules can define their own
         # configuration keys and associated default values, this will need to occur after those external
         # modules have been resolved and loaded. This is why it is separate from get_runtime_config()
-        validate_runtime_config(self.config)
+        # validate_runtime_config(self.config)
 
         # Configure our logger. We do not use __name__ here because that would give us a "fibad.fibad" logger
         # which would not aggregate logs from fibad.downloadCutout which creates its own

--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -45,12 +45,6 @@ class Fibad:
         """
         self.config_manager = ConfigManager(runtime_config_filepath=config_file)
         self.config = self.config_manager.config
-        # self.config = get_runtime_config(runtime_config_filepath=config_file)
-
-        # TODO: For now this is part of Fibad.__init__() In future when external modules can define their own
-        # configuration keys and associated default values, this will need to occur after those external
-        # modules have been resolved and loaded. This is why it is separate from get_runtime_config()
-        # validate_runtime_config(self.config)
 
         # Configure our logger. We do not use __name__ here because that would give us a "fibad.fibad" logger
         # which would not aggregate logs from fibad.downloadCutout which creates its own
@@ -97,7 +91,7 @@ class Fibad:
         self.logger.info(f"Runtime Config read from: {resolve_runtime_config(config_file)}")
 
     def _initialize_log_handlers(self):
-        """Private initialization helper, Adds handlers and level setting sto the global self.logger object"""
+        """Private initialization helper, Adds handlers and level setting to the global self.logger object"""
 
         general_config = self.config["general"]
         # default to warning level

--- a/tests/fibad/test_config_utils.py
+++ b/tests/fibad/test_config_utils.py
@@ -1,6 +1,6 @@
 import os
 
-from fibad.config_utils import get_runtime_config, merge_configs
+from fibad.config_utils import ConfigManager
 
 
 def test_merge_configs():
@@ -27,7 +27,7 @@ def test_merge_configs():
 
     expected = {"a": 5, "b": 2, "c": {"d": 6, "e": 4}, "f": 7}
 
-    assert merge_configs(default_config, user_config) == expected
+    assert ConfigManager.merge_configs(default_config, user_config) == expected
 
 
 def test_get_runtime_config():
@@ -37,7 +37,7 @@ def test_get_runtime_config():
     """
 
     this_file_dir = os.path.dirname(os.path.abspath(__file__))
-    runtime_config = get_runtime_config(
+    config_manager = ConfigManager(
         runtime_config_filepath=os.path.abspath(
             os.path.join(this_file_dir, "./test_data/test_user_config.toml")
         ),
@@ -45,6 +45,8 @@ def test_get_runtime_config():
             os.path.join(this_file_dir, "./test_data/test_default_config.toml")
         ),
     )
+
+    runtime_config = config_manager.config
 
     expected = {
         "general": {"use_gpu": False},


### PR DESCRIPTION
Adding a ConfigManager class to help wrangle the various defaults that could be imported.

The approach we're implementing is the following.
* Load the fibad_default_config
* Load the user_specific_config (USC), if defined
* Scan the USC for any external libraries, they look like lib specs under the `name` keys. i.e. `"module.submod.class"`
* Collect the file paths to default config files that are defined in the external libraries. For now, we assume the files are called `default_config.toml`.
* Merge all the external default configs to create a merged-external-default-config
* Merge the fibad default and the merged-external default configs to create a total-default-config
* Merge the USC into the total-default-config
* Validate the USC against the total-default-config

There's lots of clean up still to do.