### PR TITLE
Removing create_index codepath

### DIFF
--- a/src/fibad/data_sets/inference_dataset.py
+++ b/src/fibad/data_sets/inference_dataset.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from collections.abc import Generator
 from pathlib import Path
 from typing import Optional, Union
@@ -34,7 +33,8 @@ class InferenceDataSet(Dataset):
         # Loop over files and create if it does not exist
         batch_index_path = self.results_dir / "batch_index.npy"
         if not batch_index_path.exists():
-            self._create_index(self.results_dir)
+            msg = f"{self.results_dir} is corrupt and lacks a batch index file."
+            raise RuntimeError(msg)
 
         self.batch_index = np.load(self.results_dir / "batch_index.npy")
         self.length = len(self.batch_index)
@@ -154,34 +154,6 @@ class InferenceDataSet(Dataset):
 
         return retval
 
-    # This functionality (and its linkage to InferenceDataSetWriter) can be considered deprecated
-    # as of Feb 2025 and ought be removed shortly thereafter. Including this code was a way to
-    # be backwards compatibile with science being done as this subsystem was being developed.
-    def _create_index(self, results_dir: Path):
-        """Recreate the index into the batch numpy files
-
-        Parameters
-        ----------
-        results_dir : Path
-            Path to the batch numpy files
-        """
-        ids = []
-        batch_nums = []
-        # Use the batched numpy files to assemble an index.
-        logger.info("Recreating index...")
-        for file in results_dir.glob("batch_*.npy"):
-            print(".", end="", flush=True)
-            m = re.match(r"batch_([0-9]+).npy", file.name)
-            if m is None:
-                logger.warn(f"Could not find batch number for {file}")
-                continue
-            batch_num = int(m[1])
-            recarray = np.load(file)
-            ids += list(recarray["id"])
-            batch_nums += [batch_num] * len(recarray["id"])
-
-        InferenceDataSetWriter.save_batch_index(results_dir, np.array(ids), np.array(batch_nums))
-
 
 class InferenceDataSetWriter:
     """Class to write out inference datasets. Used by infer, umap to consistently write out numpy
@@ -233,32 +205,15 @@ class InferenceDataSetWriter:
         self.batch_index += 1
 
     def write_index(self):
-        """Writes out the batch index built up by this object over multiple write_batch calls.
-        See save_batch_index for details.
-        """
-        InferenceDataSetWriter.save_batch_index(self.result_dir, self.all_ids, self.all_batch_nums)
-
-    @staticmethod
-    def save_batch_index(result_dir: Path, all_ids: np.ndarray, all_batch_nums: np.ndarray):
-        """Save a batch index in the result directory provided
-
-        Parameters
-        ----------
-        result_dir : Path
-            The results directory
-        all_ids : np.ndarray
-            All IDs to write out.
-        all_batch_nums : np.ndarray
-            The corresponding batch numbers for the IDs provided.
-        """
+        """Writes out the batch index built up by this object over multiple write_batch calls."""
         batch_index_dtype = np.dtype([("id", np.int64), ("batch_num", np.int64)])
-        batch_index = np.zeros(len(all_ids), batch_index_dtype)
-        batch_index["id"] = np.array(all_ids)
-        batch_index["batch_num"] = np.array(all_batch_nums)
+        batch_index = np.zeros(len(self.all_ids), batch_index_dtype)
+        batch_index["id"] = np.array(self.all_ids)
+        batch_index["batch_num"] = np.array(self.all_batch_nums)
         batch_index.sort(order="id")
 
         filename = "batch_index.npy"
-        savepath = result_dir / filename
+        savepath = self.result_dir / filename
         if savepath.exists():
             RuntimeError("The path to save batch index already exists.")
         np.save(savepath, batch_index, allow_pickle=False)


### PR DESCRIPTION
We should only merge this once we're sure we don't need this codepath anymore.

i.e. all inference results we care about ought have a batch index file.
