### PR TITLE
Adding `dev_mode = false` to `fibad_default_config.toml`

### DIFF
--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -40,7 +40,9 @@ class ConfigDict(dict):
         raise RuntimeError(msg)
 
     def get(self, key, default=None):
-        """Nonfunctional stub of dict.get() which errors always"""
+        """Nonfunctional stub of dict.get() which errors always. Overriding this
+        prevents the possibility of defining default values in code that conflict
+        with default values defined in the config file."""
         msg = f"ConfigDict.get({key},{default}) called. "
         msg += "Please index config dictionaries with [] or __getitem__() only. "
         msg += "Configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
@@ -90,7 +92,8 @@ class ConfigManager:
         self._merge_defaults()
 
         self.config = self.merge_configs(self.overall_default_config, self.user_specific_config)
-        self._validate_runtime_config(self.config, self.overall_default_config)
+        if not self.config["general"]["dev_mode"]:
+            self._validate_runtime_config(self.config, self.overall_default_config)
 
     @staticmethod
     def _read_runtime_config(config_filepath: Union[Path, str] = DEFAULT_CONFIG_FILEPATH) -> ConfigDict:

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -1,5 +1,8 @@
 [general]
-use_gpu = true
+# Whether to run in development mode. When `true`, this will slightly modify the
+# behavior of Fibad to make development faster and easier. For example, it will
+# not check for the existance of default config values in external libraries.
+dev_mode = false
 
 # Destination of log messages
 # 'stderr' and 'stdout' specify the console.

--- a/tests/fibad/test_data/test_default_config.toml
+++ b/tests/fibad/test_data/test_default_config.toml
@@ -1,5 +1,5 @@
 [general]
-use_gpu = true
+dev_mode = true
 
 [train]
 model_name = "example_model" # Use a built-in FIBAD model

--- a/tests/fibad/test_data/test_user_config.toml
+++ b/tests/fibad/test_data/test_user_config.toml
@@ -1,5 +1,5 @@
 [general]
-use_gpu = false
+dev_mode = false
 
 [train.model]
 model_weights_filepath = "final_best.pth"


### PR DESCRIPTION
The primary purpose of this PR is to add a `dev_mode` flag that will allow developers (specifically of external libraries) to move more quickly, and avoid having to define default config values. Instead they will be able to modify and use their user-specific config file during development, with the understanding that, prior to deploying/releasing their code, they will need to introduce a default config file.

Additionally, this PR removes the unused "use_gpu" default config key.
