### PR TITLE
WIP Initial commit to get some things logged to mlflow.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "numpy", # Used in Holoviews visualization prototype
     "scipy", # Used in Holoviews visualization prototype
     "cython", # Used in Holoviews visualization prototype
+    "mlflow", # Used to log training metrics and compare models
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "scipy", # Used in Holoviews visualization prototype
     "cython", # Used in Holoviews visualization prototype
     "mlflow", # Used to log training metrics and compare models
+    "pynvml", # Used to gather GPU usage information
 ]
 
 [project.scripts]

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -122,6 +122,8 @@ resume = false
 # The data_set split to use when training a model.
 split = "train"
 
+# The name of the experiment when logging training results to mlflow
+experiment_name = "notebook"
 
 [data_set]
 # Name of the built-in data loader to use or the import path to an external data

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -344,13 +344,6 @@ def create_trainer(
         tensorboardx_logger.add_scalar("training/training/loss", trainer.state.output["loss"], step)
         mlflow.log_metrics({"training/loss": trainer.state.output["loss"]}, step=step)
 
-    # mlflow_logger.attach_output_handler(
-    #     trainer,
-    #     event_name=Events.ITERATION_COMPLETED,
-    #     tag="training",
-    #     output_transform=lambda loss: {"loss": loss},
-    # )
-
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_training_loss(trainer):
         logger.info(f"Epoch {trainer.state.epoch} run time: {trainer.state.times['EPOCH_COMPLETED']:.2f}[s]")

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Callable, Union
 
 import ignite.distributed as idist
+import mlflow
 import torch
 from ignite.engine import Engine, Events
 from ignite.handlers import Checkpoint, DiskSaver, global_step_from_engine
@@ -253,6 +254,7 @@ def create_validator(
     def log_validation_loss(validator, trainer):
         step = trainer.state.get_event_attrib_value(Events.EPOCH_COMPLETED)
         tensorboardx_logger.add_scalar("training/validation/loss", validator.state.output["loss"], step)
+        mlflow.log_metrics({"validation/loss": validator.state.output["loss"]}, step=step)
 
     validator.add_event_handler(Events.EPOCH_COMPLETED, log_validation_loss, trainer)
 
@@ -340,6 +342,7 @@ def create_trainer(
     def log_training_loss_tensorboard(trainer):
         step = trainer.state.get_event_attrib_value(Events.ITERATION_COMPLETED)
         tensorboardx_logger.add_scalar("training/training/loss", trainer.state.output["loss"], step)
+        mlflow.log_metrics({"training/loss": trainer.state.output["loss"]}, step=step)
 
     # mlflow_logger.attach_output_handler(
     #     trainer,

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -324,6 +324,9 @@ def create_trainer(
         prev_checkpoint = torch.load(config["train"]["resume"], map_location=device)
         Checkpoint.load_objects(to_load=to_save, checkpoint=prev_checkpoint)
 
+    # results_root_dir = Path(config["general"]["results_dir"]).resolve()
+    # mlflow_logger = MLflowLogger("file://" + str(results_root_dir / "mlflow"))
+
     @trainer.on(Events.STARTED)
     def log_training_start(trainer):
         logger.info(f"Training model on device: {device}")
@@ -337,6 +340,13 @@ def create_trainer(
     def log_training_loss_tensorboard(trainer):
         step = trainer.state.get_event_attrib_value(Events.ITERATION_COMPLETED)
         tensorboardx_logger.add_scalar("training/training/loss", trainer.state.output["loss"], step)
+
+    # mlflow_logger.attach_output_handler(
+    #     trainer,
+    #     event_name=Events.ITERATION_COMPLETED,
+    #     tag="training",
+    #     output_transform=lambda loss: {"loss": loss},
+    # )
 
     @trainer.on(Events.EPOCH_COMPLETED)
     def log_training_loss(trainer):

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -57,9 +57,7 @@ def run(config):
     mlflow.set_experiment("notebook")
 
     with mlflow.start_run(log_system_metrics=True):
-        mlflow.log_params(config["model"])
-        mlflow.log_param("epochs", config["train"]["epochs"])
-        mlflow.log_param("batch_size", config["data_loader"]["batch_size"])
+        _log_params(config)
 
         # Run the training process
         trainer.run(train_data_loader, max_epochs=config["train"]["epochs"])
@@ -72,3 +70,31 @@ def run(config):
 
     logger.info("Finished Training")
     tensorboardx_logger.close()
+
+
+def _log_params(config):
+    """Log the various parameters to mlflow from the config file.
+
+    Parameters
+    ----------
+    config : dict
+        The main configuration dictionary
+    """
+
+    # Log all model params
+    mlflow.log_params(config["model"])
+
+    # Log some training and data loader params
+    mlflow.log_param("epochs", config["train"]["epochs"])
+    mlflow.log_param("batch_size", config["data_loader"]["batch_size"])
+
+    # Log the criterion and optimizer params
+    criterion_name = config["criterion"]["name"]
+    mlflow.log_param("criterion", criterion_name)
+    if criterion_name in config:
+        mlflow.log_params(config[criterion_name])
+
+    optimizer_name = config["optimizer"]["name"]
+    mlflow.log_param("optimizer", optimizer_name)
+    if optimizer_name in config:
+        mlflow.log_params(config[optimizer_name])

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -1,5 +1,7 @@
 import logging
+from pathlib import Path
 
+import mlflow
 from tensorboardX import SummaryWriter
 
 from fibad.config_utils import create_results_dir, log_runtime_config
@@ -49,8 +51,20 @@ def run(config):
         create_validator(model, config, results_dir, tensorboardx_logger, validation_data_loader, trainer)
 
     monitor = GpuMonitor(tensorboard_logger=tensorboardx_logger)
-    # Run the training process
-    trainer.run(train_data_loader, max_epochs=config["train"]["epochs"])
+
+    results_root_dir = Path(config["general"]["results_dir"]).resolve()
+    mlflow.set_tracking_uri("file://" + str(results_root_dir / "mlflow"))
+    mlflow.set_experiment("notebook")
+
+    with mlflow.start_run():
+        mlflow.log_params(config["model"])
+        mlflow.log_param("epochs", config["train"]["epochs"])
+        mlflow.log_param("batch_size", config["data_loader"]["batch_size"])
+
+        # Run the training process
+        trainer.run(train_data_loader, max_epochs=config["train"]["epochs"])
+
+        mlflow.pytorch.log_model(model, "models")
 
     # Save the trained model
     model.save(results_dir / config["train"]["weights_filepath"])

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -56,7 +56,7 @@ def run(config):
     mlflow.set_tracking_uri("file://" + str(results_root_dir / "mlflow"))
     mlflow.set_experiment("notebook")
 
-    with mlflow.start_run():
+    with mlflow.start_run(log_system_metrics=True):
         mlflow.log_params(config["model"])
         mlflow.log_param("epochs", config["train"]["epochs"])
         mlflow.log_param("batch_size", config["data_loader"]["batch_size"])


### PR DESCRIPTION
If testing locally be sure to `pip install mlflow`, and optionally `pynvml` if you want to collect gpu metrics.

You should be able to log model parameters and metrics immediately without any initial setup. To view the results you'll need to start the mlflow server using the following at the command line: 
`mlflow ui --backend-store-uri file://<.../results/mlflow>` 

Pass in the full path to the directory `/<where your results are>/results/mlflow` with a leading `/`. 

Then go to `http://127.0.0.1:5000 and you should be presented with the MLFlow UI. 

The default experiment is `notebook`. You can change the experiment name in your config using:
```
[train]
experiment_name = "fav_experiment_name"
```

In this example, I used port 8080 by starting mlflow server like so: `mlflow ui --backend-store-uri ... --port 8080`
![mlflow_example](https://github.com/user-attachments/assets/fd158e01-b98c-4b06-88b5-923ed5abbe81)

Example showing the parameter logging - by default, it will log all the keys under `[model]` and the criterion and optimizer specific parameters in the configuration used for the run. Other parameters can be added. The screenshot below shows only the model parameter.
![mlflow_example2](https://github.com/user-attachments/assets/ce798ad9-d821-4443-80a3-ae5c0e54394b)
