### PR TITLE
Is having no validation split valid?

### DIFF
--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -88,10 +88,6 @@ class HSCDataSet(Dataset):
             else:
                 train_size = 1.0 - (test_size + validate_size)
 
-        # If we still don't have a validate size, decide whether we will infer a validate size
-        if (validate_size is None) and (np.round(train_size + test_size) != 1.0):
-            validate_size = 1.0 - (train_size + test_size)
-
         # If splits cover more than the entire dataset, error out.
         if validate_size is None:
             if np.round(train_size + test_size) > 1.0:


### PR DESCRIPTION
This PR is more of a question for the group about what the semantic meaning of setting a config to False is.

Consider this user config:
```
[data_set]
validate_size=false
```

Our existing code for generating validate splits had a bug, where it would generate you a validation split so long as train_size+test_size < 0.5. This is weird behavior and probably a result of not telling `np.round` how many decimal points to round to.

**Under this config do we construct and ultimately use a validation split or not?**

~~The code in this PR says "yes", but I'm not sure if that's correct.
At the moment "no" would mean removing the `if` block in `hsc_data_set.py` and leaving the test unchanged.

Thoughts?~~

We decided its that the answer is "no" to the question above. It is valid to not have a validation split.