### PR TITLE
First implementation of cache warming for HSCDataSet

### DIFF
--- a/docs/pre_executed/mpr_demo.ipynb
+++ b/docs/pre_executed/mpr_demo.ipynb
@@ -98,12 +98,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Specify the location of the data to use for training\n",
-    "f.config[\"general\"][\"data_dir\"] = \"../../data/hsc_8asec_1000_bu\"\n",
+    "f.config[\"general\"][\"data_dir\"] = \"../../data/hsc_8asec_1000\"\n",
     "\n",
     "# Specify the dataset class that represents the data\n",
     "f.config[\"data_set\"][\"name\"] = \"HSCDataSet\"\n",

--- a/src/fibad/fibad_default_config.toml
+++ b/src/fibad/fibad_default_config.toml
@@ -190,6 +190,10 @@ seed = false
 # first epoch. Set to `false` when running inference or on memory-constrained systems.
 use_cache = true
 
+# If `true`, preload the in memory cache using many worker threads when the dataset is constructed 
+# to reduce the effect of filesystem latency on first epoch runtime. 
+# Warning: Only suitable for situations where the entire dataset fits in system memory
+preload_cache = true
 
 [data_loader]
 # The number of data points to load at once.

--- a/src/fibad/train.py
+++ b/src/fibad/train.py
@@ -43,10 +43,6 @@ def run(config):
     train_data_loader = data_loaders["train"]
     validation_data_loader = data_loaders["validate"]
 
-    # Get a sample of input data. If the data is labeled, only return the input data.
-    batch_sample = next(iter(train_data_loader))
-    sample = batch_sample[0] if isinstance(batch_sample, (list, tuple)) else batch_sample
-
     # Create trainer, a pytorch-ignite `Engine` object
     trainer = create_trainer(model, config, results_dir, tensorboardx_logger)
 
@@ -86,6 +82,10 @@ def run(config):
         "ml_framework": "pytorch",
         "results_dir": results_dir,
     }
+
+    # Get a sample of input data. If the data is labeled, only return the input data.
+    batch_sample = next(iter(train_data_loader))
+    sample = batch_sample[0] if isinstance(batch_sample, (list, tuple)) else batch_sample
 
     export_to_onnx(model, sample, config, context)
 

--- a/tests/fibad/test_hsc_dataset.py
+++ b/tests/fibad/test_hsc_dataset.py
@@ -86,6 +86,7 @@ def mkconfig(
             "filter_catalog": filter_catalog,
             "use_cache": use_cache,
             "transform": transform,
+            "preload_cache": False,  # Don't run the preloading in unit tests, because it needs real data.
         },
     }
 


### PR DESCRIPTION
This spawns a pre-cache thread during HSCDataSet initialization. The pre-cache thread starts many worker threads that read in all the dataset files to the tensor cache. The idea is to confront a latency-limited network storage backend with a large number of requests all at once, such that we will receive the files in memory at the greatest overall bandwidth.

This change also logs a `HSCDataSet/preload_1k_obj_s` metric to tensorboard which should give an idea of object bandwidth. It is the elapsed time to load 1000 objects measured every 1000 objects.

The change is protected under a config `config["data_set"]["preload_cache"]` The config is on by default (similar to `use_cache`) because it should be harmless for small datasets and laptop usage.
