### PR TITLE
Adding the Capability for any numpy function to be passed as a transform variable

### DIFF
--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -119,6 +119,12 @@ filters = false
 # Implementation is dataset class dependent. Default is false meaning now filtering.
 filter_catalog = false
 
+
+# The transformation to be applied to images before being passed on to the model
+# This must be a valid Numpy function. Passing false will result in no transformations
+# (other than cropping) be applied to the images.  
+transform = "tanh"
+
 # How to split the data between training and eval sets.
 # The semantics are borrowed from scikit-learn's train-test-split, and HF Dataset's train-test-split function
 # It is an error for these values to add to more than 1.0 as ratios or the size of the dataset if expressed

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -650,6 +650,14 @@ def test_valid_transform_string(caplog):
         lambda_transform = [t for t in a.container.transform.transforms if isinstance(t, Lambda)][0]
         assert lambda_transform.lambd == np.arcsinh
 
+    with FakeFitsFS(test_files):
+        a = HSCDataSet(mkconfig(transform="tanh"), split=None)
+
+        # transform always has CenterCrop in the beginning followed by the user
+        # defined transform
+        lambda_transform = [t for t in a.container.transform.transforms if isinstance(t, Lambda)][0]
+        assert lambda_transform.lambd == np.tanh
+
 
 def test_invalid_transform_string(caplog):
     """Test to ensure that an invalid string passed to transform will raise an error"""

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from fibad.data_sets.hsc_data_set import HSCDataSet, HSCDataSetSplit
+from torchvision.transforms.v2 import CenterCrop, Lambda
 
 test_dir = Path(__file__).parent / "test_data" / "dataloader"
 
@@ -64,6 +65,7 @@ def mkconfig(
     seed=False,
     filter_catalog=False,
     use_cache=False,
+    transform="tanh",
 ):
     """Makes a configuration that points at nonexistent path so HSCDataSet.__init__ will create an object,
     and our FakeFitsFS shim can be called.
@@ -79,6 +81,7 @@ def mkconfig(
             "test_size": test_size,
             "validate_size": validate_size,
             "use_cache": use_cache,
+            "transform": transform,
         },
     }
 
@@ -630,3 +633,47 @@ def test_split_and_conflicting_datasets():
 
         with pytest.raises(RuntimeError):
             a.current_split.logical_and(b.current_split)
+
+
+def test_valid_transform_string(caplog):
+    """Test to ensure that a valid string passed to transform
+    will map to a numpy function"""
+
+    caplog.set_level(logging.ERROR)
+    test_files = generate_files(num_objects=10, num_filters=5, shape=(262, 263))
+
+    with FakeFitsFS(test_files):
+        a = HSCDataSet(mkconfig(transform="arcsinh"), split=None)
+
+        # transform always has CenterCrop in the beginning followed by the user
+        # defined transform
+        lambda_transform = [t for t in a.container.transform.transforms if isinstance(t, Lambda)][0]
+        assert lambda_transform.lambd == np.arcsinh
+
+
+def test_invalid_transform_string(caplog):
+    """Test to ensure that an invalid string passed to transform will raise an error"""
+
+    caplog.set_level(logging.ERROR)
+    test_files = generate_files(num_objects=10, num_filters=5, shape=(262, 263))
+
+    with FakeFitsFS(test_files):
+        with pytest.raises(RuntimeError):
+            HSCDataSet(mkconfig(transform="invalid_function"), split=None)
+
+
+def test_false_transform(caplog):
+    """Test to ensure that false passed to transform behaves as expected"""
+
+    caplog.set_level(logging.ERROR)
+    test_files = generate_files(num_objects=10, num_filters=5, shape=(262, 263))
+
+    with FakeFitsFS(test_files):
+        a = HSCDataSet(mkconfig(transform=False), split=None)
+
+        # When transform is False; only a CenterCrop should be applied
+        # automatically with a size conforming to test_files above
+        expected_transform = CenterCrop(size=(np.int64(262), np.int64(262)))
+        actual_transform = a.container.transform
+        assert isinstance(actual_transform, CenterCrop)
+        assert actual_transform.size == expected_transform.size


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
Previously, the HSC DataSet class did a tanh transformation before feeding data into models.
This PR:-
- adds the option for the user to specify transformations or skip transformations altogether
- adds the capability for any `numpy` function to be used as a transform.

- [X ] My PR includes a link to the issue that I am addressing
- This PR addresses https://github.com/lincc-frameworks/fibad/issues/160


## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->

- I introduced a new function, `_get_np_function` in `HSCDataSetContainer` that maps passed strings to `numpy` functions
- I also added a few tests to check different scenarios
