### PR TITLE
Instrumenting HSCDataSet using TensorBoardX

### DIFF
--- a/src/fibad/prepare.py
+++ b/src/fibad/prepare.py
@@ -15,7 +15,7 @@ def run(config):
         dict
     """
 
-    data_set = setup_dataset(config, split=config["train"]["split"])
+    data_set = setup_dataset(config)
 
     logger.info("Finished Prepare")
     return data_set

--- a/src/fibad/pytorch_ignite.py
+++ b/src/fibad/pytorch_ignite.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Union
+from typing import Any, Callable, Optional, Union
 
 import ignite.distributed as idist
 import numpy as np
@@ -27,16 +27,15 @@ from fibad.models.model_registry import fetch_model_class
 logger = logging.getLogger(__name__)
 
 
-def setup_dataset(config: Union[ConfigDict, dict], split: Union[str, bool] = False) -> Dataset:
+def setup_dataset(config: ConfigDict, tensorboardx_logger: Optional[SummaryWriter] = None) -> Dataset:
     """Create a dataset object based on the configuration.
 
     Parameters
     ----------
     config : ConfigDict
         The entire runtime configuration
-    split : Union[str,bool], optional
-        The name of the split that we want to use. If False, use the entire
-        dataset, by default False
+    tensorboardx_logger : SummaryWriter, optional
+        If Tensorboard is in use, the tensorboard logger so the dataset can log things
 
     Returns
     -------
@@ -47,6 +46,10 @@ def setup_dataset(config: Union[ConfigDict, dict], split: Union[str, bool] = Fal
     # Fetch data loader class specified in config and create an instance of it
     data_set_cls = fetch_data_set_class(config)
     data_set = data_set_cls(config)  # type: ignore[call-arg]
+
+    # TODO base dataset class: A base class for datasets ought have this as a property defined simply
+    # to document its existance in a central location.
+    data_set.tensorboardx_logger = tensorboardx_logger  # type: ignore[attr-defined]
 
     return data_set
 

--- a/src/fibad/rebuild_manifest.py
+++ b/src/fibad/rebuild_manifest.py
@@ -18,7 +18,7 @@ def run(config):
 
     config["rebuild_manifest"] = True
 
-    data_set = setup_dataset(config, split=config["train"]["split"])
+    data_set = setup_dataset(config)
 
     if not isinstance(data_set, HSCDataSet):
         msg = "Invalid to run rebuild manafest except on an HSCDataSet."

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -35,7 +35,7 @@ def run(config):
     tensorboardx_logger = SummaryWriter(log_dir=results_dir)
 
     # Instantiate the model and dataset
-    data_set = setup_dataset(config, split=config["train"]["split"])
+    data_set = setup_dataset(config, tensorboardx_logger)
     model = setup_model(config, data_set)
 
     # Create a data loader for the training set (and validation split if configured)


### PR DESCRIPTION
- New interface on setup_dataset to provide a tensorboardx logger to datasets right after construction.
- Datasets need not define the attribute setup_dataset sets, so logging metrics is entirely optional for a dataset writer
- File caching and reading in HSCDataSet are extensively measured
- Measurements use time.monotoinic_ns(), are logged as floating point numbers of seconds
- The time series given to tensorboard uses integer microseconds as the y axis.
- Tensorboard metrics are logged for datasets during infer runs as well.
