### PR TITLE
Using experiment_name from config to set mlflow experiment name.

### DIFF
--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -54,7 +54,12 @@ def run(config):
 
     results_root_dir = Path(config["general"]["results_dir"]).resolve()
     mlflow.set_tracking_uri("file://" + str(results_root_dir / "mlflow"))
-    mlflow.set_experiment("notebook")
+
+    # Get experiment_name and cast to string (it's a tomlkit.string by default)
+    experiment_name = str(config["train"]["experiment_name"])
+
+    # This will create the experiment if it doesn't exist
+    mlflow.set_experiment(experiment_name)
 
     with mlflow.start_run(log_system_metrics=True):
         _log_params(config)


### PR DESCRIPTION
Actually makes use of the `experiment_name` in the config file. Note that we need to cast this to a `str(...)` in order for `mlflow.set_experiment` to work correctly. 

If this is blocking, don't wait for me to merge this change. 