### PR TITLE
Add a check for malformed manifest files

### DIFF
--- a/.setup_dev.sh
+++ b/.setup_dev.sh
@@ -34,7 +34,7 @@ python -m pip install -e . > /dev/null
 echo "Installing developer dependencies in local environment"
 echo "This might take a few minutes. Only errors will be printed to stdout"
 python -m pip install -e .'[dev]' > /dev/null
-if [ -f docs/requirements.txt ]; then python -m pip install -r docs/requirements.txt; fi
+if [ -f docs/requirements.txt ]; then python -m pip install -r docs/requirements.txt > /dev/null; fi
 
 echo "Installing pre-commit"
 pre-commit install > /dev/null


### PR DESCRIPTION
- When manifest or filter_catalog files contain filenames that are obviously for the wrong object ID, we will drop the relevant object and emit a warning
- Testing system extended to allow tests for malformed manifests to be written.
- Small fixup to .setup_dev.sh script to make sure that it's promise to "not output logs" unless there is an error is actually true.