### PR TITLE
Splits for HSCDataSet

### DIFF
--- a/src/fibad/data_sets/example_cifar_data_set.py
+++ b/src/fibad/data_sets/example_cifar_data_set.py
@@ -11,11 +11,17 @@ class CifarDataSet(CIFAR10):
     FIBAD config with a transformation that works well for example code.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, split: str):
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
         )
-        super().__init__(root=config["general"]["data_dir"], train=True, download=True, transform=transform)
+
+        if split not in ["train", "test"]:
+            RuntimeError("CIFAR10 dataset only supports 'train' and 'test' splits.")
+
+        train = split == "train"
+
+        super().__init__(root=config["general"]["data_dir"], train=train, download=True, transform=transform)
 
     def shape(self):
         return (3, 32, 32)

--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from copy import copy
+from copy import copy, deepcopy
 from pathlib import Path
 from typing import Literal, Optional, Union
 
@@ -26,7 +26,7 @@ class HSCDataSet(Dataset):
 
     """
 
-    def __init__(self, config, split: Union[str, None] = None):
+    def __init__(self, config, split: Union[str, None]):
         # initialize the filesystem references
         self.container = HSCDataSetContainer(config)
 
@@ -229,7 +229,7 @@ class HSCDataSetSplit(Dataset):
         copy_object.indexes = self.indexes.copy()
 
         # Copy RNG state over.
-        copy_object.rng = copy(self.rng)
+        copy_object.rng = deepcopy(self.rng)
 
         return copy_object
 

--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -147,7 +147,7 @@ class HSCDataSetSplit(Dataset):
 
         else:
             # If we're splitting a normal hscdataset we generate a single mask with the appropriate values
-            self.mask = np.zeros(len(data), dtype=np.bool)
+            self.mask = np.zeros(len(data), dtype=bool)
             self._flip_mask_values(length, "false_to_true")
 
         self.indexes = np.nonzero(self.mask)[0]
@@ -238,13 +238,6 @@ class HSCDataSetSplit(Dataset):
 
     def __getitem__(self, idx: int) -> torch.Tensor:
         return self.data[self.indexes[idx]]
-
-    def ids(self):
-        for obj_id, index in zip(self.data.ids(), range(len(self.data))):
-            if self.mask[index] is True:
-                yield obj_id
-            else:
-                continue
 
 
 class HSCDataSetContainer(Dataset):

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -55,15 +55,16 @@ mask = false
 # e.g. "user_package.submodule.ExternalModel" or "ExampleAutoencoder"
 name = "ExampleAutoencoder"
 
-weights_filepath = "example_model.pth"
-epochs = 10
-
 base_channel_size = 32
 latent_dim = 64
 
+[train]
+weights_filepath = "example_model.pth"
+epochs = 10
 # Set this to the path of a checkpoint file to resume, or continue training,
 # from a checkpoint. Otherwise, set to false to start from scratch.
 resume = false
+split = "train"
 
 [data_set]
 # Name of the built-in data loader to use or the libpath to an external data loader
@@ -92,6 +93,41 @@ batch_size = 32
 shuffle = true
 num_workers = 2
 
+[prepare]
+# How to split the data between training and eval sets.
+# The semantics are borrowed from scikit-learn's train-test-split, and HF Dataset's train-test-split function
+# It is an error for these values to add to more than 1.0 as ratios or the size of the dataset if expressed
+# as integers.
+#
+# test_size: Size of the test split
+# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
+# test split.
+# If `int`, represents the absolute number of test samples.
+# If `false`, the value is set to the complement of the train size.
+# If `train_size` is also `false`, it will be set to `0.25`.
+test_size = 0.6
+
+# train_size: Size of the train split
+# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
+# train split.
+# If `int`, represents the absolute number of train samples.
+# If `false`, the value is automatically set to the complement of the test size.
+train_size = 0.2
+
+# validation_size: Size of the validation split
+# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
+# train split.
+# If `int`, represents the absolute number of train samples.
+# If `false`, and both train_size and test_size are defined, the value is automatically set to the complement 
+# of the other two sizes summed.
+# If `false`, and only one of the other sizes is defined, no validate split is created
+validate_size = 0.2
+
+# Random number to seed with for generating a random split. False means the data will be seeded from
+# a system source at runtime.
+seed = false
+
 [predict]
 model_weights_file = false
 batch_size = 32
+split = "test"

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -98,23 +98,15 @@ num_workers = 2
 # The semantics are borrowed from scikit-learn's train-test-split, and HF Dataset's train-test-split function
 # It is an error for these values to add to more than 1.0 as ratios or the size of the dataset if expressed
 # as integers.
-#
-# test_size: Size of the test split
-# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
-# test split.
-# If `int`, represents the absolute number of test samples.
-# If `false`, the value is set to the complement of the train size.
-# If `train_size` is also `false`, it will be set to `0.25`.
-test_size = 0.6
 
 # train_size: Size of the train split
 # If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
 # train split.
 # If `int`, represents the absolute number of train samples.
 # If `false`, the value is automatically set to the complement of the test size.
-train_size = 0.2
+train_size = 0.6
 
-# validation_size: Size of the validation split
+# validate_size: Size of the validation split
 # If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
 # train split.
 # If `int`, represents the absolute number of train samples.
@@ -123,7 +115,15 @@ train_size = 0.2
 # If `false`, and only one of the other sizes is defined, no validate split is created
 validate_size = 0.2
 
-# Random number to seed with for generating a random split. False means the data will be seeded from
+# test_size: Size of the test split
+# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
+# test split.
+# If `int`, represents the absolute number of test samples.
+# If `false`, the value is set to the complement of the train size.
+# If `train_size` is also `false`, it will be set to `0.25`.
+test_size = 0.6
+
+# Number to seed with for generating a random split. False means the data will be seeded from
 # a system source at runtime.
 seed = false
 

--- a/src/fibad/predict.py
+++ b/src/fibad/predict.py
@@ -19,7 +19,8 @@ def run(config: ConfigDict):
         The parsed config file as a nested dict
     """
 
-    model, data_set = setup_model_and_dataset(config)
+    model, data_set = setup_model_and_dataset(config, split=config["predict"]["split"])
+    logger.info(f"data set has length {len(data_set)}")
     data_loader = dist_data_loader(data_set, config)
 
     # Create a results directory and dump our config there

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -17,7 +17,7 @@ from fibad.models.model_registry import fetch_model_class
 logger = logging.getLogger(__name__)
 
 
-def setup_model_and_dataset(config: ConfigDict) -> tuple:
+def setup_model_and_dataset(config: ConfigDict, split: str) -> tuple:
     """
     Construct the dataset and the model according to configuration.
 
@@ -27,6 +27,8 @@ def setup_model_and_dataset(config: ConfigDict) -> tuple:
     ----------
     config : ConfigDict
        The entire runtime config
+    split : str
+       The name of the split we want to use from the data set.
 
     Returns
     -------
@@ -35,7 +37,7 @@ def setup_model_and_dataset(config: ConfigDict) -> tuple:
     """
     # Fetch data loader class specified in config and create an instance of it
     data_set_cls = fetch_data_set_class(config)
-    data_set = data_set_cls(config)
+    data_set = data_set_cls(config, split)
 
     # Fetch model class specified in config and create an instance of it
     model_cls = fetch_model_class(config)
@@ -210,8 +212,8 @@ def create_trainer(model: torch.nn.Module, config: ConfigDict, results_directory
         greater_or_equal=True,
     )
 
-    if config["model"]["resume"]:
-        prev_checkpoint = torch.load(config["model"]["resume"], map_location=device)
+    if config["train"]["resume"]:
+        prev_checkpoint = torch.load(config["train"]["resume"], map_location=device)
         Checkpoint.load_objects(to_load=to_save, checkpoint=prev_checkpoint)
 
     @trainer.on(Events.STARTED)

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -19,16 +19,16 @@ def run(config):
     results_dir = create_results_dir(config, "train")
     log_runtime_config(config, results_dir)
 
-    model, data_set = setup_model_and_dataset(config)
+    model, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
     data_loader = dist_data_loader(data_set, config)
 
     # Create trainer, a pytorch-ignite `Engine` object
     trainer = create_trainer(model, config, results_dir)
 
     # Run the training process
-    trainer.run(data_loader, max_epochs=config["model"]["epochs"])
+    trainer.run(data_loader, max_epochs=config["train"]["epochs"])
 
     # Save the trained model
-    model.save(results_dir / config["model"]["weights_filepath"])
+    model.save(results_dir / config["train"]["weights_filepath"])
 
     logger.info("Finished Training")

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -61,6 +61,12 @@ def mkconfig(crop_to=False, filters=False):
             "crop_to": crop_to,
             "filters": filters,
         },
+        "prepare": {
+            "seed": False,
+            "train_size": 0.2,
+            "test_size": 0.6,
+            "validate_size": 0.2,
+        },
     }
 
 
@@ -145,7 +151,7 @@ def test_load_duplicate(caplog):
         assert "_duplicate_" in caplog.text
 
         # The duplicate files should not be in the data set
-        for filepath in a._all_files():
+        for filepath in a.container._all_files():
             assert "_duplicate_" not in str(filepath)
 
 
@@ -167,7 +173,7 @@ def test_prune_warn_1_percent(caplog):
         assert len(a) == 98
 
         # Object 2 should not be loaded
-        assert "00000000000000101" not in a
+        assert "00000000000000101" not in a.container
 
         # We should Error log because greater than 5% of the objects were pruned
         assert "Greater than 1% of objects in the data directory were pruned." in caplog.text
@@ -194,7 +200,7 @@ def test_prune_error_5_percent(caplog):
         assert len(a) == 18
 
         # Object 20 should not be loaded
-        assert "00000000000000020" not in a
+        assert "00000000000000020" not in a.container
 
         # We should Error log because greater than 5% of the objects were pruned
         assert "Greater than 5% of objects in the data directory were pruned." in caplog.text
@@ -336,7 +342,7 @@ def test_partial_filter_prune_warn_1_percent(caplog):
         assert len(a) == 98
 
         # Object 101 should not be loaded
-        assert "00000000000000101" not in a
+        assert "00000000000000101" not in a.container
 
         # We should Error log because greater than 5% of the objects were pruned
         assert "Greater than 1% of objects in the data directory were pruned." in caplog.text


### PR DESCRIPTION
- HSCDataSet has been significantly modified to implement splits
- Constructors for fibad_data_sets now take a split argument
- Tests pass, but new functionality not yet tested
- New configs added in new "prepare" section to define splits
- Some configs in "model" reorganized to a "train" section that is similar to the "prepare" "predict" and "download" sections in that it configures the action more than anything else.
- Added "split" config to train and predict sections to select the split that will be used.
