### PR TITLE
Allow user to specify MLFlow run name via the config.

### DIFF
--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -125,6 +125,10 @@ split = "train"
 # The name of the experiment when logging training results to mlflow
 experiment_name = "notebook"
 
+# The name of the run when logging training results to mlflow.
+# If false, uses result directory string, <timestamp>-train-<uid>, as run name.
+run_name = false
+
 [data_set]
 # Name of the built-in data loader to use or the import path to an external data
 # loader. e.g. "HSCDataSet", "user_pkg.data_set.ExternalDataSet"

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -61,7 +61,11 @@ def run(config):
     # This will create the experiment if it doesn't exist
     mlflow.set_experiment(experiment_name)
 
-    with mlflow.start_run(log_system_metrics=True):
+    # If run_name is not `false` in the config, use it as the MLFlow run name in
+    # this experiment. Otherwise use the name of the results directory
+    run_name = str(config["train"]["run_name"]) if config["train"]["run_name"] else results_dir.name
+
+    with mlflow.start_run(log_system_metrics=True, run_name=run_name):
         _log_params(config)
 
         # Run the training process


### PR DESCRIPTION
This PR introduces a new config value, `['train']['run_name']`. The default value is `false`. 

When this value is false and the user runs `fibad.train()`, the resulting MLFlow run will be the same as the auto-generated results directory, i.e. `<timestamp>-train-<uid>`. 

When the user provides a value with a string representation, i.e. "super_turtle", that value will be used as the MLFlow run name.

In the screenshot below the first in the list is user defined, the second in the list is the default timestamped value. The third item in the list is a previously autogenerated run name.  

<img width="503" alt="Screenshot 2025-02-10 at 4 06 18 PM" src="https://github.com/user-attachments/assets/de0d9427-54ba-4ce2-8310-12c84ffcf1de" />
