### PR TITLE
Metadata interface v1 for Datasets

### DIFF
--- a/src/fibad/config_utils.py
+++ b/src/fibad/config_utils.py
@@ -27,6 +27,10 @@ class ConfigDict(dict):
     # values? i.e. a method to make a config dictionary fully immutable (or very difficult/annoying to
     # mutate) before we pass control to possibly external module code that is relying on the dictionary
     # to be static throughout the run.
+    #
+    # Note that we currently modify configdict objects in HSCDataSet as a matter of course
+    # This is to serialize the config used to create them, so it can be kept around in InferenceDatasets
+    # and re-constituted for visualization purposes
 
     __slots__ = ()  # we don't need __dict__ on this object at all.
 

--- a/src/fibad/data_sets/data_set_registry.py
+++ b/src/fibad/data_sets/data_set_registry.py
@@ -17,7 +17,7 @@ def fibad_data_set(cls):
     type
         The original, unmodified class.
     """
-    required_methods = ["shape", "__getitem__", "__len__"]
+    required_methods = ["shape", "__getitem__", "__len__", "ids"]
     for name in required_methods:
         if not hasattr(cls, name):
             logger.error(f"Fibad data set {cls.__name__} missing required method {name}.")

--- a/src/fibad/data_sets/hsc_data_set.py
+++ b/src/fibad/data_sets/hsc_data_set.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
 import numpy as np
+import numpy.typing as npt
 import torch
 from astropy.io import fits
 from astropy.table import Table
@@ -34,12 +35,33 @@ logger = logging.getLogger(__name__)
 dim_dict = dict[str, list[tuple[int, int]]]
 files_dict = dict[str, dict[str, str]]
 
+# Notes on metadata interface
+# What I think I want for visualization:
+#  - You send me a list of IDs (preferably as a numpy array)
+#  - You also send me a set of fields you want
+#
+#  - I give you back a rec array thats ID, Field1, field2, ... with everything you want
+#  - If I don't have what you want you get a warning on partial, and an error when I have nothing for you
+#
+# Another interface we need: Tell me all the fields you have dataset!
+#
+# Alternate interface: You send me a list of indexes and same as above (Same same... but different)
+#
+# But also for HSCDataSet we're looking up in a fits file catalog regardless
+# And the fits file catalog indexes aren't necessarilty the index order of the dataset object
+# (but they might be)
+#
+# There is not a way to make metadata work here unless there's a fits file catalog with the relevant fields
+# So we need to check for that along the metadata call-path and just be like "we have nothing"
+
 
 @fibad_data_set
 class HSCDataSet(Dataset):
     _called_from_test = False
 
-    def __init__(self, config):
+    def __init__(self, config: dict):
+        self.config = config
+
         crop_to = config["data_set"]["crop_to"]
         filters = config["data_set"]["filters"]
         transform_str = config["data_set"]["transform"]
@@ -60,16 +82,16 @@ class HSCDataSet(Dataset):
         elif not rebuild_manifest:
             filter_catalog = Path(config["general"]["data_dir"]) / Downloader.MANIFEST_FILE_NAME
             if not filter_catalog.exists():
-                filter_catalog = False
+                filter_catalog = None
         else:
-            filter_catalog = False
+            filter_catalog = None
 
         self._init_from_path(
             config["general"]["data_dir"],
             transform=transform,
             cutout_shape=crop_to if crop_to else None,
             filters=filters if filters else None,
-            filter_catalog=Path(filter_catalog) if filter_catalog else None,
+            filter_catalog=filter_catalog,
         )
 
     def _get_np_function(self, transform_str: str) -> Callable[..., Any]:
@@ -134,7 +156,14 @@ class HSCDataSet(Dataset):
         self.path = path
         self.transform = transform
 
-        self.filter_catalog = self._read_filter_catalog(filter_catalog)
+        self.filter_catalog_table = self._read_filter_catalog(filter_catalog)
+
+        self.filter_catalog = (
+            None
+            if self.filter_catalog_table is None
+            else self._parse_filter_catalog(self.filter_catalog_table)
+        )
+
         if isinstance(self.filter_catalog, tuple):
             self.files = self.filter_catalog[0]
             self.dims = self.filter_catalog[1]
@@ -224,9 +253,7 @@ class HSCDataSet(Dataset):
 
         return files
 
-    def _read_filter_catalog(
-        self, filter_catalog_path: Optional[Path]
-    ) -> Optional[Union[list[str], files_dict, tuple[files_dict, dim_dict]]]:
+    def _read_filter_catalog(self, filter_catalog_path: Optional[Path]) -> Table:
         if filter_catalog_path is None:
             return None
 
@@ -236,19 +263,31 @@ class HSCDataSet(Dataset):
 
         table = Table.read(filter_catalog_path, format="fits")
         colnames = table.colnames
+
         if "object_id" not in colnames:
             logger.error(f"Filter catalog file {filter_catalog_path} has no column object_id")
             return None
 
+        table.add_index("object_id")
+        table.add_index("filter")
+
+        if ("filter" not in colnames) ^ ("filename" not in colnames):
+            msg = f"Filter catalog file {filter_catalog_path} provides one of filters or filenames "
+            msg += "without the other. Filesystem scan will still occur without both defined."
+            logger.warning(msg)
+
+        return table
+
+    def _parse_filter_catalog(
+        self, table: Table
+    ) -> Optional[Union[list[str], files_dict, tuple[files_dict, dim_dict]]]:
+        colnames = table.colnames
         # We are dealing with just a list of object_ids
         if "filter" not in colnames and "filename" not in colnames:
             return list(table["object_id"])
 
         # Or a table that lacks both filter and filename
         elif "filter" not in colnames or "filename" not in colnames:
-            msg = f"Filter catalog file {filter_catalog_path} provides one of filters or filenames "
-            msg += "without the other. Filesystem scan will still occur without both defined."
-            logger.warning(msg)
             return list(set(table["object_id"]))
 
         # We have filter and filename defined so we can assemble the catalog at file level.
@@ -643,7 +682,7 @@ class HSCDataSet(Dataset):
         filter = filter_names[index % self.num_filters]
         return self._file_to_path(filters[filter])
 
-    def ids(self, log_every=None) -> Generator[str, None, None]:
+    def ids(self, log_every=None) -> Generator[str]:
         """Public read-only iterator over all object_ids that enforces a strict total order across
         objects. Will not work prior to self.files initialization in __init__
 
@@ -656,7 +695,7 @@ class HSCDataSet(Dataset):
         for index, object_id in enumerate(self.files):
             if log and index != 0 and index % log_every == 0:
                 logger.info(f"Processed {index} objects")
-            yield object_id
+            yield str(object_id)
         else:
             if log:
                 logger.info(f"Processed {index} objects")
@@ -804,3 +843,66 @@ class HSCDataSet(Dataset):
             self.tensors[object_id] = data_torch
 
         return data_torch
+
+    def original_config(self) -> dict:
+        # Resolve the paths on configs which we depend on to initialize repeatably.
+        # This allows this method to be used to serialize the config used to create this dataset
+        # so that it can be repeatably re-created no matter what cwd is in future fibad invocations
+        config = self.config
+        config["data_set"]["filter_catalog"] = (
+            str(Path(config["data_set"]["filter_catalog"]).resolve())
+            if config["data_set"]["filter_catalog"]
+            else False
+        )
+        config["general"]["data_dir"] = (
+            str(Path(config["general"]["data_dir"]).resolve()) if config["general"]["data_dir"] else False
+        )
+
+        return config
+
+    def metadata_fields(self) -> list[str]:
+        """Metadata field names for the HSCDataSet.
+
+        This will return an empty list of fields if there was no filter catalog, and is inherently limited
+        to fields in the filter catalog provided.
+
+        Returns
+        -------
+        list[str]
+            Strings with the names of all metadata fields that can be looked up for a given
+            datum in this dataset
+        """
+        if self.filter_catalog_table is None:
+            return []
+
+        colnames = list(self.filter_catalog_table.colnames)
+
+        # We don't expose these per object_id, because they have a multiplicy of values for each object_id
+        colnames.remove("filename")
+        colnames.remove("filter")
+
+        return colnames
+
+    def metadata(self, idxs: npt.ArrayLike, fields: list[str]) -> npt.ArrayLike:
+        # Determine what fields we will be processing
+        metadata_fields = self.metadata_fields()
+        for field in fields:
+            if field not in metadata_fields:
+                msg = f"Field {field} is not available for this HSCDataSet."
+                logger.error(msg)
+
+        columns = [field for field in fields if field in metadata_fields]
+
+        if len(columns) == 0:
+            msg = f"None of the metadata fields passed [{fields}] are available for this HSCDataSet."
+            raise RuntimeError(msg)
+
+        # Find the object IDs corresponding to indicies passed
+        object_ids = np.array(list(self.files.keys()))[idxs]  # type: ignore[index]
+
+        # Query our catalog table based on the object IDs, deduplicating by filter
+        metadata_filter_dup = self.filter_catalog_table.loc["object_id", object_ids]
+        metadata_slice = metadata_filter_dup.loc["filter", self.filters_ref[0]]
+
+        # Slice out only the columns asked for.
+        return metadata_slice[columns].as_array()  # type: ignore[no-any-return]

--- a/src/fibad/infer.py
+++ b/src/fibad/infer.py
@@ -55,16 +55,12 @@ def run(config: ConfigDict):
             },
         )
 
-    data_writer = InferenceDataSetWriter(results_dir)
+    data_writer = InferenceDataSetWriter(data_set, results_dir)
 
     # These are values the _save_batch callback needs to run
     write_index = 0
     batch_index = 0
-    object_ids: list[int] = []
-    if hasattr(data_set, "ids"):
-        object_ids = list(int(id) for id in data_set.ids())
-    else:
-        object_ids = list(range(len(data_set)))  # type: ignore[arg-type]
+    object_ids = list(int(id) for id in data_set.ids())  # type: ignore[attr-defined]
 
     def _save_batch(batch_results: Tensor):
         """Receive and write results tensors to results_dir immediately

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -27,7 +27,7 @@ from fibad.models.model_registry import fetch_model_class
 logger = logging.getLogger(__name__)
 
 
-def setup_dataset(config: ConfigDict, split: Union[str, bool] = False) -> Dataset:
+def setup_dataset(config: Union[ConfigDict, dict], split: Union[str, bool] = False) -> Dataset:
     """Create a dataset object based on the configuration.
 
     Parameters

--- a/src/fibad/verbs/umap.py
+++ b/src/fibad/verbs/umap.py
@@ -78,14 +78,14 @@ class Umap(Verb):
 
         self.reducer = umap.UMAP(**self.config["umap.UMAP"])
 
-        # Set up the results directory where we will store our umapped output
-        results_dir = create_results_dir(self.config, "umap")
-        logger.info(f"Saving UMAP results to {results_dir}")
-        umap_results = InferenceDataSetWriter(results_dir)
-
         # Load all the latent space data.
         inference_results = InferenceDataSet(self.config, results_dir=input_dir)
         total_length = len(inference_results)
+
+        # Set up the results directory where we will store our umapped output
+        results_dir = create_results_dir(self.config, "umap")
+        logger.info(f"Saving UMAP results to {results_dir}")
+        umap_results = InferenceDataSetWriter(inference_results, results_dir)
 
         # Sample the data to fit
         config_sample_size = self.config["umap"]["fit_sample_size"]
@@ -129,7 +129,7 @@ class Umap(Verb):
             # imap returns results as they complete so writing should complete in parallel for large datasets
             for batch_ids, transformed_batch in tqdm(
                 pool.imap(self._transform_batch, args),
-                desc="Creating LowerDimensional Representation using UMAP:",
+                desc="Creating lower dimensional representation using UMAP:",
                 total=num_batches,
             ):
                 logger.debug("Writing a batch out async...")

--- a/src/fibad/verbs/visualize.py
+++ b/src/fibad/verbs/visualize.py
@@ -49,15 +49,32 @@ class Visualize(Verb):
         Holoview
             Combined holoview object
         """
-        from holoviews import DynamicMap, Table, extension
+        from holoviews import DynamicMap, extension
         from holoviews.operation.datashader import dynspread, rasterize
         from holoviews.streams import Lasso, RangeXY, SelectionXY, Tap
         from scipy.spatial import KDTree
 
         from fibad.data_sets.inference_dataset import InferenceDataSet
 
+        # TODO xcxc Is this an argument?
+        fields = ["object_id", "ra", "dec"]
+
         # Get the umap data and put it in a kdtree for indexing.
         self.umap_results = InferenceDataSet(self.config, results_dir=input_dir, verb="umap")
+
+        available_fields = self.umap_results.metadata_fields()
+        for field in fields.copy():
+            if field not in available_fields:
+                logger.warning(f"Field {field} is unavailable for this dataset")
+                fields.remove(field)
+
+        if "object_id" not in fields:
+            msg = "Umap dataset much support object_id field"
+            raise RuntimeError(msg)
+
+        self.data_fields = fields.copy()
+        self.data_fields.remove("object_id")
+
         self.tree = KDTree(self.umap_results)
 
         # Initialize holoviews with bokeh.
@@ -97,7 +114,10 @@ class Visualize(Verb):
         ]
 
         # Setup the table pane
-        self.table = Table(([0], [0], [0]), ["object_id"], ["x", "y"])
+        # self.table = Table(tuple([[0]]*(3+len(self.data_fields))), ["object_id"], self.data_fields)
+        self.points = np.array([])
+        self.points_id = np.array([])
+        self.table = self._table_from_points()
         table_options = {"width": plot_options["width"]}
         table_pane = DynamicMap(self.selected_objects, streams=table_streams).opts(**table_options)
 
@@ -145,30 +165,51 @@ class Visualize(Verb):
         hv.Table
             Table with Object ID, x, y locations of the selected objects
         """
-        from holoviews import Table
 
         if self._called_lasso(kwargs):
-            points, points_id = self.poly_select_points(kwargs["geometry"])
+            self.points, self.points_id, self.points_idx = self.poly_select_points(kwargs["geometry"])
         elif self._called_tap(kwargs):
-            _, id = self.tree.query([kwargs["x"], kwargs["y"]])
-            points = np.array([self.umap_results[id].numpy()])
-            points_id = np.array([str(id)])
+            _, idx = self.tree.query([kwargs["x"], kwargs["y"]])
+            self.points = np.array([self.umap_results[idx].numpy()])
+            self.points_id = np.array([list(self.umap_results.ids())[idx]])
+            self.points_idx = np.array([idx])
         elif self._called_box_select(kwargs):
-            points, points_id = self.box_select_points(kwargs["x_selection"], kwargs["y_selection"])
+            self.points, self.points_id, self.points_idx = self.box_select_points(
+                kwargs["x_selection"], kwargs["y_selection"]
+            )
         else:
             # We return whatever cached table state we have if we were not called by any event
             # This normally happens during initialization.
             self.prev_kwargs = kwargs
             return self.table
 
-        # Basic table with x/y pairs
-        if len(points_id):
-            self.table = Table((points_id, points.T[0], points.T[1]), ["id"], ["x", "y"])
-        else:
-            self.table = Table(([0], [0], [0]), ["id"], ["x", "y"])
+        self.table = self._table_from_points()
 
         self.prev_kwargs = kwargs
         return self.table
+
+    def _table_from_points(self) -> Table:
+        # Basic table with x/y pairs
+        key_dims = ["object_id"]
+        value_dims = ["x", "y"] + self.data_fields
+
+        if not len(self.points_id):
+            columns = [[1]] * (len(key_dims) + len(value_dims))
+            return Table(tuple(columns), key_dims, value_dims)
+
+        # these are the object_id, x, and y columns
+        columns = [self.points_id, self.points.T[0], self.points.T[1]]  # type: ignore[list-item]
+
+        # These are the rest of the columns, pulled from metadata
+        try:
+            metadata = self.umap_results.metadata(self.points_idx, self.data_fields)
+        except Exception as e:
+            # Leave in this try/catch beause some notebook implementations dont
+            # allow us to return an exception to the console.
+            return Table(([str(e)]), ["message"])
+
+        columns += [metadata[field] for field in self.data_fields]  # type: ignore[call-overload,misc,index]
+        return Table(tuple(columns), key_dims, value_dims)
 
     def _called_lasso(self, kwargs):
         return kwargs["geometry"] is not None and (
@@ -197,7 +238,7 @@ class Visualize(Verb):
             )
         )
 
-    def poly_select_points(self, geometry) -> tuple[np.ndarray, np.ndarray]:
+    def poly_select_points(self, geometry) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Select points inside a polygon.
 
         Parameters
@@ -227,13 +268,13 @@ class Visualize(Verb):
             points = points_coarse[mask]
             point_indexes = np.array(point_indexes_coarse)[mask]
             points_id = np.array(list(self.umap_results.ids()))[point_indexes]
-            return points, points_id
+            return points, points_id, point_indexes
         else:
-            return np.array([[]]), np.array([])
+            return np.array([[]]), np.array([]), np.array([])
 
     def box_select_points(
         self, x_range: Union[tuple, list], y_range: Union[tuple, list]
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Return the points and IDs for a box in the latent space
 
         Parameters
@@ -251,7 +292,7 @@ class Visualize(Verb):
         """
         indexes = self.box_select_indexes(x_range, y_range)
         ids = np.array(list(self.umap_results.ids()))[indexes]
-        return self.umap_results[indexes].numpy(), ids
+        return self.umap_results[indexes].numpy(), ids, indexes
 
     def box_select_indexes(self, x_range: Union[tuple, list], y_range: Union[tuple, list]):
         """Return the indexes inside of a particular box in the latent space


### PR DESCRIPTION
- HSCDataSet, InferenceDataSet, and CifarDataSet all have:
  - original_config() to fetch the config required to (re)create the dataset with the metadata
  - metadata_fields() which returns a list of metadata fields
  - metadata() which takes a set of indexes and fields and fills out a table of metadata, passing it back.
- InferenceDatasetWriter saves out the original config for a given dataset
- InferenceDataSet reads in the original config from its f/s rather than using the runtime config as the other datasets do
- infer, umap, and visualize verbs are all modified to use the new interfaces
- visualize verb currently hardcodes ra/dec as metadata fields and displays ra/dec in a table as a POC.

