### PR TITLE
Initial version of filter_catalog feature.

### DIFF
--- a/src/fibad/downloadCutout/downloadCutout.py
+++ b/src/fibad/downloadCutout/downloadCutout.py
@@ -21,6 +21,8 @@ import urllib.response
 from collections.abc import Generator
 from typing import IO, Any, Callable, Optional, Union, cast
 
+import numpy as np
+
 __all__ = []
 
 
@@ -760,6 +762,9 @@ def parse_bool(s: Union[str, bool]) -> bool:
         True or False.
     """
     if isinstance(s, bool):
+        return s
+
+    if isinstance(s, np.bool):
         return s
 
     return {

--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -14,7 +14,7 @@ class Fibad:
     CLI functions in fibad_cli are implemented by calling this class
     """
 
-    verbs = ["train", "predict", "download"]
+    verbs = ["train", "predict", "download", "prepare"]
 
     def __init__(self, *, config_file: Union[Path, str] = None, setup_logging: bool = True):
         """Initialize fibad. Always applies the default config, and merges it with any provided config file.
@@ -175,5 +175,13 @@ class Fibad:
         See Fibad.predict.run()
         """
         from .predict import run
+
+        return run(config=self.config, **kwargs)
+
+    def prepare(self, **kwargs):
+        """
+        See Fibad.predict.run()
+        """
+        from .prepare import run
 
         return run(config=self.config, **kwargs)

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -90,6 +90,10 @@ crop_to = false
 #filters = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
 filters = false
 
+# A fits file which specifies object IDs to filter a large dataset in [general].data_dir down
+# Implementation is dataset class dependent. Default is false meaning now filtering.
+filter_catalog = false
+
 [data_loader]
 # Default PyTorch DataLoader parameters
 batch_size = 32

--- a/src/fibad/prepare.py
+++ b/src/fibad/prepare.py
@@ -1,0 +1,21 @@
+import logging
+
+from fibad.pytorch_ignite import setup_model_and_dataset
+
+logger = logging.getLogger(__name__)
+
+
+def run(config):
+    """Prepare the dataset for a given model and data loader.
+
+    Parameters
+    ----------
+    config : dict
+        The parsed config file as a nested
+        dict
+    """
+
+    _, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
+
+    logger.info("Finished Prepare")
+    return data_set

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -31,7 +31,7 @@ class FakeFitsFS:
         self.test_files = test_files
 
         mock_paths = [Path(x) for x in list(test_files.keys())]
-        target = "fibad.data_sets.hsc_data_set.Path.glob"
+        target = "fibad.data_sets.hsc_data_set.Path.iterdir"
         self.patchers.append(mock.patch(target, return_value=mock_paths))
 
         mock_fits_open = mock.Mock(side_effect=self._open_file)
@@ -53,7 +53,15 @@ class FakeFitsFS:
             patcher.stop()
 
 
-def mkconfig(crop_to=False, filters=False, train_size=0.2, test_size=0.6, validate_size=0, seed=False):
+def mkconfig(
+    crop_to=False,
+    filters=False,
+    train_size=0.2,
+    test_size=0.6,
+    validate_size=0,
+    seed=False,
+    filter_catalog=False,
+):
     """Makes a configuration that points at nonexistent path so HSCDataSet.__init__ will create an object,
     and our FakeFitsFS shim can be called.
     """
@@ -62,6 +70,7 @@ def mkconfig(crop_to=False, filters=False, train_size=0.2, test_size=0.6, valida
         "data_set": {
             "crop_to": crop_to,
             "filters": filters,
+            "filter_catalog": filter_catalog,
         },
         "prepare": {
             "seed": seed,


### PR DESCRIPTION
- We can take a fits file as a config
- We filter objects_ids out of a big dataset based on it
- We also skip filesystem checks if there is enough info in the filter catalog.
- Lacks any unit testing
- Added the prepare verb, but right now it just gives you the dataset object when run from a notebook.

Closes #111 