### PR TITLE
Default to using the whole dataset for inference unless overriden

### DIFF
--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -150,4 +150,6 @@ num_workers = 2
 
 [infer]
 model_weights_file = false
-split = "test"
+# Select a split ("train", "test", or "validate") to use for inference
+# default of false selects the entire dataset for inference.
+split = false


### PR DESCRIPTION
See discussion on Issue #138 This implements @drewoldag 's suggestion.