### PR TITLE
Initial vectordb interface and chromadb impl with sharding

### DIFF
--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -198,9 +198,6 @@ model_weights_file = false
 # The data_set split to use for inference. Use `false` for entire dataset.
 split = false
 
-# Whether to generate a chromadb vector database of inference results
-chromadb = true
-
 
 [results]
 # Path to inference results to use for visualization and lookups. Uses latest inference run if none provided.
@@ -223,3 +220,8 @@ n_components = 2
 # Controls how UMAP balances local versus global structure in the data.
 # See official documentation for details.
 n_neighbors = 15
+
+
+[vector_db]
+# The type of vector db to use. Use "false" to disable vector database.
+name = "chromadb"

--- a/src/fibad/infer.py
+++ b/src/fibad/infer.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Optional, Union
 
-import chromadb
 import numpy as np
 from torch import Tensor
 
@@ -19,6 +18,7 @@ from fibad.pytorch_ignite import (
     setup_dataset,
     setup_model,
 )
+from fibad.vector_dbs.vector_db_factory import vector_db_factory
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def run(config: ConfigDict):
     config : ConfigDict
         The parsed config file as a nested dict
     """
-
+    context = {}
     data_set = setup_dataset(config, split=config["infer"]["split"])
     model = setup_model(config, data_set)
     logger.info(f"data set has length {len(data_set)}")  # type: ignore[arg-type]
@@ -41,19 +41,11 @@ def run(config: ConfigDict):
     results_dir = create_results_dir(config, "infer")
     log_runtime_config(config, results_dir)
     load_model_weights(config, model)
+    context["results_dir"] = results_dir
 
-    # Create a chromadb in results dir
-    if config["infer"]["chromadb"]:
-        chromadb_client = chromadb.PersistentClient(path=str(results_dir))
-        collection = chromadb_client.create_collection(
-            name="fibad",
-            metadata={
-                # These are all chromdb defaults. We may want to configure them
-                "hsnw:space": "l2",
-                "hsnw:construction_ef": 100,
-                "hsnw:search_ef": 100,
-            },
-        )
+    vector_db = vector_db_factory(config, context)
+    if vector_db:
+        vector_db.create()
 
     data_writer = InferenceDataSetWriter(results_dir)
 
@@ -79,12 +71,12 @@ def run(config: ConfigDict):
         batch_results = batch_results.detach().to("cpu")
         batch_object_ids = [object_ids[id] for id in range(write_index, write_index + len(batch_results))]
 
-        # Save results to ChromaDB vector database
-        if config["infer"]["chromadb"]:
-            nonlocal collection
-            chroma_ids: list[str] = [str(id) for id in batch_object_ids]
-            embeddings: list[np.ndarray] = [t.flatten().numpy() for t in batch_results]
-            collection.add(embeddings=embeddings, ids=chroma_ids)
+        # Save results to vector database
+        nonlocal vector_db
+        if vector_db:
+            ids: list[str | int] = [str(id) for id in batch_object_ids]
+            vectors: list[np.ndarray] = [t.flatten().numpy() for t in batch_results]
+            vector_db.insert(ids=ids, vectors=vectors)
 
         # Save results from this batch in a numpy file as a structured array
         data_writer.write_batch(np.array(batch_object_ids), [t.numpy() for t in batch_results])

--- a/src/fibad/vector_dbs/chromadb_impl.py
+++ b/src/fibad/vector_dbs/chromadb_impl.py
@@ -1,0 +1,161 @@
+from typing import Union
+
+import chromadb
+import numpy as np
+from fibad.vector_dbs.vector_db_interface import VectorDB
+
+
+class ChromaDB(VectorDB):
+    """Implementation of the VectorDB interface using ChromaDB as the backend."""
+
+    def __init__(self, config, context):
+        super().__init__(config, context)
+        self.chromadb_client = None
+        self.collection = None
+
+        self.shard_index = 0  # The current shard id for insertion
+        self.shard_size = 0  # The number of vectors in the current shard
+
+        # The approximate maximum size of a shard before a new one is created
+        self.shard_size_limit = 41_666
+
+    def connect(self):
+        """Create a database connection"""
+        results_dir = self.context["results_dir"]
+        self.chromadb_client = chromadb.PersistentClient(path=str(results_dir))
+        return self.chromadb_client
+
+    def create(self):
+        """Create a new database"""
+
+        if self.chromadb_client is None:
+            self.connect()
+
+        # Create a chromadb shard (a.k.a. "collection")
+        self.collection = self.chromadb_client.create_collection(
+            name=f"shard_{self.shard_index}",
+            metadata={
+                # These are chromadb defaults, may want to make them configurable
+                "hsnw:space": "l2",
+                "hsnw:construction_ef": 100,
+                "hsnw:search_ef": 100,
+            },
+        )
+
+        return self.collection
+
+    def insert(self, ids: list[Union[str | int]], vectors: list[np.ndarray]):
+        """Insert a batch of vectors into the database.
+
+        Parameters
+        ----------
+        ids : list[Union[str | int]]
+            The ids to associate with the vectors
+        vectors : list[np.ndarray]
+            The vectors to insert into the database
+        """
+
+        # increment counter, if exceeds shard limit, create a new collection
+        self.shard_size += len(ids)
+        if self.shard_size > self.shard_size_limit:
+            self.shard_index += 1
+            self.shard_size = 0
+            self.collection = self.create()
+
+        self.collection.add(ids=ids, embeddings=vectors)
+
+    def search_by_id(self, id: Union[str | int], k: int = 1) -> list[Union[str | int]]:
+        """Get the ids of the k nearest neighbors for a given id in the database.
+        Should use the provided id to look up the vector, then call search_by_vector.
+
+        Parameters
+        ----------
+        id : Union[str | int]
+            The id of the vector in the database for which we want to find the
+            k nearest neighbors
+        k : int, optional
+            The number of nearest neighbors to return, by default 1, return only
+            the closest neighbor
+
+        Returns
+        -------
+        list[Union[str,int]]
+            The ids of the k nearest neighbors
+
+        Raises
+        ------
+        ValueError
+            If more than one vector is found for the given id
+        """
+
+        # create the database connection
+        self.chromadb_client = self.connect()
+
+        # get all the shards
+        shards = self.chromadb_client.list_collections()
+
+        vectors = []
+        for shard in shards:
+            # Get the vector for the id
+            collection = self.chromadb_client.get_collection(id=shard.id)
+            results = collection.get(id, include=["embeddings"])
+
+            vectors.extend(results["embeddings"])
+
+        query_results: list[Union[str | int]] = []
+        # no matching id found in database
+        if len(vectors) == 0:
+            query_results = []
+
+        # multiple matching ids found in database
+        elif len(vectors) > 1:
+            raise ValueError(f"More than one vector found for id: {id}")
+
+        # single matching id found in database
+        else:
+            query_results = self.search_by_vector(vectors[0], k=k)
+
+        return query_results
+
+    def search_by_vector(self, vector: np.ndarray, k: int = 1) -> list[Union[str | int]]:
+        """Get the ids of the k nearest neighbors for a given vector.
+
+        Parameters
+        ----------
+        vector : np.ndarray
+            The vector to use when searching for nearest neighbors
+        k : int, optional
+            The number of nearest neighbors to return, by default 1, return only
+            the closest neighbor
+
+        Returns
+        -------
+        list[Union[str,int]]
+            The ids of the k nearest neighbors
+        """
+
+        # create the database connection
+        self.chromadb_client = self.connect()
+
+        # get all the shards
+        shards = self.chromadb_client.list_collections()
+
+        # Query each shard, return the k nearest neighbors from each shard.
+        ids = []
+        distances = []
+        for shard in shards:
+            # Get the vector for the id
+            collection = self.chromadb_client.get_collection(id=shard.id)
+            results = collection.query(query_embeddings=vector, n_results=k)
+
+            ids.extend(results["ids"][0])
+            distances.extend(results["distances"][0])
+
+        # Sort the distances ascending
+        sorted_indicies = np.argsort(distances, stable=True)
+
+        # Apply the sorting to the ids
+        sorted_ids: list[Union[str | int]] = np.asarray(ids)[sorted_indicies].tolist()
+
+        # Return the k nearest neighbors as a python list
+        return sorted_ids[:k]

--- a/src/fibad/vector_dbs/vector_db_factory.py
+++ b/src/fibad/vector_dbs/vector_db_factory.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+from fibad.vector_dbs.chromadb_impl import ChromaDB
+from fibad.vector_dbs.vector_db_interface import VectorDB
+
+
+def vector_db_factory(config: dict, context: dict) -> Union[VectorDB | None]:
+    """Factory method to create a database object"""
+
+    # if the vector_db name is `False`, return None
+    if not config["vector_db"]["name"]:
+        return None
+
+    vector_db_name = config["vector_db"]["name"]
+
+    if vector_db_name == "chromadb":
+        return ChromaDB(config, context)
+    else:
+        return None

--- a/src/fibad/vector_dbs/vector_db_interface.py
+++ b/src/fibad/vector_dbs/vector_db_interface.py
@@ -1,0 +1,84 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+import numpy as np
+
+
+class VectorDB(ABC):
+    """Interface for a vector database"""
+
+    def __init__(self, config: Optional[dict] = None, context: Optional[dict] = None):
+        """Create a new instance of a `VectorDB` object.
+
+        Parameters
+        ----------
+        config : dict, optional
+            An instance of the runtime configuration, by default None
+        context : dict, optional
+            An instance of the context object, by default None
+        """
+        self.config = config
+        self.context = context
+
+    @abstractmethod
+    def connect(self):
+        """Connect to an existing database"""
+        pass
+
+    @abstractmethod
+    def create(self):
+        """Create a new database"""
+        pass
+
+    @abstractmethod
+    def insert(self, ids: list[Union[str | int]], vectors: list[np.ndarray]):
+        """Insert a batch of vectors into the database.
+
+        Parameters
+        ----------
+        ids : list[Union[str | int]]
+            The ids to associate with the vectors
+        vectors : list[np.ndarray]
+            The vectors to insert into the database
+        """
+        pass
+
+    @abstractmethod
+    def search_by_id(self, id: Union[str | int], k: int = 1) -> list[Union[str, int]]:
+        """Get the ids of the k nearest neighbors for a given id in the database.
+        Should use the provided id to look up the vector, then call search_by_vector.
+
+        Parameters
+        ----------
+        id : Union[str | int]
+            The id of the vector in the database for which we want to find the
+            k nearest neighbors
+        k : int, optional
+            The number of nearest neighbors to return, by default 1, return only
+            the closest neighbor
+
+        Returns
+        -------
+        list[Union[str,int]]
+            The ids of the k nearest neighbors
+        """
+        pass
+
+    @abstractmethod
+    def search_by_vector(self, vector: np.ndarray, k: int = 1) -> list[Union[str, int]]:
+        """Get the ids of the k nearest neighbors for a given vector.
+
+        Parameters
+        ----------
+        vector : np.ndarray
+            The vector to use when searching for nearest neighbors
+        k : int, optional
+            The number of nearest neighbors to return, by default 1, return only
+            the closest neighbor
+
+        Returns
+        -------
+        list[Union[str,int]]
+            The ids of the k nearest neighbors
+        """
+        pass

--- a/src/fibad/vector_dbs/vector_db_interface.py
+++ b/src/fibad/vector_dbs/vector_db_interface.py
@@ -44,7 +44,7 @@ class VectorDB(ABC):
         pass
 
     @abstractmethod
-    def search_by_id(self, id: Union[str | int], k: int = 1) -> list[Union[str, int]]:
+    def search_by_id(self, id: Union[str | int], k: int = 1) -> dict[int, list[Union[str, int]]]:
         """Get the ids of the k nearest neighbors for a given id in the database.
         Should use the provided id to look up the vector, then call search_by_vector.
 
@@ -59,18 +59,19 @@ class VectorDB(ABC):
 
         Returns
         -------
-        list[Union[str,int]]
-            The ids of the k nearest neighbors
+        dict[int, list[Union[str, int]]]
+            Dictionary with input vector index as the key and the ids of the k
+            nearest neighbors as the value.s
         """
         pass
 
     @abstractmethod
-    def search_by_vector(self, vector: np.ndarray, k: int = 1) -> list[Union[str, int]]:
+    def search_by_vector(self, vectors: list[np.ndarray], k: int = 1) -> dict[int, list[Union[str, int]]]:
         """Get the ids of the k nearest neighbors for a given vector.
 
         Parameters
         ----------
-        vector : np.ndarray
+        vectors : np.ndarray
             The vector to use when searching for nearest neighbors
         k : int, optional
             The number of nearest neighbors to return, by default 1, return only
@@ -78,7 +79,8 @@ class VectorDB(ABC):
 
         Returns
         -------
-        list[Union[str,int]]
-            The ids of the k nearest neighbors
+        dict[int, list[Union[str, int]]]
+            Dictionary with input vector index as the key and the ids of the
+            k nearest neighbors as the value.
         """
         pass

--- a/src/fibad/vector_dbs/vector_db_interface.py
+++ b/src/fibad/vector_dbs/vector_db_interface.py
@@ -17,8 +17,8 @@ class VectorDB(ABC):
         context : dict, optional
             An instance of the context object, by default None
         """
-        self.config = config
-        self.context = context
+        self.config = config if config else {}
+        self.context = context if context else {}
 
     @abstractmethod
     def connect(self):


### PR DESCRIPTION
Implementing sharding for the chromadb vector database because we have seen that the insertion times become overly burdensome as total size of the "collection" (database table) becomes large, by some definition of large. 

Sharding helps keep the insertion costs down with the downstream cost of less efficient nearest neighbor look ups. Now we must scan all the shards for nearest neighbors instead of just scanning a single collection.