### PR TITLE
Reduce verbosity of model logging

### DIFF
--- a/src/hyrax/verbs/infer.py
+++ b/src/hyrax/verbs/infer.py
@@ -63,11 +63,14 @@ class Infer(Verb):
         tensorboardx_logger = SummaryWriter(log_dir=results_dir)
 
         dataset = setup_dataset(config, tensorboardx_logger)
+        model = setup_model(config, dataset)
+        logger.info(
+            f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Inference model:{Style.RESET_ALL} "
+            f"{model.__class__.__name__}"
+        )
         logger.info(
             f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Inference dataset(s):{Style.RESET_ALL}\n{dataset}"
         )
-        model = setup_model(config, dataset)
-        logger.info(f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Inference model:{Style.RESET_ALL}\n{model}")
         if dataset.is_map():
             logger.debug(f"data set has length {len(dataset)}")  # type: ignore[arg-type]
 

--- a/src/hyrax/verbs/train.py
+++ b/src/hyrax/verbs/train.py
@@ -60,7 +60,10 @@ class Train(Verb):
         # Instantiate the model and dataset
         dataset = setup_dataset(config, tensorboardx_logger)
         model = setup_model(config, dataset)
-        logger.info(f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Training model:{Style.RESET_ALL} {model.__class__.__name__}")
+        logger.info(
+            f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Training model:{Style.RESET_ALL} "
+            f"{model.__class__.__name__}"
+        )
         logger.info(f"{Style.BRIGHT}{Fore.BLACK}{Back.GREEN}Training dataset(s):{Style.RESET_ALL}\n{dataset}")
 
         # Create a data loader for the training set (and validation split if configured)


### PR DESCRIPTION
When running train or infer, the logging for which model is being trained is verbose and unhelpful. All we really need is the model name.

<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
