### PR TITLE
Cleaning up default config formatting, values and comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "astropy", # Used to load fits files of sources to query HSC cutout server
     "pytorch-ignite", # Used for distributed training, logging, etc.
     "toml", # Used to load configuration files as dictionaries
+    "tomlkit", # Used to load configuration files as dictionaries and retain comments
     "torch", # Used for CNN model and in train.py
     "torchvision", # Used in hsc data loader, example autoencoder, and CNN model data set
     "tensorboardX", # Used to log training metrics

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -1,78 +1,97 @@
 [general]
-# Whether to run in development mode. When `true`, this will slightly modify the
-# behavior of Fibad to make development faster and easier. For example, it will
-# not check for the existance of default config values in external libraries.
+# Set to `true` during development to skip checking for default config values
+# in external libraries. Use `false` otherwise.
 dev_mode = false
 
-# Destination of log messages
-# 'stderr' and 'stdout' specify the console.
+# Destination of log messages. Options: 'stderr', 'stdout' specify the console,
+# "path/to/fibad.log" specifies a file.
 log_destination = "stderr"
-# A path name specifies a file e.g.
-# log_destination = "fibad_log.txt"
 
-# Lowest log level to emit.
-# As you go down the list, fibad will become more verbose in the log.
-#
-# log_level = "critical" # Only emit the most severe of errors
-# log_level = "error"    # Emit all errors
-# log_level = "warning"  # Emit warnings and all errors
-log_level = "info"     # Emit informational messages, warnings and all errors
-# log_level = "debug"    # Very verbose, emit all log messages.
+# Lowest log level to emit. Options: "critical", "error", "warning", "info", "debug".
+log_level = "info"
 
+# Directory where data is stored.
 data_dir = "./data"
-results_dir = "./results" # Results get named <verb>-<timestamp> under this directory
+
+#Top level directory for writing results.
+results_dir = "./results"
+
 
 [download]
+# Cut out width in arcseconds.
 sw = "22asec"
+
+# Cut out height in arcseconds.
 sh = "22asec"
+
+# The filters to download.
 filter = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
+
+# The type of data to download.
 type = "coadd"
+
+# The data release to download from.
 rerun = "pdr3_wide"
 
-# Credentials for the downloader. Either provide username/password in a fibad config file
-# or with a credentials.ini file. The format for credentials.ini is as follows:
-#
+# Path to credentials.ini file for the downloader. File contents should be:
 # username = "<your username>"
 # password = "<your password>"
-#
-# It is preferred to use a credentials.ini file to avoid sensitive user credentials being
-# committed to source control systems like git.
-username = false
-password = false
-# Location of the credentials.ini file. Defaults to credentials.ini in the current directory
-# but can be configured to a common location for batch processing.
 credentials_file = "./credentials.ini"
 
-num_sources = -1 # Values below 1 here indicate all sources in the catalog will be downloaded
+# Alternative method to pass credentials to the downloader. Prefer to use a
+#credentials.ini file to avoid exposing credentials with source control.
+username = false
+password = false
+
+# The number of sources to download from the catalog. Default is -1, which
+# downloads all sources in the catalog.
+num_sources = -1
+
+# The number of sources to skip in the catalog. Default is 0.
 offset = 0
+
+# The number of concurrent connections to use when downloading data.
 concurrent_connections = 4
+
+# The number of seconds between printing download statistics.
 stats_print_interval = 60
+
+# The path to the catalog file that defines which cutouts to download.
 fits_file = "./catalog.fits"
 
-# These control the downloader's HTTP requests and retries
-# `retry_wait` How long to wait before retrying a failed HTTP request in seconds. Default 30s
+# The number of seconds to wait before retrying a failed HTTP request in seconds.
 retry_wait = 30
-# `retries` How many times to retry a failed HTTP request before moving on to the next one. Default 3 times
+
+# How many times to retry a failed HTTP request before moving on to the next one.
 retries = 3
-# `timepout` How long should we wait to get a full HTTP response from the server. Default 3600s (1hr)
+
+# Number of seconds to wait for a full HTTP response from the server.
 timeout = 3600
-# `chunksize` How many sky location rectangles should we request in a single request. Default is 990
+
+# The number of sky location rectangles should we request in a single request.
 chunk_size = 990
 
-# Whether to retrieve the image layer
+# Request the image layer from the cutout service
 image = true
-# Whether to retrieve the variance layer
+
+# Request the variance layer from the cutout service
 variance = false
-# Whether to retrieve the mask layer
+
+# Request the mask layer from the cutout service
 mask = false
 
+
 [model]
-# The name of the built-in model to use or the libpath to an external model
-# e.g. "user_package.submodule.ExternalModel" or "ExampleAutoencoder"
+# The name of the model to use. Option are a builtin model class name or import path
+# to an external model. e.g. "ExampleAutoencoder", "user_pkg.model.ExternalModel"
 name = "ExampleAutoencoder"
 
+# The number of output channels from the first layer.
 base_channel_size = 32
+
+# The length of the latent space vector.
 latent_dim = 64
+
 
 [criterion]
 # The name of the built-in criterion to use or the libpath to an external criterion

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -38,8 +38,8 @@ rerun = "pdr3_wide"
 # password = "<your password>"
 credentials_file = "./credentials.ini"
 
-# Alternative method to pass credentials to the downloader. Prefer to use a
-#credentials.ini file to avoid exposing credentials with source control.
+# Alternate way to pass credentials to the downloader. Users should prefer a
+# credentials.ini file to avoid exposing credentials with source control.
 username = false
 password = false
 
@@ -82,7 +82,7 @@ mask = false
 
 
 [model]
-# The name of the model to use. Option are a builtin model class name or import path
+# The name of the model to use. Option are a built-in model class name or import path
 # to an external model. e.g. "ExampleAutoencoder", "user_pkg.model.ExternalModel"
 name = "ExampleAutoencoder"
 
@@ -94,98 +94,96 @@ latent_dim = 64
 
 
 [criterion]
-# The name of the built-in criterion to use or the libpath to an external criterion
+# The name of the built-in criterion to use or the import path to an external criterion
 name = "torch.nn.CrossEntropyLoss"
 
 [optimizer]
-# The name of the built-in optimizer to use or the libpath to an external optimizer
+# The name of the built-in optimizer to use or the import path to an external optimizer
 name = "torch.optim.SGD"
 
-# Default PyTorch optimizer parameters. The keys match the names of the parameters
+# learning rate parameter for default optimizer. The keys match the names of the parameters
 lr = 0.01
+
+# momentum parameter for default optimizer. The keys match the names of the parameters
 momentum = 0.9
 
+
 [train]
+# The name of the file were the model weights will be saved after training.
 weights_filepath = "example_model.pth"
+
+#The number of epochs to train for.
 epochs = 10
-# Set this to the path of a checkpoint file to resume, or continue training,
-# from a checkpoint. Otherwise, set to false to start from scratch.
+
+# If resuming from a check point, set to the path of the checkpoint file.
+# Otherwise set to `false` to start training from the beginning.
 resume = false
+
+# The data_set split to use when training a model.
 split = "train"
 
+
 [data_set]
-# Name of the built-in data loader to use or the libpath to an external data loader
-# e.g. "user_package.submodule.ExternalDataLoader" or "HSCDataSet"
+# Name of the built-in data loader to use or the import path to an external data
+# loader. e.g. "HSCDataSet", "user_pkg.data_set.ExternalDataSet"
 name = "CifarDataSet"
 
-# Pixel dimensions used to crop all images prior to loading. Will prune any images that are too small.
-#
-# If not provided by user, the default of 'false' scans the directory for the smallest dimensioned files, and 
-# uses those pixel dimensions as the crop size.
-#
-#crop_to = [100,100]
+# Crop pixel dimensions for images, e.g., [100, 100]. If false, scans for the
+# smallest image size in [general].data_dir and uses it.
 crop_to = false
 
-# Limit data loader to only particular filters when there are more in the data set.
-#
-# When not provided by the user, the number of filters will be automatically gleaned from the data set.
-# Defaults behavior is produced by the false value.
-#
-#filters = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
+# Specific to `hsc_data_set`. Limit to only particular filters from the data set.
+# When `false`, uses all filters found in the data set.
 filters = false
 
-# A fits file which specifies object IDs to filter a large dataset in [general].data_dir down
-# Implementation is dataset class dependent. Default is false meaning now filtering.
+# Path to a fits file that specifies object IDs to use from the data stored in
+# [general].data_dir. Implementation is data_set class dependent. Use `false` for no filtering.
 filter_catalog = false
 
-# How to split the data between training and eval sets.
-# The semantics are borrowed from scikit-learn's train-test-split, and HF Dataset's train-test-split function
-# It is an error for these values to add to more than 1.0 as ratios or the size of the dataset if expressed
-# as integers.
+# For train_size, validation_size, and test_size, the following options are available:
+# A `float` between `0.0` and `1.0` is the proportion of the dataset to include in the split.
+# If `int`, represents the absolute number of samples in the particular split.
+# It is an error for these values to add to more than 1.0 as ratios or the size
+# of the dataset if expressed as integers.
 
-# train_size: Size of the train split
-# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
-# train split.
-# If `int`, represents the absolute number of train samples.
-# If `false`, the value is automatically set to the complement of the test size.
+# Size of the train split.
+# If `false`, the value is automatically set to the complement of test_size.
 train_size = 0.6
 
-# validate_size: Size of the validation split
-# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
-# train split.
-# If `int`, represents the absolute number of train samples.
-# If `false`, and both train_size and test_size are defined, the value is automatically set to the complement 
-# of the other two sizes summed.
-# If `false`, and only one of the other sizes is defined, no validate split is created
+# Size of the validation split.
+# If `false`, and both train_size and test_size are defined, the value is set
+# to the complement of the other two sizes summed.
+# If `false`, and only one of the other sizes is defined, no validate split is created.
 validate_size = 0.2
 
-# test_size: Size of the test split
-# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
-# test split.
-# If `int`, represents the absolute number of test samples.
-# If `false`, the value is set to the complement of the train size.
-# If `train_size` is also `false`, it will be set to `0.25`.
+# Size of the test split.
+# If `false`, the value is set to the complement of train_size.
+# If `false` and `train_size = false`, test_size is set to `0.25`.
 test_size = 0.2
 
-# Number to seed with for generating a random split. False means the data will be seeded from
-# a system source at runtime.
+# Number to seed with for generating a random split. Use `false` to seed from a
+# system source at runtime.
 seed = false
 
-#Controls whether images are cached during data loading. For training, this reduces runtimes
-#after the first epoch.
+# If `true`, cache data in memory during training. For training, this reduces runtimes
+#after the first epoch. Set to `false` to disable caching or when running inference.
 use_cache = true
 
-[data_loader]
-# Default PyTorch DataLoader parameters
-batch_size =32
 
-# We could remove this potentially - pytorch-ignite will default to shuffle=True
-# If the user wanted to explicitly require no shuffling, they could set this to false.
+[data_loader]
+# The number of data points to load at once.
+batch_size = 32
+
+# Whether the input data is shuffled before being loaded.
 shuffle = false
+
+# Number of subprocesses for data loading. Typically between 2 and the number of CPUs.
 num_workers = 2
 
+
 [infer]
+# The path to the model weights file to use for inference.
 model_weights_file = false
-# Select a split ("train", "test", or "validate") to use for inference
-# default of false selects the entire dataset for inference.
+
+# The data_set split to use for inference. Use `false` for entire dataset.
 split = false

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -47,9 +47,6 @@ password = false
 # downloads all sources in the catalog.
 num_sources = -1
 
-# The number of sources to skip in the catalog. Default is 0.
-offset = 0
-
 # The number of concurrent connections to use when downloading data.
 concurrent_connections = 4
 
@@ -133,49 +130,44 @@ name = "CifarDataSet"
 crop_to = false
 
 # Specific to `hsc_data_set`. Limit to only particular filters from the data set.
-# When `false`, uses all filters found in the data set.
+# When `false`, use all filters. Options: ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
 filters = false
 
 # Path to a fits file that specifies object IDs to use from the data stored in
 # [general].data_dir. Implementation is data_set class dependent. Use `false` for no filtering.
 filter_catalog = false
 
-# For train_size, validation_size, and test_size, the following options are available:
-# A `float` between `0.0` and `1.0` is the proportion of the dataset to include in the split.
-# If `int`, represents the absolute number of samples in the particular split.
-# It is an error for these values to add to more than 1.0 as ratios or the size
-# of the dataset if expressed as integers.
+# train_size, validation_size, and test_size use these conventions:
+# * A `float` between `0.0` and `1.0` is the proportion of the dataset to include in the split.
+# * An `int`, represents the absolute number of samples in the particular split.
+# * It is an error for these values to add to more than 1.0 as ratios or the size
+#   of the dataset if expressed as integers.
 
-# Size of the train split.
-# If `false`, the value is automatically set to the complement of test_size.
+# Size of the train split. If `false`, the value is automatically set to the
+# complement of test_size plus validate_size (if any).
 train_size = 0.6
 
-# Size of the validation split.
-# If `false`, and both train_size and test_size are defined, the value is set
-# to the complement of the other two sizes summed.
+# Size of the validation split. If `false`, and both train_size and test_size
+# are defined, the value is set to the complement of the other two sizes summed.
 # If `false`, and only one of the other sizes is defined, no validate split is created.
 validate_size = 0.2
 
-# Size of the test split.
-# If `false`, the value is set to the complement of train_size.
-# If `false` and `train_size = false`, test_size is set to `0.25`.
+# Size of the test split. If `false`, the value is set to the complement of train_size plus
+# the validate_size (if any). If `false` and `train_size = false`, test_size is set to `0.25`.
 test_size = 0.2
 
 # Number to seed with for generating a random split. Use `false` to seed from a
 # system source at runtime.
 seed = false
 
-# If `true`, cache data in memory during training. For training, this reduces runtimes
-#after the first epoch. Set to `false` to disable caching or when running inference.
+# If `true`, cache samples in memory during training to reduce runtime after the
+# first epoch. Set to `false` when running inference or on memory-constrained systems.
 use_cache = true
 
 
 [data_loader]
 # The number of data points to load at once.
-batch_size = 32
-
-# Whether the input data is shuffled before being loaded.
-shuffle = false
+batch_size = 512
 
 # Number of subprocesses for data loading. Typically between 2 and the number of CPUs.
 num_workers = 2

--- a/tests/fibad/test_data/test_default_config.toml
+++ b/tests/fibad/test_data/test_default_config.toml
@@ -1,4 +1,7 @@
+# this is the default config file
 [general]
+# set dev_mode to true when developing
+# set to false for production use
 dev_mode = true
 
 [train]

--- a/tests/fibad/test_data/test_user_config.toml
+++ b/tests/fibad/test_data/test_user_config.toml
@@ -1,9 +1,14 @@
 [general]
-dev_mode = false
+dev_mode = true
 
 [train.model]
 model_weights_filepath = "final_best.pth"
 layers = 3
 
 [infer]
-batch_size = 8
+batch_size = 8 # change batch size
+
+[bespoke_table]
+# this is a bespoke table
+key1 = "value1"
+key2 = "value2" # unlikely to modify


### PR DESCRIPTION
Doing my best to apply some uniform formatting to the config file to make it a little less overwhelming. 

The linting rules that I tried to adhere to:
1. No table-level comments
2. No comments outside of a table
3. Two lines between tables
4. One line between a key and the following comment
5. 2 lines of comments "maximum" per key - I failed on this for the test/validation/train splits.
6. No free floating blocks of comments - Again I failed when it came to the test/validation/train splits, there's just a lot there.
7. Reasonable maximum line length for comments
8. Include optional values when possible (i.e. allowed log levels)
9. Tried to have one comment per key, but used best judgement there. (i.e. username, password only got one comment)