### PR TITLE
Allow definition of Loss and Optimizer in config file.

### DIFF
--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -61,6 +61,18 @@ name = "ExampleAutoencoder"
 base_channel_size = 32
 latent_dim = 64
 
+[criterion]
+# The name of the built-in criterion to use or the libpath to an external criterion
+name = "torch.nn.CrossEntropyLoss"
+
+[optimizer]
+# The name of the built-in optimizer to use or the libpath to an external optimizer
+name = "torch.optim.SGD"
+
+# Default PyTorch optimizer parameters. The keys match the names of the parameters
+lr = 0.01
+momentum = 0.9
+
 [train]
 weights_filepath = "example_model.pth"
 epochs = 10

--- a/src/fibad/models/example_cnn_classifier.py
+++ b/src/fibad/models/example_cnn_classifier.py
@@ -7,7 +7,6 @@ import logging
 import torch
 import torch.nn as nn
 import torch.nn.functional as F  # noqa N812
-import torch.optim as optim
 
 from .model_registry import fibad_model
 
@@ -63,9 +62,3 @@ class ExampleCNN(nn.Module):
         loss.backward()
         self.optimizer.step()
         return {"loss": loss.item()}
-
-    def _criterion(self):
-        return nn.CrossEntropyLoss()
-
-    def _optimizer(self):
-        return optim.SGD(self.parameters(), lr=0.001, momentum=0.9)

--- a/src/fibad/plugin_utils.py
+++ b/src/fibad/plugin_utils.py
@@ -1,7 +1,7 @@
 import importlib
 
 
-def get_or_load_class(config: dict, registry: dict) -> type:
+def get_or_load_class(config: dict, registry: dict = None) -> type:
     """Given a configuration dictionary and a registry dictionary, attempt to return
     the requested class either from the registry or by dynamically importing it.
 
@@ -28,7 +28,7 @@ def get_or_load_class(config: dict, registry: dict) -> type:
     if "name" in config:
         class_name = config["name"]
 
-        if class_name in registry:
+        if registry and class_name in registry:
             returned_class = registry[class_name]
         else:
             returned_class = import_module_from_string(class_name)


### PR DESCRIPTION
This is an initial implementation that allows defining PyTorch Loss (Criterion) and Optimizers from within the config file. 

Two new tables are introduced, `[criterion]` and `[optimizer]` and we currently use the relatively familiar libpath approach to avoid having to create a registry of pytorch criterion and optimizer functions which would need to be loaded at run time (kind of heavy and slow) 

The keys in the tables need to share the same names as the parameters that would be passed to the loss or optimizer functions. (we just use  `**config` to pass the params in). 

Within the `__init__` function of either the built in models or in an external class the user will still need to call: 
```
self.optimizer = self._optimizer()
self.criterion = self._criterion()
```
(I would like to fix that in a followup PR - Issue #134)

Additionally, if the user has a special `def _optimizer()` or `def _criterion()` function that is defined in the model class, we will not over write that.

One final followup would be to allow a Learning Rate scheduler ([described here](https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate)) to be defined in the config as well. That won't happen in this PR though.
 