### PR TITLE
Extracting dataset split code from data_sets

### DIFF
--- a/docs/pre_executed/visualize.ipynb
+++ b/docs/pre_executed/visualize.ipynb
@@ -30,34 +30,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-02-07 14:24:49,095 fibad:INFO] Runtime Config read from: /Users/mtauraso/src/fibad/src/fibad/fibad_default_config.toml\n",
-      "[2025-02-07 14:24:49,115 fibad.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-02-07 14:24:49,116 fibad.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-02-07 14:24:49,118 fibad.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-02-07 14:24:49,120 fibad.data_sets.hsc_data_set:INFO] test split contains 199 items\n",
-      "[2025-02-07 14:24:49,120 fibad.data_sets.hsc_data_set:INFO] train split contains 596 items\n",
-      "[2025-02-07 14:24:49,121 fibad.data_sets.hsc_data_set:INFO] validate split contains 198 items\n",
-      "[2025-02-07 14:24:49,127 fibad.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "2025-02-07 14:24:49,128 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<fibad.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x33ae8c520>, 'batch_size': 512, 'num_workers': 2, 'pin_memory': False}\n",
-      "2025-02-07 14:24:49,128 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<fibad.data_sets.hsc': \n",
-      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x33aec85b0>, 'batch_size': 512, 'num_workers': 2, 'pin_memory': False}\n",
-      "2025/02/07 14:24:49 WARNING mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics because creating `GPUMonitor` failed with error: Failed to initialize NVML, skip logging GPU metrics: NVML Shared Library Not Found.\n",
-      "2025/02/07 14:24:49 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
-      "[2025-02-07 14:24:49,196 fibad.pytorch_ignite:INFO] Training model on device: mps\n"
+      "[2025-02-24 16:32:57,701 fibad:INFO] Runtime Config read from: /Users/mtauraso/src/fibad/src/fibad/fibad_default_config.toml\n",
+      "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/ignite/handlers/checkpoint.py:16: DeprecationWarning: `TorchScript` support for functional optimizers is deprecated and will be removed in a future PyTorch release. Consider using the `torch.compile` optimizer instead.\n",
+      "  from torch.distributed.optim import ZeroRedundancyOptimizer\n",
+      "[2025-02-24 16:33:00,011 fibad.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-02-24 16:33:00,012 fibad.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-02-24 16:33:00,014 fibad.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
+      "[2025-02-24 16:33:00,019 fibad.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "2025-02-24 16:33:00,027 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<fibad.data_sets.hsc': \n",
+      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x14b5cd7e0>, 'batch_size': 512, 'num_workers': 0, 'pin_memory': False}\n",
+      "2025-02-24 16:33:00,028 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<fibad.data_sets.hsc': \n",
+      "\t{'sampler': <torch.utils.data.sampler.SubsetRandomSampler object at 0x14b5cd810>, 'batch_size': 512, 'num_workers': 0, 'pin_memory': False}\n",
+      "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/ignite/handlers/tqdm_logger.py:127: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n",
+      "2025/02/24 16:33:00 WARNING mlflow.system_metrics.system_metrics_monitor: Skip logging GPU metrics because creating `GPUMonitor` failed with error: Failed to initialize NVML, skip logging GPU metrics: NVML Shared Library Not Found.\n",
+      "2025/02/24 16:33:00 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n",
+      "[2025-02-24 16:33:00,124 fibad.pytorch_ignite:INFO] Training model on device: mps\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9a6555a19eea4c798842b50a944627aa",
+       "model_id": "fef709fd27c14baf9c920523c4fc60bc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -71,7 +72,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4977a234a5744f38b6d5756f09b0aff4",
+       "model_id": "0ceb7fe1d26844a28bac6905f7f4bd1e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -85,7 +86,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "12a3aa67ab7d44d49abe2cd7e27d9e2b",
+       "model_id": "7522966233804014b536ad973ecd3a79",
        "version_major": 2,
        "version_minor": 0
       },
@@ -99,7 +100,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0d5128d5fa9847efb9d869abf0b0c6f2",
+       "model_id": "9357213a9abe4570852e2aa7c1d5c76a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -113,7 +114,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "697d27102f324a55a025a72153d55c15",
+       "model_id": "4499c7d8321946da9407727dfef57db2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -127,7 +128,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4115e00beba04cb0a3fe75a231dc66ed",
+       "model_id": "e234a3f0e136403daf8339dd46b23db8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -141,7 +142,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d7c65b0134fb4bc59f7828a1703a9e55",
+       "model_id": "d9b0959eff0b4a99b237d838a9670bc8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -155,7 +156,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "819716e2c3a943cd81247fe9939dea12",
+       "model_id": "e913c59d33c9426fa4f01ce11a259df9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -169,7 +170,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ba5bdf5927c046369d03469abdf9ff2f",
+       "model_id": "cd6ce5c2ddb148b19f76cdcb8f773ba0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -183,7 +184,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9991d45ab532466185e9887a198f2d2c",
+       "model_id": "a0e3780c5cae4dfbaae74c99b00332ec",
        "version_major": 2,
        "version_minor": 0
       },
@@ -198,12 +199,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-02-07 14:30:32,098 fibad.pytorch_ignite:INFO] Total training time: 342.90[s]\n",
-      "[2025-02-07 14:30:32,103 fibad.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250207-142449-train--VED/checkpoint_epoch_10.pt\n",
-      "[2025-02-07 14:30:32,103 fibad.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250207-142449-train--VED/checkpoint_10_loss=-428.7067.pt\n",
-      "2025/02/07 14:30:42 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
-      "2025/02/07 14:30:42 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
-      "[2025-02-07 14:30:42,173 fibad.train:INFO] Finished Training\n"
+      "[2025-02-24 16:33:06,484 fibad.pytorch_ignite:INFO] Total training time: 6.36[s]\n",
+      "[2025-02-24 16:33:06,485 fibad.pytorch_ignite:INFO] Latest checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250224-163259-train-qGk8/checkpoint_epoch_10.pt\n",
+      "[2025-02-24 16:33:06,485 fibad.pytorch_ignite:INFO] Best metric checkpoint saved as: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250224-163259-train-qGk8/checkpoint_9_loss=-494.0631.pt\n",
+      "2025/02/24 16:33:06 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n",
+      "2025/02/24 16:33:06 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n",
+      "[2025-02-24 16:33:06,504 fibad.train:INFO] Finished Training\n"
      ]
     }
    ],
@@ -235,27 +236,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-02-07 15:39:30,760 fibad.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
-      "[2025-02-07 15:39:30,761 fibad.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
-      "[2025-02-07 15:39:30,763 fibad.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
-      "[2025-02-07 15:39:30,764 fibad.data_sets.hsc_data_set:INFO] test split contains 199 items\n",
-      "[2025-02-07 15:39:30,765 fibad.data_sets.hsc_data_set:INFO] train split contains 596 items\n",
-      "[2025-02-07 15:39:30,765 fibad.data_sets.hsc_data_set:INFO] validate split contains 198 items\n",
-      "[2025-02-07 15:39:30,772 fibad.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
-      "[2025-02-07 15:39:30,773 fibad.infer:INFO] data set has length 993\n",
-      "2025-02-07 15:39:30,773 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<fibad.data_sets.hsc': \n",
-      "\t{'sampler': None, 'batch_size': 512, 'num_workers': 2, 'pin_memory': False}\n",
-      "[2025-02-07 15:39:30,954 fibad.pytorch_ignite:INFO] Evaluating model on device: mps\n",
-      "[2025-02-07 15:39:30,954 fibad.pytorch_ignite:INFO] Total epochs: 1\n",
-      "[2025-02-07 15:39:42,235 fibad.pytorch_ignite:INFO] Total evaluation time: 11.28[s]\n",
-      "[2025-02-07 15:39:52,240 fibad.infer:INFO] Inference results saved in: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250207-153930-infer-26Kj\n"
+      "[2025-02-24 16:33:20,073 fibad.data_sets.hsc_data_set:INFO] Processed 993 objects for pruning\n",
+      "[2025-02-24 16:33:20,073 fibad.data_sets.hsc_data_set:INFO] Checking file dimensions to determine standard cutout size...\n",
+      "[2025-02-24 16:33:20,075 fibad.data_sets.hsc_data_set:INFO] HSC Data set loader has 993 objects\n",
+      "[2025-02-24 16:33:20,079 fibad.models.model_registry:INFO] Using criterion: torch.nn.CrossEntropyLoss with default arguments.\n",
+      "[2025-02-24 16:33:20,080 fibad.infer:INFO] data set has length 993\n",
+      "2025-02-24 16:33:20,080 ignite.distributed.auto.auto_dataloader INFO: Use data loader kwargs for dataset '<fibad.data_sets.hsc': \n",
+      "\t{'sampler': None, 'batch_size': 512, 'num_workers': 0, 'pin_memory': False}\n",
+      "[2025-02-24 16:33:20,212 fibad.pytorch_ignite:INFO] Evaluating model on device: mps\n",
+      "[2025-02-24 16:33:20,213 fibad.pytorch_ignite:INFO] Total epochs: 1\n",
+      "[2025-02-24 16:33:22,906 fibad.pytorch_ignite:INFO] Total evaluation time: 2.69[s]\n",
+      "[2025-02-24 16:33:22,907 fibad.infer:INFO] Inference results saved in: /Users/mtauraso/src/fibad/docs/pre_executed/results/20250224-163320-infer-ET1e\n"
      ]
     }
    ],
@@ -265,16 +263,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-02-07 15:39:52,281 fibad.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250207-153930-infer-26Kj for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
+      "[2025-02-24 16:33:27,427 fibad.verbs.umap:INFO] Saving UMAP results to /Users/mtauraso/src/fibad/docs/pre_executed/results/20250224-163327-umap-dNRl\n",
+      "[2025-02-24 16:33:27,428 fibad.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250224-163320-infer-ET1e for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n",
       "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/sklearn/utils/deprecation.py:151: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.\n",
       "  warnings.warn(\n",
+      "OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4e5af9ccdafa4b2285bac3b3c697a86c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Creating Lower Dimensional Representation using UMAP:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/sklearn/utils/deprecation.py:151: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.\n",
       "  warnings.warn(\n",
       "/Users/mtauraso/miniforge3/envs/fibad/lib/python3.10/site-packages/sklearn/utils/deprecation.py:151: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.\n",
@@ -297,15 +317,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2025-02-13 16:33:33,219 fibad:INFO] Runtime Config read from: /Users/mtauraso/src/fibad/src/fibad/fibad_default_config.toml\n",
-      "[2025-02-13 16:33:34,906 fibad.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250207-153952-umap-yQVG for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n"
+      "[2025-02-24 16:33:40,789 fibad.data_sets.inference_dataset:INFO] Using most recent results dir /Users/mtauraso/src/fibad/docs/pre_executed/results/20250224-163327-umap-dNRl for lookup. Use the [results] inference_dir config to set a directory or pass it to this verb.\n"
      ]
     },
     {
@@ -352,12 +371,12 @@
      "data": {
       "application/vnd.holoviews_exec.v0+json": "",
       "text/html": [
-       "<div id='66b52816-973f-4b26-81d5-ac361951be13'>\n",
-       "  <div id=\"dd943ddd-c1c8-4c4c-8e58-458931dd6979\" data-root-id=\"66b52816-973f-4b26-81d5-ac361951be13\" style=\"display: contents;\"></div>\n",
+       "<div id='a254aff7-800a-435e-bfca-eeae513a2b94'>\n",
+       "  <div id=\"cb9372d4-31e6-4102-8601-d794dc648804\" data-root-id=\"a254aff7-800a-435e-bfca-eeae513a2b94\" style=\"display: contents;\"></div>\n",
        "</div>\n",
        "<script type=\"application/javascript\">(function(root) {\n",
-       "  var docs_json = {\"324aed32-0890-4e66-b476-f3a0deca9792\":{\"version\":\"3.6.2\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"66b52816-973f-4b26-81d5-ac361951be13\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"38a36489-1c50-4adb-b187-2105dd2e43bd\",\"attributes\":{\"plot_id\":\"66b52816-973f-4b26-81d5-ac361951be13\",\"comm_id\":\"d92c6b0ff9e546fda87050ebdbac9d6e\",\"client_comm_id\":\"5aea98c2a29c4c0dadbdfe81c8be9441\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"ReactiveESM1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"JSComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"ReactComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"AnyWidgetComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"request_value1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"_synced\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_request_sync\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
-       "  var render_items = [{\"docid\":\"324aed32-0890-4e66-b476-f3a0deca9792\",\"roots\":{\"66b52816-973f-4b26-81d5-ac361951be13\":\"dd943ddd-c1c8-4c4c-8e58-458931dd6979\"},\"root_ids\":[\"66b52816-973f-4b26-81d5-ac361951be13\"]}];\n",
+       "  var docs_json = {\"028ab8c6-7ad4-417f-b182-e664f22d6c83\":{\"version\":\"3.6.2\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"a254aff7-800a-435e-bfca-eeae513a2b94\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"70f5b33f-5cc2-4b33-b139-031e6a535082\",\"attributes\":{\"plot_id\":\"a254aff7-800a-435e-bfca-eeae513a2b94\",\"comm_id\":\"48285c12b98d4e87889dc0feb56a4921\",\"client_comm_id\":\"d21b93e0f7754d7094e69aa10b43b18a\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"ReactiveESM1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"JSComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"ReactComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"AnyWidgetComponent1\",\"properties\":[{\"name\":\"esm_constants\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}}]},{\"type\":\"model\",\"name\":\"request_value1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"_synced\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_request_sync\",\"kind\":\"Any\",\"default\":0}]}]}};\n",
+       "  var render_items = [{\"docid\":\"028ab8c6-7ad4-417f-b182-e664f22d6c83\",\"roots\":{\"a254aff7-800a-435e-bfca-eeae513a2b94\":\"cb9372d4-31e6-4102-8601-d794dc648804\"},\"root_ids\":[\"a254aff7-800a-435e-bfca-eeae513a2b94\"]}];\n",
        "  var docs = Object.values(docs_json)\n",
        "  if (!docs) {\n",
        "    return\n",
@@ -426,7 +445,7 @@
      },
      "metadata": {
       "application/vnd.holoviews_exec.v0+json": {
-       "id": "66b52816-973f-4b26-81d5-ac361951be13"
+       "id": "a254aff7-800a-435e-bfca-eeae513a2b94"
       }
      },
      "output_type": "display_data"
@@ -524,15 +543,15 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a1202ac91de24955a8084f7c299972f8",
+       "model_id": "af4e37644f7f4707949090775339796b",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "BokehModel(combine_events=True, render_bundle={'docs_json': {'85a28c36-6380-473c-84e6-e46d20b6d520': {'version…"
+       "BokehModel(combine_events=True, render_bundle={'docs_json': {'811f1826-94a9-41dc-855e-ef06098672f0': {'version…"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/fibad/data_sets/example_cifar_data_set.py
+++ b/src/fibad/data_sets/example_cifar_data_set.py
@@ -1,9 +1,7 @@
 # ruff: noqa: D101, D102
 import logging
 
-import numpy as np
 import torchvision.transforms as transforms
-from torch.utils.data.sampler import SubsetRandomSampler
 from torchvision.datasets import CIFAR10
 
 from .data_set_registry import fibad_data_set
@@ -15,73 +13,17 @@ logger = logging.getLogger(__name__)
 class CifarDataSet(CIFAR10):
     """This is simply a version of CIFAR10 that has our needed shape method, and is initialized using
     FIBAD config with a transformation that works well for example code.
+
+    We only use the training split in the data, because it is larger (50k images). Fibad will then divide that
+    into Train/test/Validate according to configuration.
     """
 
-    def __init__(self, config, split: str):
+    def __init__(self, config):
         transform = transforms.Compose(
             [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
         )
 
-        if split not in ["train", "validate", "test"]:
-            RuntimeError("CIFAR10 dataset only supports 'train' and 'test' splits.")
-
-        train = split != "test"
-
-        super().__init__(root=config["general"]["data_dir"], train=train, download=True, transform=transform)
-
-        if train:
-            self.train_sampler = None
-            self.validation_sampler = None
-            data_set_length = len(self)
-            indices = list(range(data_set_length))
-
-            train_size = config["data_set"]["train_size"] if config["data_set"]["train_size"] else None
-            validate_size = (
-                config["data_set"]["validate_size"] if config["data_set"]["validate_size"] else None
-            )
-
-            if isinstance(train_size, int):
-                train_size = train_size / data_set_length
-            if isinstance(validate_size, int):
-                validate_size = validate_size / data_set_length
-
-            # Shuffle the indices
-            random_seed = None
-            if config["data_set"]["seed"]:
-                random_seed = config["data_set"]["seed"]
-            np.random.seed(random_seed)
-            np.random.shuffle(indices)
-
-            # Get absolute numbers of training and validation samples
-            num_train = 0
-            if train_size:
-                num_train = int(np.floor(train_size * data_set_length))
-
-            num_validation = 0
-            if validate_size:
-                num_validation = int(np.floor(validate_size * data_set_length))
-
-            # Let the user know if they are asking for too many points
-            if num_train + num_validation > data_set_length:
-                raise RuntimeError(
-                    f"Sum of train and validation ({num_train} + {num_validation})"
-                    f" exceed dataset size ({data_set_length})."
-                )
-
-            # Create the SubsetRandomSamplers
-            train_idx = []
-            if train_size:
-                train_idx = indices[:num_train]
-                self.train_sampler = SubsetRandomSampler(train_idx)
-
-            valid_idx = []
-            if validate_size:
-                valid_idx = indices[num_train : num_train + num_validation]
-                self.validation_sampler = SubsetRandomSampler(valid_idx)
-
-            logger.debug(f"Dataset size: {len(self)}")
-            logger.debug(f"Train size: {len(train_idx)}")
-            logger.debug(f"Validation size: {len(valid_idx)}")
+        super().__init__(root=config["general"]["data_dir"], train=True, download=True, transform=transform)
 
     def shape(self):
         return (3, 32, 32)

--- a/src/fibad/data_sets/inference_dataset.py
+++ b/src/fibad/data_sets/inference_dataset.py
@@ -23,7 +23,6 @@ class InferenceDataSet(Dataset):
     def __init__(
         self,
         config,
-        split: Union[str, bool],
         results_dir: Optional[Union[Path, str]] = None,
         verb: Optional[str] = None,
     ):

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -1,10 +1,16 @@
 import functools
 import logging
+import warnings
 from pathlib import Path
-from typing import Any, Callable, Union
+from typing import Any, Callable, Optional, Union
 
 import ignite.distributed as idist
-import mlflow
+import numpy as np
+
+with warnings.catch_warnings():
+    warnings.simplefilter(action="ignore", category=DeprecationWarning)
+    import mlflow
+
 import torch
 from ignite.engine import Engine, Events
 from ignite.handlers import Checkpoint, DiskSaver, global_step_from_engine
@@ -12,6 +18,7 @@ from ignite.handlers.tqdm_logger import ProgressBar
 from tensorboardX import SummaryWriter
 from torch.nn.parallel import DataParallel, DistributedDataParallel
 from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.sampler import SubsetRandomSampler
 
 from fibad.config_utils import ConfigDict
 from fibad.data_sets.data_set_registry import fetch_data_set_class
@@ -39,7 +46,7 @@ def setup_dataset(config: ConfigDict, split: Union[str, bool] = False) -> Datase
 
     # Fetch data loader class specified in config and create an instance of it
     data_set_cls = fetch_data_set_class(config)
-    data_set = data_set_cls(config, split)  # type: ignore[call-arg]
+    data_set = data_set_cls(config)  # type: ignore[call-arg]
 
     return data_set
 
@@ -67,8 +74,14 @@ def setup_model(config: ConfigDict, dataset: Dataset) -> torch.nn.Module:
     return model
 
 
-def dist_data_loader(data_set: Dataset, config: ConfigDict, split: str):
-    """Create a Pytorch Ignite distributed data loader
+def dist_data_loader(
+    data_set: Dataset,
+    config: ConfigDict,
+    split: Optional[Union[str, list[str]]] = None,
+):
+    """Create Pytorch Ignite distributed data loaders
+
+    It is recommended that each verb needing dataloaders only call this function once.
 
     Parameters
     ----------
@@ -76,26 +89,136 @@ def dist_data_loader(data_set: Dataset, config: ConfigDict, split: str):
         A Pytorch Dataset object
     config : ConfigDict
         Fibad runtime configuration
-    split : str
-        The name of the split we want to use from the data set.
+    split : Union[str, list[str]], Optional
+        The name(s) of the split we want to use from the data set.
+        If this is not passed, you get all three
 
     Returns
     -------
     Dataloader (or an ignite-wrapped equivalent)
         This is the distributed dataloader, formed by calling ignite.distributed.auto_dataloader
+
+    For multiple splits, we return a dictionary where the keys are the names of the splits
+    and the value is either a Dataloader as described above or the value None if the split
+    was not configured.
     """
 
-    #! Here we are allowing `train_sampler` and `validation_sampler` to become magic words.
-    #! It would be nice to find a way to do this that doesn't require external libraries to
-    #! know about these.
-    if hasattr(data_set, "train_sampler") and split == "train":
-        sampler = data_set.train_sampler
-    elif hasattr(data_set, "validation_sampler") and split == "validate":
-        sampler = data_set.validation_sampler
-    else:
-        sampler = None
+    # Sanitize split argument
+    if split is None:
+        split = ["train", "validate", "test"]
+    if isinstance(split, str):
+        split = [split]
 
-    return idist.auto_dataloader(data_set, sampler=sampler, **config["data_loader"])
+    # Configure the torch rng
+    torch_rng = torch.Generator(device=idist.device())
+    seed = config["data_set"]["seed"] if config["data_set"]["seed"] else None
+    if seed is not None:
+        torch_rng.manual_seed(seed)
+
+    # Create the indexes for all splits based on config.
+    indexes = create_splits(data_set, config)
+
+    # Create samplers and dataloaders for each split we are interested in
+    samplers = {
+        s: SubsetRandomSampler(indexes[s], generator=torch_rng) if indexes.get(s) else None for s in split
+    }
+
+    dataloaders = {
+        split: idist.auto_dataloader(data_set, sampler=sampler, **config["data_loader"]) if sampler else None
+        for split, sampler in samplers.items()
+    }
+
+    # Return only one if we were only passed one split in, return the dictionary otherwise.
+    return dataloaders[split[0]] if len(split) == 1 else dataloaders
+
+
+def create_splits(data_set: Dataset, config: ConfigDict):
+    """Returns train, test, and validation indexes constructed to be used with the passed in
+    dataset. The allocation of indexes in the underlying dataset to samplers depends on
+    the data_set section of the config dict.
+
+    Parameters
+    ----------
+    data_set : Dataset
+        The data set to use
+    config : ConfigDict
+        Configuration that defines dataset splits
+    split : str
+        Name of the split to use.
+    """
+    data_set_size = len(data_set)  # type: ignore[arg-type]
+
+    # Init the splits based on config values
+    train_size = config["data_set"]["train_size"] if config["data_set"]["train_size"] else None
+    test_size = config["data_set"]["test_size"] if config["data_set"]["test_size"] else None
+    validate_size = config["data_set"]["validate_size"] if config["data_set"]["validate_size"] else None
+
+    # Convert all values specified as counts into ratios of the underlying container
+    if isinstance(train_size, int):
+        train_size = train_size / data_set_size
+    if isinstance(test_size, int):
+        test_size = test_size / data_set_size
+    if isinstance(validate_size, int):
+        validate_size = validate_size / data_set_size
+
+    # Initialize Test size when not provided
+    if test_size is None:
+        if train_size is None:
+            train_size = 0.25
+
+        if validate_size is None:  # noqa: SIM108
+            test_size = 1.0 - train_size
+        else:
+            test_size = 1.0 - (train_size + validate_size)
+
+    # Initialize train size when not provided, and can be inferred from test_size and validate_size.
+    if train_size is None:
+        if validate_size is None:  # noqa: SIM108
+            train_size = 1.0 - test_size
+        else:
+            train_size = 1.0 - (test_size + validate_size)
+
+    # If splits cover more than the entire dataset, error out.
+    if validate_size is None:
+        if np.round(train_size + test_size, decimals=5) > 1.0:
+            raise RuntimeError("Split fractions add up to more than 1.0")
+    elif np.round(train_size + test_size + validate_size, decimals=5) > 1.0:
+        raise RuntimeError("Split fractions add up to more than 1.0")
+
+    # If any split is less than 0.0 also error out
+    if (
+        np.round(test_size, decimals=5) < 0.0
+        or np.round(train_size, decimals=5) < 0.0
+        or (validate_size is not None and np.round(validate_size, decimals=5) < 0.0)
+    ):
+        raise RuntimeError("One of the Split fractions configured is negative.")
+
+    indices = list(range(data_set_size))
+
+    # shuffle the indices
+    seed = config["data_set"]["seed"] if config["data_set"]["seed"] else None
+    np.random.seed(seed)
+    np.random.shuffle(indices)
+
+    # Given the number of samples in the dataset and the ratios of the splits
+    # we can calculate the number of samples in each split.
+    num_test = int(np.round(data_set_size * test_size))
+    num_train = int(np.round(data_set_size * train_size))
+
+    # split the indices
+    test_idx = indices[:num_test]
+    train_idx = indices[num_test : num_test + num_train]
+
+    # assume that validate gets all the remaining indices
+    if validate_size:
+        num_validate = int(np.round(data_set_size * validate_size))
+        valid_idx = indices[num_test + num_train : num_test + num_train + num_validate]
+
+    split_inds = {"train": train_idx, "test": test_idx}
+    if validate_size:
+        split_inds["validate"] = valid_idx
+
+    return split_inds
 
 
 def create_engine(funcname: str, device: torch.device, model: torch.nn.Module) -> Engine:

--- a/src/fibad/rebuild_manifest.py
+++ b/src/fibad/rebuild_manifest.py
@@ -14,13 +14,18 @@ def run(config):
         The parsed config file as a nested
         dict
     """
+    from .data_sets.hsc_data_set import HSCDataSet
 
     config["rebuild_manifest"] = True
 
     data_set = setup_dataset(config, split=config["train"]["split"])
 
+    if not isinstance(data_set, HSCDataSet):
+        msg = "Invalid to run rebuild manafest except on an HSCDataSet."
+        raise RuntimeError(msg)
+
     logger.info("Starting rebuild of manifest")
 
-    data_set.rebuild_manifest(config)
+    data_set._rebuild_manifest(config)
 
     logger.info("Finished Rebuild Manifest")

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -37,11 +37,10 @@ def run(config):
     data_set = setup_dataset(config, split=config["train"]["split"])
     model = setup_model(config, data_set)
 
-    # Create a data loader for the training set
-    train_data_loader = dist_data_loader(data_set, config, "train")
-
-    # Create validation_data_loader if a validation split is defined in data_set
-    validation_data_loader = dist_data_loader(data_set, config, "validate")
+    # Create a data loader for the training set (and validation split if configured)
+    data_loaders = dist_data_loader(data_set, config, ["train", "validate"])
+    train_data_loader = data_loaders["train"]
+    validation_data_loader = data_loaders["validate"]
 
     # Create trainer, a pytorch-ignite `Engine` object
     trainer = create_trainer(model, config, results_dir, tensorboardx_logger)

--- a/src/fibad/verbs/lookup.py
+++ b/src/fibad/verbs/lookup.py
@@ -91,7 +91,7 @@ class Lookup(Verb):
         if isinstance(results_dir, str):
             results_dir = Path(results_dir)
 
-        inference_dataset = InferenceDataSet(self.config, split=False, results_dir=results_dir)
+        inference_dataset = InferenceDataSet(self.config, results_dir=results_dir)
 
         all_ids = np.array([i for i in inference_dataset.ids()])
         lookup_index = np.argwhere(all_ids == id)

--- a/src/fibad/verbs/umap.py
+++ b/src/fibad/verbs/umap.py
@@ -33,7 +33,7 @@ class Umap(Verb):
     # superclass to build the call to run based on what the subclass verb defined in setup_parser
     def run_cli(self, args: Optional[Namespace] = None):
         """Stub CLI implementation"""
-        logger.info("Search run from cli")
+        logger.info("umap run from cli")
         if args is None:
             raise RuntimeError("Run CLI called with no arguments.")
 
@@ -74,7 +74,7 @@ class Umap(Verb):
         umap_results = InferenceDataSetWriter(results_dir)
 
         # Load all the latent space data.
-        inference_results = InferenceDataSet(self.config, split=False, results_dir=input_dir)
+        inference_results = InferenceDataSet(self.config, results_dir=input_dir)
         total_length = len(inference_results)
 
         # Sample the data to fit

--- a/src/fibad/verbs/visualize.py
+++ b/src/fibad/verbs/visualize.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
-
 from holoviews import Points, Table
 
 from .verb_registry import Verb, fibad_verb
@@ -58,7 +57,7 @@ class Visualize(Verb):
         from fibad.data_sets.inference_dataset import InferenceDataSet
 
         # Get the umap data and put it in a kdtree for indexing.
-        self.umap_results = InferenceDataSet(self.config, split=False, results_dir=input_dir, verb="umap")
+        self.umap_results = InferenceDataSet(self.config, results_dir=input_dir, verb="umap")
         self.tree = KDTree(self.umap_results)
 
         # Initialize holoviews with bokeh.

--- a/tests/fibad/test_splits.py
+++ b/tests/fibad/test_splits.py
@@ -1,0 +1,161 @@
+import pytest
+
+from fibad.pytorch_ignite import create_splits
+
+
+def mkconfig(train_size=0.2, test_size=0.6, validate_size=0.1, seed=False):
+    """Makes a configuration that has enough keys for create_splits"""
+    return {
+        "data_set": {
+            "seed": seed,
+            "train_size": train_size,
+            "test_size": test_size,
+            "validate_size": validate_size,
+        },
+    }
+
+
+def test_split():
+    """Test splitting in the default config where train, test, and validate are all specified"""
+
+    fake_dataset = [1] * 100
+    config = mkconfig()
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["validate"]) == 10
+    assert len(indexes["test"]) == 60
+    assert len(indexes["train"]) == 20
+
+
+def test_split_no_validate():
+    """Test splitting when validate is overridden"""
+    fake_dataset = [1] * 100
+    config = mkconfig(validate_size=False)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 60
+    assert len(indexes["train"]) == 20
+    assert indexes.get("validate") is None
+
+
+def test_split_with_validate_no_test():
+    """Test splitting when validate is provided by test size is not"""
+    fake_dataset = [1] * 100
+    config = mkconfig(test_size=False, validate_size=0.2)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["validate"]) == 20
+    assert len(indexes["test"]) == 60
+    assert len(indexes["train"]) == 20
+
+
+def test_split_with_validate_no_test_no_train():
+    """Test splitting when validate is provided by test size is not"""
+    fake_dataset = [1] * 100
+    config = mkconfig(test_size=False, train_size=False, validate_size=0.2)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 55
+    assert len(indexes["train"]) == 25
+    assert len(indexes["validate"]) == 20
+
+
+def test_split_with_validate_with_test_no_train():
+    """Test splitting when validate is provided by test size is not"""
+    fake_dataset = [1] * 100
+    config = mkconfig(test_size=0.6, train_size=False, validate_size=0.2)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 60
+    assert len(indexes["train"]) == 20
+    assert len(indexes["validate"]) == 20
+
+
+def test_split_no_validate_no_test():
+    """Test splitting when validate and test are overridden"""
+    fake_dataset = [1] * 100
+    config = mkconfig(validate_size=False, test_size=False)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 80
+    assert len(indexes["train"]) == 20
+    assert indexes.get("validate") is None
+
+
+def test_split_no_validate_no_train():
+    """Test splitting when validate and train are overridden"""
+    fake_dataset = [1] * 100
+    config = mkconfig(validate_size=False, train_size=False)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 60
+    assert len(indexes["train"]) == 40
+    assert indexes.get("validate") is None
+
+
+def test_split_invalid_ratio():
+    """Test that split RuntimeErrors when provided with an invalid ratio"""
+    fake_dataset = [1] * 100
+
+    with pytest.raises(RuntimeError):
+        create_splits(fake_dataset, mkconfig(validate_size=False, train_size=1.1))
+
+    with pytest.raises(RuntimeError):
+        create_splits(fake_dataset, mkconfig(validate_size=False, train_size=-0.1))
+
+
+def test_split_no_splits_configured():
+    """Test splitting when all splits are overriden, and nothing is specified."""
+    fake_dataset = [1] * 100
+    config = mkconfig(validate_size=False, test_size=False, train_size=False)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 75
+    assert len(indexes["train"]) == 25
+    assert indexes.get("validate") is None
+
+
+def test_split_values_configured():
+    """Test splitting when all splits are integer data counts"""
+
+    fake_dataset = [1] * 100
+    config = mkconfig(validate_size=22, test_size=56, train_size=22)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 56
+    assert len(indexes["train"]) == 22
+    assert len(indexes["validate"]) == 22
+
+
+def test_split_values_configured_no_validate():
+    """Test splitting when all splits are integer data counts and validate is not configured
+    so the total selected data doesn't cover the dataset.
+    """
+    fake_dataset = [1] * 100
+    config = mkconfig(test_size=56, train_size=22)
+    indexes = create_splits(fake_dataset, config)
+
+    assert len(indexes["test"]) == 56
+    assert len(indexes["train"]) == 22
+    assert len(indexes["validate"]) == 10
+
+
+def test_split_invalid_configured():
+    """Test that split RuntimeErrors when provided with an invalid datapoint count"""
+    fake_dataset = [1] * 100
+
+    with pytest.raises(RuntimeError):
+        create_splits(fake_dataset, mkconfig(validate_size=False, train_size=120))
+
+    with pytest.raises(RuntimeError):
+        create_splits(fake_dataset, mkconfig(validate_size=False, train_size=-10))
+
+
+def test_split_values_rng():
+    """Generate twice with the same RNG seed, verify same values are selected."""
+    fake_dataset = [1] * 100
+    config = mkconfig(test_size=56, train_size=22, seed=5)
+    indexes_a = create_splits(fake_dataset, config)
+    indexes_b = create_splits(fake_dataset, config)
+
+    assert all([a == b for a, b in zip(indexes_a, indexes_b)])


### PR DESCRIPTION
- Data Sets no longer have any awareness of splits
- All splitting behavior is negotiated between the verb and pytorch_ignite while creating distributed data loader(s).
- HSCDataSetSplit and HSCDataSetContainer are removed entirely, with HSCDataSet now having the code that was in HSCDataSetContainer.
- CifarDataSet is much shorter and only uses the training CIFAR dataset
- Tests of splits are in their own file and preserve behavior with prior HSCDataSetSplit tests.