### PR TITLE
Adding `onnxscript` dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "pooch", # Used to download data files
     "onnx", # Used to export models to ONNX format
     "onnxruntime", # Used to run ONNX models
+    "onnxscript", # Used to convert PyTorch models to ONNX format
     "plotly", # Used in 3d visualization
     "psutil", # Used for memory monitoring
     "tqdm", # Used to show progress bars


### PR DESCRIPTION
See the failing workflow https://github.com/lincc-frameworks/hyrax/actions/runs/18552893012/job/52883692299 as an example. These workflows started failling yesterday. Python 3.9 seems unaffected because it is no longer supported by onnx, and onnxruntime