### PR TITLE
Initial investigation of exporting to ONNX after training.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ example_model.pth
 # Common location to stash personal or notebook example config
 fibad_config.toml
 credentials.ini
+
+# MLFlow data directory
+mlruns/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "pynvml", # Used to gather GPU usage information
     "umap-learn", # Used to map latent spaces down to 2d
     "pooch", # Used to download data files
+    "onnx", # Used to export models to ONNX format
+    "onnxruntime", # Used to run ONNX models
 ]
 
 [project.scripts]

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -129,6 +129,13 @@ experiment_name = "notebook"
 # If false, uses result directory string, <timestamp>-train-<uid>, as run name.
 run_name = false
 
+[onnx]
+
+# The operator set version to use when exporting a model. See the following for info:
+# https://onnxruntime.ai/docs/reference/compatibility.html#onnx-opset-support
+opset_version = 20
+
+
 [data_set]
 # Name of the built-in data loader to use or the import path to an external data
 # loader. e.g. "HSCDataSet", "user_pkg.data_set.ExternalDataSet"
@@ -183,9 +190,6 @@ use_cache = true
 # The number of data points to load at once.
 batch_size = 512
 
-# Number of subprocesses for data loading. Typically between 2 and the number of CPUs.
-num_workers = 2
-
 
 [infer]
 # The path to the model weights file to use for inference.
@@ -197,9 +201,11 @@ split = false
 # Whether to generate a chromadb vector database of inference results
 chromadb = true
 
+
 [results]
 # Path to inference results to use for visualization and lookups. Uses latest inference run if none provided.
 inference_dir = false
+
 
 [umap]
 # Number of data points used to fit the umap transform.

--- a/src/fibad/model_exporters.py
+++ b/src/fibad/model_exporters.py
@@ -34,6 +34,9 @@ def export_to_onnx(model, sample, config, ctx):
     sample_out = None
     if ctx["ml_framework"] == "pytorch":
         sample_out = _export_pytorch_to_onnx(model, sample, onnx_output_filepath, onnx_opset_version)
+    else:
+        logger.warning("No ONNX export implementation for the given ML framework.")
+        return
 
     # check the ONNX model for correctness
     try:

--- a/src/fibad/model_exporters.py
+++ b/src/fibad/model_exporters.py
@@ -1,0 +1,85 @@
+import logging
+from pathlib import Path
+
+import onnx
+import onnxruntime
+from numpy import allclose
+
+logger = logging.getLogger(__name__)
+
+
+def export_to_onnx(model, sample, config, ctx):
+    """Dispatching function to convert a ML framework model into an ONNX model.
+
+    Parameters
+    ----------
+    model : ML framework model
+        The model that was just trained using the ML framework. i.e. PyTorch
+    sample : Tensor
+        A single sample from the training data loader. This is used to check the
+        output of the ONNX model against the output of the PyTorch model.
+    config : dict
+        The parsed config file as a nested dict
+    ctx : dict
+        A context dictionary containing info needed for the conversion to ONNX.
+    """
+
+    # build the output ONNX file path
+    model_filename = Path(config["train"]["weights_filepath"]).stem
+    onnx_opset_version = config["onnx"]["opset_version"]
+    onnx_model_filename = f"{model_filename}_opset_{onnx_opset_version}.onnx"
+    onnx_output_filepath = ctx["results_dir"] / onnx_model_filename
+
+    # use the "ml_framework" context value to determine how to convert to ONNX.
+    sample_out = None
+    if ctx["ml_framework"] == "pytorch":
+        sample_out = _export_pytorch_to_onnx(model, sample, onnx_output_filepath, onnx_opset_version)
+
+    # check the ONNX model for correctness
+    try:
+        onnx_model = onnx.load(onnx_output_filepath)
+        onnx.checker.check_model(onnx_model)
+    except:  # noqa E722
+        logger.error(f"Failed to create ONNX model. {ctx['ml_framework']} implementation has been saved.")
+
+    # check the ONNX model against the PyTorch model
+    ort_session = onnxruntime.InferenceSession(onnx_output_filepath, providers=["CPUExecutionProvider"])
+    ort_inputs = {ort_session.get_inputs()[0].name: sample.cpu().numpy()}
+    ort_outs = ort_session.run(None, ort_inputs)
+
+    # verify ONNX model inference produces results close to the the original model
+    if not allclose(sample_out.detach().numpy(), ort_outs[0], rtol=1e-03, atol=1e-05):
+        logger.warning("The outputs from the PyTorch model and the ONNX model are not close.")
+
+    logger.info(f"Exported model to ONNX format: {onnx_output_filepath}")
+
+
+# Very tempting to use @singledispatch on the type of model here, but that
+# would necessitate importing all the ML frameworks in order to get their datatypes,
+# which is what we want to avoid in order to reduce the start up time.
+def _export_pytorch_to_onnx(model, sample, output_filepath, opset_version):
+    """Specific implementation to convert PyTorch model to ONNX format."""
+
+    # deferred import to reduce start up time
+    from torch.onnx import export
+
+    # set model in eval mode and move it to the CPU to prep for export to ONNX.
+    model.train(False)
+    model.to("cpu")
+
+    # run a single sample through the model. We'll check this against the output
+    # from the ONNX version to make sure it's the same, i.e. `np.assert_allclose`.
+    sample_out = model(sample)
+
+    # export the model to ONNX format
+    export(
+        model,
+        sample,
+        output_filepath,
+        opset_version=opset_version,
+        input_names=["input"],
+        output_names=["output"],
+        dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},
+    )
+
+    return sample_out

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -42,7 +42,7 @@ def run(config):
     data_loaders = dist_data_loader(data_set, config, ["train", "validate"])
     train_data_loader = data_loaders["train"]
     validation_data_loader = data_loaders["validate"]
-    
+
     # Get a sample of input data. If the data is labeled, only return the input data.
     batch_sample = next(iter(train_data_loader))
     sample = batch_sample[0] if isinstance(batch_sample, (list, tuple)) else batch_sample

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -41,8 +41,9 @@ def run(config):
     # Create a data loader for the training set
     train_data_loader = dist_data_loader(data_set, config, "train")
 
+    # Get a sample of input data. If the data is labeled, only return the input data.
     batch_sample = next(iter(train_data_loader))
-    sample = batch_sample[0]
+    sample = batch_sample[0] if isinstance(batch_sample, (list, tuple)) else batch_sample
 
     # Create validation_data_loader if a validation split is defined in data_set
     validation_data_loader = dist_data_loader(data_set, config, "validate")

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -6,6 +6,7 @@ from tensorboardX import SummaryWriter
 
 from fibad.config_utils import create_results_dir, log_runtime_config
 from fibad.gpu_monitor import GpuMonitor
+from fibad.model_exporters import export_to_onnx
 from fibad.pytorch_ignite import (
     create_trainer,
     create_validator,
@@ -39,6 +40,9 @@ def run(config):
 
     # Create a data loader for the training set
     train_data_loader = dist_data_loader(data_set, config, "train")
+
+    batch_sample = next(iter(train_data_loader))
+    sample = batch_sample[0]
 
     # Create validation_data_loader if a validation split is defined in data_set
     validation_data_loader = dist_data_loader(data_set, config, "validate")
@@ -77,6 +81,13 @@ def run(config):
 
     logger.info("Finished Training")
     tensorboardx_logger.close()
+
+    context = {
+        "ml_framework": "pytorch",
+        "results_dir": results_dir,
+    }
+
+    export_to_onnx(model, sample, config, context)
 
 
 def _log_params(config):

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -4,9 +4,8 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from torchvision.transforms.v2 import CenterCrop, Lambda
-
 from fibad.data_sets.hsc_data_set import HSCDataSet
+from torchvision.transforms.v2 import CenterCrop, Lambda
 
 test_dir = Path(__file__).parent / "test_data" / "dataloader"
 

--- a/tests/fibad/test_splits.py
+++ b/tests/fibad/test_splits.py
@@ -1,5 +1,4 @@
 import pytest
-
 from fibad.pytorch_ignite import create_splits
 
 


### PR DESCRIPTION
This PR is an first step toward exporting multiple forms of models. Obviously at this point we're only focusing on PyTorch, but I've tried to write this in a way that will support future different ML frameworks. I probably haven't done this in an ideal way, but it's a start. Two aspects of this are worth noting, and I would appreciate feedback on them.

### A context object
I've created a simple dictionary that carries "context" from the train.run function into the export_to_onnx function. This context object sounds a lot like a python `dataclass`. Additionally, it feels like a reasonable way to percolate information back up to the fibad object after `train` has finished. Extra-additionally, perhaps this is the right time to transform `train` into a proper verb class.

### Using `@singledispatch`
In the `model_exporters` module, the function `export_to_onnx` will accept the context object and then dispatch the request to the appropriate private function that implements the conversion to ONNX. As it stands, it's only the pytorch->ONNX function, but we're trying to plan ahead. This is an ideal use case for `@singledispatch` where we use the model type as the discriminator, i.e. `torch.nn.Module`. However, to do so, _I believe_ would require that we import torch at the top level. And while torch is pretty quick to import, I'm not sure about the other libraries, so I wanted to defer the imports (in the same way we do that with verbs) to avoid a really long "start up" time at the end of `.train()`. At this point, I'm using a string in the context object (`context['ml_framework'] == 'pytorch'`) to determine which specific implementation to use. And while that's fine, it doesn't feel as cool as using `@singledispatch`...


## Remaining work

- [ ] Implement something on the `.infer` side so that we can make use of the .onnx model
- [ ] Take some benchmarks to see if .onnx is actually faster or not
- [ ] A little more research into versions. ONNX (opset_version and IRVersion), PyTorch (support for different opset and IR versions), PyTorch-ignite (newer versions of PyTorch)