### PR TITLE
Protect against 0-length validation splits in cifar dataset

### DIFF
--- a/src/fibad/data_sets/example_cifar_data_set.py
+++ b/src/fibad/data_sets/example_cifar_data_set.py
@@ -1,10 +1,14 @@
 # ruff: noqa: D101, D102
+import logging
+
 import numpy as np
 import torchvision.transforms as transforms
 from torch.utils.data.sampler import SubsetRandomSampler
 from torchvision.datasets import CIFAR10
 
 from .data_set_registry import fibad_data_set
+
+logger = logging.getLogger(__name__)
 
 
 @fibad_data_set
@@ -26,27 +30,58 @@ class CifarDataSet(CIFAR10):
         super().__init__(root=config["general"]["data_dir"], train=train, download=True, transform=transform)
 
         if train:
-            num_train = len(self)
-            indices = list(range(num_train))
-            split_idx = 0
-            if config["data_set"]["validate_size"]:
-                split_idx = int(np.floor(config["data_set"]["validate_size"] * num_train))
+            self.train_sampler = None
+            self.validation_sampler = None
+            data_set_length = len(self)
+            indices = list(range(data_set_length))
 
+            train_size = config["data_set"]["train_size"] if config["data_set"]["train_size"] else None
+            validate_size = (
+                config["data_set"]["validate_size"] if config["data_set"]["validate_size"] else None
+            )
+
+            if isinstance(train_size, int):
+                train_size = train_size / data_set_length
+            if isinstance(validate_size, int):
+                validate_size = validate_size / data_set_length
+
+            # Shuffle the indices
             random_seed = None
             if config["data_set"]["seed"]:
                 random_seed = config["data_set"]["seed"]
             np.random.seed(random_seed)
             np.random.shuffle(indices)
 
-            train_idx, valid_idx = indices[split_idx:], indices[:split_idx]
+            # Get absolute numbers of training and validation samples
+            num_train = 0
+            if train_size:
+                num_train = int(np.floor(train_size * data_set_length))
 
-            #! These two "samplers" are used by PyTorch's DataLoader to split the
-            #! dataset into training and validation sets. Using Samplers is mutually
-            #! exclusive with using "shuffle" in the DataLoader.
-            #! If a user doesn't define a Sampler, the default behavior of pytorch-ignite
-            #! is to shuffle the data unless `shuffle = False` in the config.
-            self.train_sampler = SubsetRandomSampler(train_idx)
-            self.validation_sampler = SubsetRandomSampler(valid_idx)
+            num_validation = 0
+            if validate_size:
+                num_validation = int(np.floor(validate_size * data_set_length))
+
+            # Let the user know if they are asking for too many points
+            if num_train + num_validation > data_set_length:
+                raise RuntimeError(
+                    f"Sum of train and validation ({num_train} + {num_validation})"
+                    f" exceed dataset size ({data_set_length})."
+                )
+
+            # Create the SubsetRandomSamplers
+            train_idx = []
+            if train_size:
+                train_idx = indices[:num_train]
+                self.train_sampler = SubsetRandomSampler(train_idx)
+
+            valid_idx = []
+            if validate_size:
+                valid_idx = indices[num_train : num_train + num_validation]
+                self.validation_sampler = SubsetRandomSampler(valid_idx)
+
+            logger.debug(f"Dataset size: {len(self)}")
+            logger.debug(f"Train size: {len(train_idx)}")
+            logger.debug(f"Validation size: {len(valid_idx)}")
 
     def shape(self):
         return (3, 32, 32)


### PR DESCRIPTION
This PR amounted to duplicating a lot of code that was in hsc dataset. 

The protection and approach is broadly applicable, so it probably makes sense to abstract this up a level and inject the code when a dataset class uses the @fibad_dataset decorator. 

The only reason I didn't take that step here was because I want to take a minute to think clearly about how this will work as we expand beyond just Pytorch data sets. A little research into the HuggingFace dataset API would be good. 