### PR TITLE
Breaking `setup_model_and_dataset` into two functions.

### DIFF
--- a/src/fibad/predict.py
+++ b/src/fibad/predict.py
@@ -5,7 +5,12 @@ import numpy as np
 from torch import Tensor
 
 from fibad.config_utils import ConfigDict, create_results_dir, log_runtime_config
-from fibad.pytorch_ignite import create_evaluator, dist_data_loader, setup_model_and_dataset
+from fibad.pytorch_ignite import (
+    create_evaluator,
+    dist_data_loader,
+    setup_dataset,
+    setup_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +24,8 @@ def run(config: ConfigDict):
         The parsed config file as a nested dict
     """
 
-    model, data_set = setup_model_and_dataset(config, split=config["predict"]["split"])
+    data_set = setup_dataset(config, split=config["predict"]["split"])
+    model = setup_model(config, data_set)
     logger.info(f"data set has length {len(data_set)}")
     data_loader = dist_data_loader(data_set, config)
 

--- a/src/fibad/prepare.py
+++ b/src/fibad/prepare.py
@@ -1,6 +1,6 @@
 import logging
 
-from fibad.pytorch_ignite import setup_model_and_dataset
+from fibad.pytorch_ignite import setup_dataset
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ def run(config):
         dict
     """
 
-    _, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
+    data_set = setup_dataset(config, split=config["train"]["split"])
 
     logger.info("Finished Prepare")
     return data_set

--- a/src/fibad/rebuild_manifest.py
+++ b/src/fibad/rebuild_manifest.py
@@ -1,6 +1,6 @@
 import logging
 
-from fibad.pytorch_ignite import setup_model_and_dataset
+from fibad.pytorch_ignite import setup_dataset
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ def run(config):
 
     config["rebuild_manifest"] = True
 
-    _, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
+    data_set = setup_dataset(config, split=config["train"]["split"])
 
     logger.info("Starting rebuild of manifest")
 

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -4,7 +4,13 @@ from tensorboardX import SummaryWriter
 
 from fibad.config_utils import create_results_dir, log_runtime_config
 from fibad.gpu_monitor import GpuMonitor
-from fibad.pytorch_ignite import create_trainer, create_validator, dist_data_loader, setup_model_and_dataset
+from fibad.pytorch_ignite import (
+    create_trainer,
+    create_validator,
+    dist_data_loader,
+    setup_dataset,
+    setup_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +32,8 @@ def run(config):
     tensorboardx_logger = SummaryWriter(log_dir=results_dir)
 
     # Instantiate the model and dataset
-    model, data_set = setup_model_and_dataset(config, split=config["train"]["split"])
+    data_set = setup_dataset(config, split=config["train"]["split"])
+    model = setup_model(config, data_set)
 
     # Create a data loader for the training set
     train_data_loader = dist_data_loader(data_set, config, "train")


### PR DESCRIPTION
Breaking these apart avoids unnecessary creation of model instances in prepare and rebuild_manifest. And this opens the door for a potentially more intuitive way to create datasets for training that include (train, [validate, test]) subsets. 

This PR only implements the separation of the `setup_model_and_dataset` function and percolates that change down to the various fibad verb implementations. 