### PR TITLE
Optimizer and criterion subtables

### DIFF
--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -35,7 +35,7 @@ class ConfigDict(dict):
 
     def __missing__(self, key):
         msg = f"Accessed configuration key/section {key} which has not been defined. "
-        msg += "All configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
+        msg += f"All configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
         logger.fatal(msg)
         raise RuntimeError(msg)
 
@@ -45,7 +45,7 @@ class ConfigDict(dict):
         with default values defined in the config file."""
         msg = f"ConfigDict.get({key},{default}) called. "
         msg += "Please index config dictionaries with [] or __getitem__() only. "
-        msg += "Configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
+        msg += f"Configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
         logger.fatal(msg)
         raise RuntimeError(msg)
 

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -97,14 +97,17 @@ latent_dim = 64
 # The name of the built-in criterion to use or the import path to an external criterion
 name = "torch.nn.CrossEntropyLoss"
 
+
 [optimizer]
 # The name of the built-in optimizer to use or the import path to an external optimizer
 name = "torch.optim.SGD"
 
-# learning rate parameter for default optimizer. The keys match the names of the parameters
+
+["torch.optim.SGD"]
+# learning rate for torch.optim.SGD optimizer.
 lr = 0.01
 
-# momentum parameter for default optimizer. The keys match the names of the parameters
+# momentum for torch.optim.SGD optimizer.
 momentum = 0.9
 
 

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -1,78 +1,97 @@
 [general]
-# Whether to run in development mode. When `true`, this will slightly modify the
-# behavior of Fibad to make development faster and easier. For example, it will
-# not check for the existance of default config values in external libraries.
+# Set to `true` during development to skip checking for default config values
+# in external libraries. Use `false` otherwise.
 dev_mode = false
 
-# Destination of log messages
-# 'stderr' and 'stdout' specify the console.
+# Destination of log messages. Options: 'stderr', 'stdout' specify the console,
+# "path/to/fibad.log" specifies a file.
 log_destination = "stderr"
-# A path name specifies a file e.g.
-# log_destination = "fibad_log.txt"
 
-# Lowest log level to emit.
-# As you go down the list, fibad will become more verbose in the log.
-#
-# log_level = "critical" # Only emit the most severe of errors
-# log_level = "error"    # Emit all errors
-# log_level = "warning"  # Emit warnings and all errors
-log_level = "info"     # Emit informational messages, warnings and all errors
-# log_level = "debug"    # Very verbose, emit all log messages.
+# Lowest log level to emit. Options: "critical", "error", "warning", "info", "debug".
+log_level = "info"
 
+# Directory where data is stored.
 data_dir = "./data"
-results_dir = "./results" # Results get named <verb>-<timestamp> under this directory
+
+#Top level directory for writing results.
+results_dir = "./results"
+
 
 [download]
+# Cut out width in arcseconds.
 sw = "22asec"
+
+# Cut out height in arcseconds.
 sh = "22asec"
+
+# The filters to download.
 filter = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
+
+# The type of data to download.
 type = "coadd"
+
+# The data release to download from.
 rerun = "pdr3_wide"
 
-# Credentials for the downloader. Either provide username/password in a fibad config file
-# or with a credentials.ini file. The format for credentials.ini is as follows:
-#
+# Path to credentials.ini file for the downloader. File contents should be:
 # username = "<your username>"
 # password = "<your password>"
-#
-# It is preferred to use a credentials.ini file to avoid sensitive user credentials being
-# committed to source control systems like git.
-username = false
-password = false
-# Location of the credentials.ini file. Defaults to credentials.ini in the current directory
-# but can be configured to a common location for batch processing.
 credentials_file = "./credentials.ini"
 
-num_sources = -1 # Values below 1 here indicate all sources in the catalog will be downloaded
+# Alternative method to pass credentials to the downloader. Prefer to use a
+#credentials.ini file to avoid exposing credentials with source control.
+username = false
+password = false
+
+# The number of sources to download from the catalog. Default is -1, which
+# downloads all sources in the catalog.
+num_sources = -1
+
+# The number of sources to skip in the catalog. Default is 0.
 offset = 0
+
+# The number of concurrent connections to use when downloading data.
 concurrent_connections = 4
+
+# The number of seconds between printing download statistics.
 stats_print_interval = 60
+
+# The path to the catalog file that defines which cutouts to download.
 fits_file = "./catalog.fits"
 
-# These control the downloader's HTTP requests and retries
-# `retry_wait` How long to wait before retrying a failed HTTP request in seconds. Default 30s
+# The number of seconds to wait before retrying a failed HTTP request in seconds.
 retry_wait = 30
-# `retries` How many times to retry a failed HTTP request before moving on to the next one. Default 3 times
+
+# How many times to retry a failed HTTP request before moving on to the next one.
 retries = 3
-# `timepout` How long should we wait to get a full HTTP response from the server. Default 3600s (1hr)
+
+# Number of seconds to wait for a full HTTP response from the server.
 timeout = 3600
-# `chunksize` How many sky location rectangles should we request in a single request. Default is 990
+
+# The number of sky location rectangles should we request in a single request.
 chunk_size = 990
 
-# Whether to retrieve the image layer
+# Request the image layer from the cutout service
 image = true
-# Whether to retrieve the variance layer
+
+# Request the variance layer from the cutout service
 variance = false
-# Whether to retrieve the mask layer
+
+# Request the mask layer from the cutout service
 mask = false
 
+
 [model]
-# The name of the built-in model to use or the libpath to an external model
-# e.g. "user_package.submodule.ExternalModel" or "ExampleAutoencoder"
+# The name of the model to use. Option are a builtin model class name or import path
+# to an external model. e.g. "ExampleAutoencoder", "user_pkg.model.ExternalModel"
 name = "ExampleAutoencoder"
 
+# The number of output channels from the first layer.
 base_channel_size = 32
+
+# The length of the latent space vector.
 latent_dim = 64
+
 
 [criterion]
 # The name of the built-in criterion to use or the libpath to an external criterion

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -38,8 +38,8 @@ rerun = "pdr3_wide"
 # password = "<your password>"
 credentials_file = "./credentials.ini"
 
-# Alternative method to pass credentials to the downloader. Prefer to use a
-#credentials.ini file to avoid exposing credentials with source control.
+# Alternate way to pass credentials to the downloader. Users should prefer a
+# credentials.ini file to avoid exposing credentials with source control.
 username = false
 password = false
 
@@ -82,7 +82,7 @@ mask = false
 
 
 [model]
-# The name of the model to use. Option are a builtin model class name or import path
+# The name of the model to use. Option are a built-in model class name or import path
 # to an external model. e.g. "ExampleAutoencoder", "user_pkg.model.ExternalModel"
 name = "ExampleAutoencoder"
 
@@ -94,98 +94,96 @@ latent_dim = 64
 
 
 [criterion]
-# The name of the built-in criterion to use or the libpath to an external criterion
+# The name of the built-in criterion to use or the import path to an external criterion
 name = "torch.nn.CrossEntropyLoss"
 
 [optimizer]
-# The name of the built-in optimizer to use or the libpath to an external optimizer
+# The name of the built-in optimizer to use or the import path to an external optimizer
 name = "torch.optim.SGD"
 
-# Default PyTorch optimizer parameters. The keys match the names of the parameters
+# learning rate parameter for default optimizer. The keys match the names of the parameters
 lr = 0.01
+
+# momentum parameter for default optimizer. The keys match the names of the parameters
 momentum = 0.9
 
+
 [train]
+# The name of the file were the model weights will be saved after training.
 weights_filepath = "example_model.pth"
+
+#The number of epochs to train for.
 epochs = 10
-# Set this to the path of a checkpoint file to resume, or continue training,
-# from a checkpoint. Otherwise, set to false to start from scratch.
+
+# If resuming from a check point, set to the path of the checkpoint file.
+# Otherwise set to `false` to start training from the beginning.
 resume = false
+
+# The data_set split to use when training a model.
 split = "train"
 
+
 [data_set]
-# Name of the built-in data loader to use or the libpath to an external data loader
-# e.g. "user_package.submodule.ExternalDataLoader" or "HSCDataSet"
+# Name of the built-in data loader to use or the import path to an external data
+# loader. e.g. "HSCDataSet", "user_pkg.data_set.ExternalDataSet"
 name = "CifarDataSet"
 
-# Pixel dimensions used to crop all images prior to loading. Will prune any images that are too small.
-#
-# If not provided by user, the default of 'false' scans the directory for the smallest dimensioned files, and 
-# uses those pixel dimensions as the crop size.
-#
-#crop_to = [100,100]
+# Crop pixel dimensions for images, e.g., [100, 100]. If false, scans for the
+# smallest image size in [general].data_dir and uses it.
 crop_to = false
 
-# Limit data loader to only particular filters when there are more in the data set.
-#
-# When not provided by the user, the number of filters will be automatically gleaned from the data set.
-# Defaults behavior is produced by the false value.
-#
-#filters = ["HSC-G", "HSC-R", "HSC-I", "HSC-Z", "HSC-Y"]
+# Specific to `hsc_data_set`. Limit to only particular filters from the data set.
+# When `false`, uses all filters found in the data set.
 filters = false
 
-# A fits file which specifies object IDs to filter a large dataset in [general].data_dir down
-# Implementation is dataset class dependent. Default is false meaning now filtering.
+# Path to a fits file that specifies object IDs to use from the data stored in
+# [general].data_dir. Implementation is data_set class dependent. Use `false` for no filtering.
 filter_catalog = false
 
-# How to split the data between training and eval sets.
-# The semantics are borrowed from scikit-learn's train-test-split, and HF Dataset's train-test-split function
-# It is an error for these values to add to more than 1.0 as ratios or the size of the dataset if expressed
-# as integers.
+# For train_size, validation_size, and test_size, the following options are available:
+# A `float` between `0.0` and `1.0` is the proportion of the dataset to include in the split.
+# If `int`, represents the absolute number of samples in the particular split.
+# It is an error for these values to add to more than 1.0 as ratios or the size
+# of the dataset if expressed as integers.
 
-# train_size: Size of the train split
-# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
-# train split.
-# If `int`, represents the absolute number of train samples.
-# If `false`, the value is automatically set to the complement of the test size.
+# Size of the train split.
+# If `false`, the value is automatically set to the complement of test_size.
 train_size = 0.6
 
-# validate_size: Size of the validation split
-# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
-# train split.
-# If `int`, represents the absolute number of train samples.
-# If `false`, and both train_size and test_size are defined, the value is automatically set to the complement 
-# of the other two sizes summed.
-# If `false`, and only one of the other sizes is defined, no validate split is created
+# Size of the validation split.
+# If `false`, and both train_size and test_size are defined, the value is set
+# to the complement of the other two sizes summed.
+# If `false`, and only one of the other sizes is defined, no validate split is created.
 validate_size = 0.2
 
-# test_size: Size of the test split
-# If `float`, should be between `0.0` and `1.0` and represent the proportion of the dataset to include in the 
-# test split.
-# If `int`, represents the absolute number of test samples.
-# If `false`, the value is set to the complement of the train size.
-# If `train_size` is also `false`, it will be set to `0.25`.
+# Size of the test split.
+# If `false`, the value is set to the complement of train_size.
+# If `false` and `train_size = false`, test_size is set to `0.25`.
 test_size = 0.2
 
-# Number to seed with for generating a random split. False means the data will be seeded from
-# a system source at runtime.
+# Number to seed with for generating a random split. Use `false` to seed from a
+# system source at runtime.
 seed = false
 
-#Controls whether images are cached during data loading. For training, this reduces runtimes
-#after the first epoch.
+# If `true`, cache data in memory during training. For training, this reduces runtimes
+#after the first epoch. Set to `false` to disable caching or when running inference.
 use_cache = true
 
-[data_loader]
-# Default PyTorch DataLoader parameters
-batch_size =32
 
-# We could remove this potentially - pytorch-ignite will default to shuffle=True
-# If the user wanted to explicitly require no shuffling, they could set this to false.
+[data_loader]
+# The number of data points to load at once.
+batch_size = 32
+
+# Whether the input data is shuffled before being loaded.
 shuffle = false
+
+# Number of subprocesses for data loading. Typically between 2 and the number of CPUs.
 num_workers = 2
 
+
 [infer]
+# The path to the model weights file to use for inference.
 model_weights_file = false
-# Select a split ("train", "test", or "validate") to use for inference
-# default of false selects the entire dataset for inference.
+
+# The data_set split to use for inference. Use `false` for entire dataset.
 split = false

--- a/src/fibad/models/model_registry.py
+++ b/src/fibad/models/model_registry.py
@@ -24,16 +24,42 @@ def _torch_load(self: nn.Module, load_path: Path):
 
 
 def _torch_criterion(self: nn.Module):
-    criterion_function_cls = get_or_load_class(self.config["criterion"])
-    arguments = dict(self.config["criterion"])
-    del arguments["name"]
-    return criterion_function_cls(**arguments)
+    """Load the criterion class using the name defined in the config and
+    instantiate it with the arguments defined in the config."""
+
+    # Load the class and get any parameters from the config dictionary
+    criterion_cls = get_or_load_class(self.config["criterion"])
+    criterion_name = self.config["criterion"]["name"]
+    arguments = self.config.get(criterion_name, {})
+
+    # Print some information about the criterion function and parameters used
+    log_string = f"Using criterion: {criterion_name} "
+    if arguments:
+        log_string += f"with arguments: {arguments}."
+    else:
+        log_string += "with default arguments."
+    logger.info(log_string)
+
+    return criterion_cls(**arguments)
 
 
 def _torch_optimizer(self: nn.Module):
+    """Load the optimizer class using the name defined in the config and
+    instantiate it with the arguments defined in the config."""
+
+    # Load the class and get any parameters from the config dictionary
     optimizer_cls = get_or_load_class(self.config["optimizer"])
-    arguments = {key: value for key, value in self.config["optimizer"].items() if value is not False}
-    del arguments["name"]
+    optimizer_name = self.config["optimizer"]["name"]
+    arguments = self.config.get(optimizer_name, {})
+
+    # Print some information about the optimizer function and parameters used
+    log_string = f"Using optimizer: {optimizer_name} "
+    if arguments:
+        log_string += f"with arguments: {arguments}."
+    else:
+        log_string += "with default arguments."
+    logger.info(log_string)
+
     return optimizer_cls(self.parameters(), **arguments)
 
 

--- a/src/fibad/models/model_registry.py
+++ b/src/fibad/models/model_registry.py
@@ -30,7 +30,10 @@ def _torch_criterion(self: nn.Module):
     # Load the class and get any parameters from the config dictionary
     criterion_cls = get_or_load_class(self.config["criterion"])
     criterion_name = self.config["criterion"]["name"]
-    arguments = self.config.get(criterion_name, {})
+
+    arguments = {}
+    if criterion_name in self.config:
+        arguments = self.config[criterion_name]
 
     # Print some information about the criterion function and parameters used
     log_string = f"Using criterion: {criterion_name} "
@@ -50,7 +53,10 @@ def _torch_optimizer(self: nn.Module):
     # Load the class and get any parameters from the config dictionary
     optimizer_cls = get_or_load_class(self.config["optimizer"])
     optimizer_name = self.config["optimizer"]["name"]
-    arguments = self.config.get(optimizer_name, {})
+
+    arguments = {}
+    if optimizer_name in self.config:
+        arguments = self.config[optimizer_name]
 
     # Print some information about the optimizer function and parameters used
     log_string = f"Using optimizer: {optimizer_name} "


### PR DESCRIPTION
This PR allows defining subtables in the config that will sandbox the parameters used for a particular criterion or optimizer. 

This means that parameters for multiple functions can be included in the config without conflicting with each other - the biggest risk is that different functions might have parameters with the same name, but substantially different meanings. 