### PR TITLE
Pulling `colorama` in as a dependency to highlight the model and data being used for training and inference.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "psutil", # Used for memory monitoring
     "tqdm", # Used to show progress bars
     "qdrant-client", # Vector database for similarity search
+    "colorama", # Used to color terminal output
 ]
 
 [project.scripts]

--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 from typing import Optional, Union
 
+from colorama import Back, Fore, Style
+
 from .verb_registry import Verb, hyrax_verb
 
 logger = logging.getLogger(__name__)
@@ -61,7 +63,11 @@ class Infer(Verb):
         tensorboardx_logger = SummaryWriter(log_dir=results_dir)
 
         dataset = setup_dataset(config, tensorboardx_logger)
+        logger.info(
+            f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Inference dataset(s):{Style.RESET_ALL}\n{dataset}"
+        )
         model = setup_model(config, dataset)
+        logger.info(f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Inference model:{Style.RESET_ALL}\n{model}")
         if dataset.is_map():
             logger.debug(f"data set has length {len(dataset)}")  # type: ignore[arg-type]
 

--- a/src/hyrax/verbs/train.py
+++ b/src/hyrax/verbs/train.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+from colorama import Back, Fore, Style
+
 from .verb_registry import Verb, hyrax_verb
 
 logger = logging.getLogger(__name__)
@@ -57,7 +59,9 @@ class Train(Verb):
 
         # Instantiate the model and dataset
         dataset = setup_dataset(config, tensorboardx_logger)
+        logger.info(f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Training dataset(s):{Style.RESET_ALL}\n{dataset}")
         model = setup_model(config, dataset)
+        logger.info(f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Training model:{Style.RESET_ALL}\n{model}")
 
         # Create a data loader for the training set (and validation split if configured)
         data_loaders = dist_data_loader(dataset, config, ["train", "validate"])


### PR DESCRIPTION
Despite the amount of logging produced by Hyrax, one thing that wasn't logged was the data and model used for training and inference. 

This PR adds (loud) logging lines that show the data and the model being used. Example screen shot from a notebook:
<img width="821" height="806" alt="Screenshot 2025-10-07 at 2 20 28 PM" src="https://github.com/user-attachments/assets/f1b4c353-a10b-4fa5-ac75-27229fa6aa7a" />
