### PR TITLE
Rebuild a fits manifest from an HSC data directory.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "toml", # Used to load configuration files as dictionaries
     "torch", # Used for CNN model and in train.py
     "torchvision", # Used in hsc data loader, example autoencoder, and CNN model data set
+    "schwimmbad", # Used to speedup hsc data loader file scans
 ]
 
 [project.scripts]

--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -644,7 +644,7 @@ class HSCDataSetContainer(Dataset):
         column_names = Downloader.MANIFEST_COLUMN_NAMES
         columns = {column_name: [] for column_name in column_names}
 
-        # These we vary every object and must be implemented below
+        # These will vary every object and must be implemented below
         dynamic_column_names = ["object_id", "filter", "dim", "tract", "ra", "dec", "filename"]
         # These are pulled from config ("sw", "sh", "rerun", "type", "image", "mask", and "variance")
         static_column_names = [name for name in column_names if name not in dynamic_column_names]

--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -33,32 +33,6 @@ from .data_set_registry import fibad_data_set
 logger = logging.getLogger(__name__)
 
 
-def num_cpus() -> int:
-    """
-    Checks both os.sched_getaffinity and multiprocessing.cpu_count()
-    to find the number of CPUs we have runtime access to.
-
-    Note borrowed from: https://github.com/pylint-dev/pylint/pull/6098/files
-    But we don't check for cgroup-based cpu time limits.
-
-    Returns
-    -------
-    int
-        Number of CPUs
-    """
-    cpu_count = None
-    sched_getaffinity = getattr(os, "sched_getaffinity", None)
-
-    if sched_getaffinity:
-        cpu_count = len(sched_getaffinity(0))
-    elif multiprocessing:
-        cpu_count = multiprocessing.cpu_count()
-    else:
-        cpu_count = 1
-
-    return cpu_count
-
-
 @fibad_data_set
 class HSCDataSet(Dataset):
     _called_from_test = False

--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -502,8 +502,11 @@ class HSCDataSetContainer(Dataset):
 
     @staticmethod
     def _fits_file_dims(filepath):
-        with fits.open(filepath) as hdul:
-            return hdul[1].shape
+        try:
+            with fits.open(filepath) as hdul:
+                return hdul[1].shape
+        except OSError:
+            return (0, 0)
 
     def _prune_objects(self, filters_ref: list[str]):
         """Class initialization helper. Prunes objects from the list of objects.

--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -426,7 +426,7 @@ class HSCDataSetContainer(Dataset):
                 msg += "and will not be included in the data set."
                 logger.error(msg)
 
-            if index != 0 and index % 100_000 == 0:
+            if index != 0 and index % 1_000_000 == 0:
                 logger.info(f"Processed {index} files.")
         else:
             logger.info(f"Processed {index+1} files")
@@ -488,11 +488,11 @@ class HSCDataSetContainer(Dataset):
         logger.info("Scanning for dimensions...")
 
         retval = {}
-        with MultiPool(processes=10) as pool:
+        with MultiPool(processes=150) as pool:
             args = (
-                (object_id, list(self._object_files(object_id))) for object_id in self.ids(log_every=100_000)
+                (object_id, list(self._object_files(object_id))) for object_id in self.ids(log_every=1_000_000)
             )
-            retval = dict(pool.map(self._scan_file_dimension, args))
+            retval = dict(pool.imap(self._scan_file_dimension, args, chunksize=1000))
         return retval
 
     @staticmethod
@@ -544,7 +544,7 @@ class HSCDataSetContainer(Dataset):
                         msg += f"({self.cutout_shape[0]}px, {self.cutout_shape[1]}px)"
                         self._mark_for_prune(object_id, msg)
                         break
-            if index != 0 and index % 100_000 == 0:
+            if index != 0 and index % 1_000_000 == 0:
                 logger.info(f"Processed {index} objects for pruning")
         else:
             logger.info(f"Processed {index + 1} objects for pruning")
@@ -694,7 +694,7 @@ class HSCDataSetContainer(Dataset):
                     # which will be hit when someone alters dynamic column names above without also
                     # writing an implementation.
                     raise RuntimeError(f"No implementation to process column {dynamic_col}")
-            if index != 0 and index % 100_000 == 0:
+            if index != 0 and index % 1_000_000 == 0:
                 logger.info(f"Addeed {index} objects to manifest")
         else:
             logger.info(f"Addeed {index+1} objects to manifest")

--- a/src/fibad/download.py
+++ b/src/fibad/download.py
@@ -28,6 +28,8 @@ class Downloader:
     # of the immutable fields that we rely on for hash checks are also included.
     RECT_COLUMN_NAMES = list(dict.fromkeys(VARIABLE_FIELDS + dC.Rect.immutable_fields + ["dim"]))
 
+    MANIFEST_COLUMN_NAMES = RECT_COLUMN_NAMES + ["filename", "object_id"]
+
     MANIFEST_FILE_NAME = "manifest.fits"
 
     def __init__(self, config):
@@ -280,9 +282,8 @@ resuming the correct download? Deleting the manifest and cutout files will start
         logger.info(f"Writing out download manifest with {len(combined_manifest)} entries.")
 
         # Convert the combined manifest into an astropy table by building a dict of {column_name: column_data}
-        # for all the fields in a rect, plus our object_id and filename.
-        column_names = Downloader.RECT_COLUMN_NAMES + ["filename", "object_id"]
-        columns = {column_name: [] for column_name in column_names}
+        # for all the fields we require in a manifest
+        columns = {column_name: [] for column_name in Downloader.MANIFEST_COLUMN_NAMES}
 
         for rect, msg in combined_manifest.items():
             # This parsing relies on the name format set up in create_rects to work properly

--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import Union
 
-from .config_utils import ConfigManager, resolve_runtime_config
+from .config_utils import ConfigManager
 
 
 class Fibad:
@@ -14,7 +14,7 @@ class Fibad:
     CLI functions in fibad_cli are implemented by calling this class
     """
 
-    verbs = ["train", "predict", "download", "prepare"]
+    verbs = ["train", "predict", "download", "prepare", "rebuild_manifest"]
 
     def __init__(self, *, config_file: Union[Path, str] = None, setup_logging: bool = True):
         """Initialize fibad. Always applies the default config, and merges it with any provided config file.
@@ -88,7 +88,7 @@ class Fibad:
             # Setup our handlers from config
             self._initialize_log_handlers()
 
-        self.logger.info(f"Runtime Config read from: {resolve_runtime_config(config_file)}")
+        self.logger.info(f"Runtime Config read from: {ConfigManager.resolve_runtime_config(config_file)}")
 
     def _initialize_log_handlers(self):
         """Private initialization helper, Adds handlers and level setting to the global self.logger object"""
@@ -180,8 +180,16 @@ class Fibad:
 
     def prepare(self, **kwargs):
         """
-        See Fibad.predict.run()
+        See Fibad.prepare.run()
         """
         from .prepare import run
+
+        return run(config=self.config, **kwargs)
+
+    def rebuild_manifest(self, **kwargs):
+        """
+        See Fibad.rebuild_manifest.run()
+        """
+        from .rebuild_manifest import run
 
         return run(config=self.config, **kwargs)

--- a/src/fibad/rebuild_manifest.py
+++ b/src/fibad/rebuild_manifest.py
@@ -15,6 +15,8 @@ def run(config):
         dict
     """
 
+    config["rebuild_manifest"] = True
+
     _, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
 
     logger.info("Starting rebuild of manifest")

--- a/src/fibad/rebuild_manifest.py
+++ b/src/fibad/rebuild_manifest.py
@@ -17,6 +17,8 @@ def run(config):
 
     _, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
 
+    logger.info("Starting rebuild of manifest")
+
     data_set.rebuild_manifest(config)
 
-    logger.info("Finished Prepare")
+    logger.info("Finished Rebuild Manifest")

--- a/src/fibad/rebuild_manifest.py
+++ b/src/fibad/rebuild_manifest.py
@@ -1,0 +1,22 @@
+import logging
+
+from fibad.pytorch_ignite import setup_model_and_dataset
+
+logger = logging.getLogger(__name__)
+
+
+def run(config):
+    """Rebuild a broken download manifest
+
+    Parameters
+    ----------
+    config : dict
+        The parsed config file as a nested
+        dict
+    """
+
+    _, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
+
+    data_set.rebuild_manifest(config)
+
+    logger.info("Finished Prepare")

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -131,8 +131,8 @@ def test_load(caplog):
         # 10 objects should load
         assert len(a) == 10
 
-        # The number of filters, and image dimensions should be correct
-        assert a.shape() == (5, 262, 263)
+        # The number of filters, and image dimensions should be correct and square
+        assert a.shape() == (5, 262, 262)
 
         # No warnings should be printed
         assert caplog.text == ""
@@ -152,8 +152,8 @@ def test_load_duplicate(caplog):
         # Only 10 objects should load
         assert len(a) == 10
 
-        # The number of filters, and image dimensions should be correct
-        assert a.shape() == (5, 262, 263)
+        # The number of filters, and image dimensions should be correct and square
+        assert a.shape() == (5, 262, 262)
 
         # We should get duplicate object errors
         assert "Duplicate object ID" in caplog.text
@@ -327,8 +327,8 @@ def test_partial_filter(caplog):
         # 10 objects should load
         assert len(a) == 10
 
-        # The number of filters, and image dimensions should be correct
-        assert a.shape() == (2, 262, 263)
+        # The number of filters, and image dimensions should be correct and square
+        assert a.shape() == (2, 262, 262)
 
         # No warnings should be printed
         assert caplog.text == ""

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -9,6 +9,8 @@ from fibad.data_sets.hsc_data_set import HSCDataSet, HSCDataSetSplit
 
 test_dir = Path(__file__).parent / "test_data" / "dataloader"
 
+HSCDataSet._called_from_test = True
+
 
 class FakeFitsFS:
     """


### PR DESCRIPTION
- Added a new verb rebuild_manifest
- When run with the HSC dataset class this verb will: 0) Scan the data directory and ingest HSC cutout files 1) Read in the original catalog file configured for download for metadata 2) Write out rebuilt_manifest.fits in the data directory
- Fixed up config resolution so that fibad_config.toml in the cwd works again for CLI invocations.
- File scanning has been parallelized with multiprocessing to reduce time from ~30d -> 6hr on hyak w 24M files
- Number of processes to launch dynamically chosen based on system limits, with intent to achieve max io bandwidth.
