### PR TITLE
Configuration help in notebook

### DIFF
--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -6,7 +6,7 @@ import random
 import re
 from importlib import util as importlib_util
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import tomlkit
 from tomlkit.toml_document import TOMLDocument
@@ -70,6 +70,98 @@ class ConfigDict(dict):
         raise RuntimeError("Removing keys or sections from a ConfigDict using clear() is not supported")
 
 
+def config_help(config: TOMLDocument, *args):
+    """
+    A simple config help function. It's a bit difficult to parse through
+    the Tomlkit Table to print just one item such that it would include the comments
+    preceding it.
+
+    For now, we support the following cases, and generally print out the entire
+    table for the given key.
+
+    Cases:
+    - if no args, prints the whole config.
+    - if args[0] is a table name, print the whole table
+    - if args[0] is not a table, assume it's a key and search
+    -- print each one of the tables that it is found in.
+
+    Parameters
+    ----------
+    config : TOMLDocument
+        A configuration dictionary that will be used to search for specified tables
+        and keys.
+
+    args : str
+        A variable number of string arguments that specify the table name or key
+        to search for in the configuration dictionary.
+    """
+
+    # Get the config as a dictionary
+    config_dict = config.value
+
+    # No tables provided, print the whole config
+    if not args:
+        print(config.as_string())
+
+    # Table name provided as args[0], print that config table
+    if len(args) == 1 and args[0] in config_dict:
+        print(f"[{args[0]}]")
+        print(config[args[0]].as_string())
+
+    # One arg provided, but it's not a table name.
+    # Assume it's a config key and search the config for it.
+    # Print each table that it is found in.
+    if len(args) == 1 and args[0] not in config_dict:
+        matching = find_keys(config_dict, args[0])
+        if len(matching):
+            tables = [m.split(".")[0] for m in matching]
+            print(f"Found '{args[0]}' in the following config sections: [{'], ['.join(tables)}]")
+            for t in tables:
+                config_help(config, t)
+        else:
+            print(f"Could not find '{args[0]}' in the config")
+
+    if len(args) == 2:
+        if args[0] in config_dict and args[1] in config_dict[args[0]]:
+            print(f"[{args[0]}]")
+            print(config[args[0]].as_string())
+        else:
+            print(f"Cannot find ['{args[0]}']['{args[1]}'] in the current configuration.")
+
+    if len(args) > 2:
+        print("Too many arguments provided. Expecting 0, 1, or 2 arguments.")
+        print("Usage: config.help(['table_name'|'key_name']), config.help('table_name', 'key_name')")
+
+
+def find_keys(config: dict[str, Any], key_name: str):
+    """
+    Recursively find all keys in a nested dictionary that match the given key name.
+
+    Parameters
+    ----------
+    config : dict
+        The nested dictionary to search.
+    key_name : str
+        The name of the key to find.
+
+    Returns
+    -------
+    list
+        A list of matching keys.
+    """
+    matching_keys = []
+
+    def _find_keys(d, parent_key=""):
+        if isinstance(d, dict):
+            for k, v in d.items():
+                if k == key_name:
+                    matching_keys.append((parent_key + "." + k).strip("."))
+                _find_keys(v, parent_key + "." + k)
+
+    _find_keys(config)
+    return matching_keys
+
+
 # Here we patch the TOMLDocument functions to use the ConfigDict functions so that
 # we get the behavior that we desire - i.e. errors on missing default keys, no
 # use of config.get(..., <default>), etc.
@@ -79,6 +171,7 @@ TOMLDocument.__delitem__ = ConfigDict.__delitem__  # type: ignore[assignment, me
 TOMLDocument.pop = ConfigDict.pop  # type: ignore[assignment, method-assign]
 TOMLDocument.popitem = ConfigDict.popitem  # type: ignore[assignment, method-assign]
 TOMLDocument.clear = ConfigDict.clear  # type: ignore[assignment, method-assign]
+TOMLDocument.help = config_help  # type: ignore
 
 
 class ConfigManager:
@@ -368,93 +461,3 @@ def log_runtime_config(runtime_config: ConfigDict, output_path: Path, file_name:
     """
     with open(output_path / file_name, "w") as f:
         f.write(tomlkit.dumps(runtime_config))
-
-
-def config_help(config: TOMLDocument, *args):
-    """
-    Early version of a config help function. It's a bit difficult to parse through
-    the Tomlkit Table to print just one item such that it would include the comments
-    preceding it.
-
-    For now, we support the following cases, and generally print out the entire
-    table for the given key.
-
-    Cases:
-    - if no args, prints the whole config.
-    - if args[0] is a table name, print the whole table
-    - if args[0] is not a table, assume it's a key and search
-    -- print each one of the tables that it is found in.
-
-    Parameters
-    ----------
-    config : TOMLDocument
-        A configuration dictionary that will be used to search for specified tables
-        and keys.
-
-    args : str
-        A variable number of string arguments that specify the table name or key
-        to search for in the configuration dictionary.
-    """
-
-    config_dict = config.value
-
-    # No tables provided, print the whole config
-    if not args:
-        print(config.as_string())
-
-    # Table name provided as args[0], print that config table
-    if len(args) == 1 and args[0] in config_dict:
-        print(f"[{args[0]}]")
-        print(config[args[0]].as_string())
-
-    # One arg provided, but it's not a table name.
-    # Assume it's a config key and search the config for it.
-    # Print each table that it is found in.
-    if len(args) == 1 and args[0] not in config_dict:
-        matching = find_keys(config, args[0])
-        if len(matching):
-            tables = [m.split(".")[0] for m in matching]
-            print(f"Found '{args[0]}' in the following config sections: [{'], ['.join(tables)}]")
-            for t in tables:
-                config_help(config, t)
-        else:
-            print(f"Could not find '{args[0]}' in the config")
-
-    if len(args) == 2:
-        if args[0] in config_dict and args[1] in config_dict[args[0]]:
-            print(f"[{args[0]}]")
-            print(config[args[0]].as_string())
-        else:
-            print(f"Cannot find ['{args[0]}']['{args[1]}'] in the current configuration.")
-
-
-def find_keys(config, key_name):
-    """
-    Recursively find all keys in a nested dictionary that match the given key name.
-
-    Parameters
-    ----------
-    config : dict
-        The nested dictionary to search.
-    key_name : str
-        The name of the key to find.
-
-    Returns
-    -------
-    list
-        A list of matching keys.
-    """
-    matching_keys = []
-
-    def _find_keys(d, parent_key=""):
-        if isinstance(d, dict):
-            for k, v in d.items():
-                if k == key_name:
-                    matching_keys.append((parent_key + "." + k).strip("."))
-                _find_keys(v, parent_key + "." + k)
-        # elif isinstance(d, list):
-        #     for i, item in enumerate(d):
-        #         _find_keys(item, parent_key + f'[{i}]')
-
-    _find_keys(config)
-    return matching_keys

--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Union
 
-from .config_utils import ConfigManager
+from .config_utils import ConfigManager, config_help
 from .verbs.verb_registry import all_class_verbs, fetch_verb_class, is_verb_class
 
 
@@ -134,6 +134,22 @@ class Fibad:
         # Format our log messages
         formatter = logging.Formatter("[%(asctime)s %(name)s:%(levelname)s] %(message)s")
         handler.setFormatter(formatter)
+
+    def config_help(self, *args):
+        """
+        Small function to pass self.config to Fibad.config_utils.config_help().
+
+        We expect users to call this from within a notebook. The typical syntax
+        would be:
+        ```
+        f = Fibad()
+        f.config_help()  # To print the whole configuration
+        f.config_help("<section>")  # To print a particular section of the config.
+        f.config_help("<section>", "<key>")  # To print a section containing a key.
+        f.config_help("<key>")  # Print all sections that contain the given key.
+        """
+
+        config_help(self.config, *args)
 
     def raw_data_dimensions(self) -> tuple[list[int], list[int]]:
         """Gives the dimensions of underlying data that forms input to the training, and inference

--- a/src/fibad/fibad.py
+++ b/src/fibad/fibad.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import Optional, Union
 
-from .config_utils import ConfigManager, config_help
+from .config_utils import ConfigManager
 from .verbs.verb_registry import all_class_verbs, fetch_verb_class, is_verb_class
 
 
@@ -134,22 +134,6 @@ class Fibad:
         # Format our log messages
         formatter = logging.Formatter("[%(asctime)s %(name)s:%(levelname)s] %(message)s")
         handler.setFormatter(formatter)
-
-    def config_help(self, *args):
-        """
-        Small function to pass self.config to Fibad.config_utils.config_help().
-
-        We expect users to call this from within a notebook. The typical syntax
-        would be:
-        ```
-        f = Fibad()
-        f.config_help()  # To print the whole configuration
-        f.config_help("<section>")  # To print a particular section of the config.
-        f.config_help("<section>", "<key>")  # To print a section containing a key.
-        f.config_help("<key>")  # Print all sections that contain the given key.
-        """
-
-        config_help(self.config, *args)
 
     def raw_data_dimensions(self) -> tuple[list[int], list[int]]:
         """Gives the dimensions of underlying data that forms input to the training, and inference

--- a/tests/fibad/test_data/test_user_config_repeated_keys.toml
+++ b/tests/fibad/test_data/test_user_config_repeated_keys.toml
@@ -1,0 +1,20 @@
+[general]
+dev_mode = true
+
+[model]
+name = "resnet"
+layers = 3
+
+[loss]
+name = "cross_entropy"
+
+[optimizer]
+name = "adam"
+
+[infer]
+batch_size = 8 # change batch size
+
+[bespoke_table]
+# this is a bespoke table
+key1 = "value1"
+key2 = "value2" # unlikely to modify


### PR DESCRIPTION
Implementing simple function to print specific config tables. The goal is to allow a user to call `fibad_instance.config.help(...)` and get see the configuration comments printed. 

It's unintuitive how to parse through the data structure that tomlkit maintains in order to print out just the comments surrounding the key of interest. So as a half set, we can just print the entire enclosing table. 

So for instance:
```
import fibad
f = fibad.Fibad()
f.config.help('general', 'dev_mode')
```

Prints the full `[general]` table:
```
[general]
# Set to `true` during development to skip checking for default config values
# in external libraries. Use `false` otherwise.
dev_mode = false

# Destination of log messages. Options: 'stderr', 'stdout' specify the console,
# "path/to/fibad.log" specifies a file.
log_destination = "stderr"

# Lowest log level to emit. Options: "critical", "error", "warning", "info", "debug".
log_level = "info"

# Directory where data is stored.
data_dir = "./data"

#Top level directory for writing results.
results_dir = "./results"
```

Usage for the help looks like this:
```
f = fibad.Fibad()

f.config.help()  # Pretty prints the entire config

f.config.help('table_name')  # Pretty prints the config table

f.config.help('table_name', 'key_name')  # Pretty prints the config table

f.config.help('key_name')  # Searches for the key in all tables, prints each table that contains it

f.config.help('non-existant key or table')  # Prints a nice error message

f.config.help('table', 'key', 'third value')  # Prints a nice error with example usage.
```