### PR TITLE
Fixing config name conflict bug in DownloadedLSSTData

### DIFF
--- a/src/hyrax/data_sets/downloaded_lsst_dataset.py
+++ b/src/hyrax/data_sets/downloaded_lsst_dataset.py
@@ -80,7 +80,8 @@ class DownloadedLSSTDataset(LSSTDataset):
         self.download_dir = Path(config["general"]["data_dir"])
         self.download_dir.mkdir(exist_ok=True)
 
-        self.config = config
+        # Preventing name collision with parent class config
+        self._config = config
 
         # Initialize parent class with config
         super().__init__(config)
@@ -106,9 +107,9 @@ class DownloadedLSSTDataset(LSSTDataset):
         catalog_columns = self.catalog.colnames if hasattr(self.catalog, "colnames") else self.catalog.columns
 
         self.use_object_id = False
-        if self.config["data_set"]["object_id_column_name"]:
+        if self._config["data_set"]["object_id_column_name"]:
             self.use_object_id = True
-            self.object_id_column = self.config["data_set"]["object_id_column_name"]
+            self.object_id_column = self._config["data_set"]["object_id_column_name"]
         elif "object_id" in catalog_columns:
             self.use_object_id = True
             self.object_id_column = "object_id"


### PR DESCRIPTION
`self.config = config` conflicts with the parent dataset class(es) that `DownloadedLSSTData` inherits from. 

Changing this to `self._config = config`