### PR TITLE
Fix assorted issues encountered while experimenting with vectordb

### DIFF
--- a/docs/notebooks/train_model.ipynb
+++ b/docs/notebooks/train_model.ipynb
@@ -73,12 +73,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "%load_ext tensorboard"
+    "Fibad automatically records training metrics so that they can be examined using Tensorboard."
    ]
   },
   {
@@ -87,6 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%reload_ext tensorboard\n",
     "%tensorboard --logdir ./results\n",
     "\n",
     "# if running on a remote server, and tunnelling a connection,\n",
@@ -96,11 +95,52 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once a model has been trained, we can use the model weights file to run inference on. Here we update the configuration in the `fibad_instance` object to specify that we want to use a specific model weights file, and that we want our dataset to be 100% test data.\n",
+    "\n",
+    "If you are running this locally, you'll need to update the path to your local model weights file."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Set this to the path of the example.pth file that was created by the call to fibad_instance.train().\n",
+    "# It should be something like `.../results/<timestamp>-train/example_model.pth`.\n",
+    "fibad_instance.config[\"infer\"][\"model_weights_file\"] = \"\"\n",
+    "\n",
+    "fibad_instance.config[\"data_set\"][\"test_size\"] = 1.0\n",
+    "fibad_instance.config[\"data_set\"][\"train_size\"] = 0.0\n",
+    "fibad_instance.config[\"data_set\"][\"validate_size\"] = 0.0\n",
+    "fibad_instance.config[\"data_loader\"][\"batch_size\"] = 128"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following will run inference on the specified dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fibad_instance.infer()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TODO: Add a cell to plot a confusion matrix."
+   ]
   }
  ],
  "metadata": {
@@ -119,7 +159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/train_model.ipynb
+++ b/docs/notebooks/train_model.ipynb
@@ -132,7 +132,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fibad_instance.infer()"
+    "# Uncomment the following line after setting the model_weights_file in the previous cell\n",
+    "\n",
+    "# fibad_instance.infer()"
    ]
   },
   {

--- a/src/fibad/data_sets/example_cifar_data_set.py
+++ b/src/fibad/data_sets/example_cifar_data_set.py
@@ -32,21 +32,21 @@ class CifarDataSet(CIFAR10):
             if config["data_set"]["validate_size"]:
                 split = int(np.floor(config["data_set"]["validate_size"] * num_train))
 
-        random_seed = None
-        if config["data_set"]["seed"]:
-            random_seed = config["data_set"]["seed"]
-        np.random.seed(random_seed)
-        np.random.shuffle(indices)
+            random_seed = None
+            if config["data_set"]["seed"]:
+                random_seed = config["data_set"]["seed"]
+            np.random.seed(random_seed)
+            np.random.shuffle(indices)
 
-        train_idx, valid_idx = indices[split:], indices[:split]
+            train_idx, valid_idx = indices[split:], indices[:split]
 
-        #! These two "samplers" are used by PyTorch's DataLoader to split the
-        #! dataset into training and validation sets. Using Samplers is mutually
-        #! exclusive with using "shuffle" in the DataLoader.
-        #! If a user doesn't define a Sampler, the default behavior of pytorch-ignite
-        #! is to shuffle the data unless `shuffle = False` in the config.
-        self.train_sampler = SubsetRandomSampler(train_idx)
-        self.validation_sampler = SubsetRandomSampler(valid_idx)
+            #! These two "samplers" are used by PyTorch's DataLoader to split the
+            #! dataset into training and validation sets. Using Samplers is mutually
+            #! exclusive with using "shuffle" in the DataLoader.
+            #! If a user doesn't define a Sampler, the default behavior of pytorch-ignite
+            #! is to shuffle the data unless `shuffle = False` in the config.
+            self.train_sampler = SubsetRandomSampler(train_idx)
+            self.validation_sampler = SubsetRandomSampler(valid_idx)
 
     def shape(self):
         return (3, 32, 32)

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -150,5 +150,4 @@ num_workers = 2
 
 [infer]
 model_weights_file = false
-batch_size = 32
 split = "test"

--- a/src/fibad/infer.py
+++ b/src/fibad/infer.py
@@ -27,7 +27,7 @@ def run(config: ConfigDict):
     data_set = setup_dataset(config, split=config["infer"]["split"])
     model = setup_model(config, data_set)
     logger.info(f"data set has length {len(data_set)}")
-    data_loader = dist_data_loader(data_set, config)
+    data_loader = dist_data_loader(data_set, config, split=config["infer"]["split"])
 
     # Create a results directory and dump our config there
     results_dir = create_results_dir(config, "infer")

--- a/src/fibad/models/example_autoencoder.py
+++ b/src/fibad/models/example_autoencoder.py
@@ -36,9 +36,6 @@ class ExampleAutoencoder(nn.Module):
         self._init_encoder()
         self._init_decoder()
 
-        # create this here for use in `train_step`, to avoid recreating at each step.
-        self.optimizer = self._optimizer()
-
     def conv2d_multi_layer(self, input_size, num_applications, **kwargs) -> int:
         for _ in range(num_applications):
             input_size = self.conv2d_output_size(input_size, **kwargs)

--- a/src/fibad/models/example_cnn_classifier.py
+++ b/src/fibad/models/example_cnn_classifier.py
@@ -26,11 +26,6 @@ class ExampleCNN(nn.Module):
 
         self.config = config
 
-        # Optimizer and criterion could be set directly, i.e. `self.optimizer = optim.SGD(...)`
-        # but we define them as methods as a way to allow for more flexibility in the future.
-        self.optimizer = self._optimizer()
-        self.criterion = self._criterion()
-
     def forward(self, x):
         # This check is inefficient - we assume that the example CNN will be primarily
         # used with the CIFAR10 dataset. During training, the `train_step` method

--- a/src/fibad/models/example_cnn_classifier.py
+++ b/src/fibad/models/example_cnn_classifier.py
@@ -32,6 +32,14 @@ class ExampleCNN(nn.Module):
         self.criterion = self._criterion()
 
     def forward(self, x):
+        # This check is inefficient - we assume that the example CNN will be primarily
+        # used with the CIFAR10 dataset. During training, the `train_step` method
+        # will unpack the tuple and only pass the first element to the `forward` method.
+        # But for inference the entire tuple is passed in, so we need to handle
+        # both cases.
+        if isinstance(x, tuple):
+            x, _ = x
+
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
         x = torch.flatten(x, 1)

--- a/src/fibad/models/example_hsc_autoencoder.py
+++ b/src/fibad/models/example_hsc_autoencoder.py
@@ -37,12 +37,6 @@ class HSCAutoencoder(nn.Module):  # These shapes work with [3,258,258] inputs
 
         self.config = config
 
-        self.optimizer = self._optimizer()
-        # self.optimizer = optim.Adam(self.parameters(), lr=0.001)
-
-        self.criterion = self._criterion()
-        # self.criterion = nn.MSELoss()
-
     def forward(self, x):
         encoded = self.encoder(x)
         decoded = self.decoder(encoded)

--- a/src/fibad/models/model_registry.py
+++ b/src/fibad/models/model_registry.py
@@ -52,6 +52,15 @@ def fibad_model(cls):
         cls._criterion = _torch_criterion if not hasattr(cls, "_criterion") else cls._criterion
         cls._optimizer = _torch_optimizer if not hasattr(cls, "_optimizer") else cls._optimizer
 
+    original_init = cls.__init__
+
+    def wrapped_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.criterion = self._criterion()
+        self.optimizer = self._optimizer()
+
+    cls.__init__ = wrapped_init
+
     required_methods = ["train_step", "forward", "__init__"]
     for name in required_methods:
         if not hasattr(cls, name):

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -231,9 +231,6 @@ def create_validator(
     device = idist.device()
     model = idist.auto_model(model)
 
-    #! Need to figure out the appropriate way to switch the model between .train()
-    #! and .eval() mode. We aren't doing that here - so the model is being trained
-    #! during validation!
     validator = create_engine("train_step", device, model)
 
     @validator.on(Events.STARTED)


### PR DESCRIPTION
Remove `batch_size` from `infer` table. Fixes #145.
CiFAR example dataset wasn't working correctly for inference - changed the behavior of splits. Fixes #144
Remove need to explicitly define criterion and optimizer for models. Users still have the option to do so, but it's not required. Fixes #134