### PR TITLE
Adding guards in HSCDataSet for the manifest representation of un-downloaded files

### DIFF
--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -731,8 +731,8 @@ class HSCDataSetContainer(Dataset):
         if min(cutout_height, cutout_width) < 1:
             msg = "Automatic determination found an absurd dimension of "
             msg += f"({cutout_width}px, {cutout_height}px)\n"
-            msg += "Please either correct the data source or set a static cutout side with the \n"
-            msg += "crop_to configuration in the dataset section of the fibad config.\n"
+            msg += "Please either correct the data source or set a static cutout size with the \n"
+            msg += "crop_to configuration in the [data_set] section of your fibad config.\n"
             raise RuntimeError(msg)
 
         return cutout_width, cutout_height

--- a/src/fibad/download.py
+++ b/src/fibad/download.py
@@ -107,7 +107,7 @@ class Downloader:
             while batch := tuple(itertools.islice(iterator, n)):
                 yield batch
 
-        if len(self.rects) > num_threads:
+        if len(self.rects) < num_threads:
             msg = f"Only {len(self.rects)} sky locations, which is less than the number of threads, so we "
             msg += "will use only one thread."
             logger.info(msg)


### PR DESCRIPTION
- Should fix issue #127.
- Moved removal of incomplete downloads from the prune stage to the f/s read stage
- Added a better error to the case where HSCDataSet arrives at an absurdly small size of image to crop to.
- Unrelated fix to downloader to make it respect concurrent_connections.