### PR TITLE
Timing diagnostics

### DIFF
--- a/src/hyrax/data_sets/random/hyrax_random_dataset.py
+++ b/src/hyrax/data_sets/random/hyrax_random_dataset.py
@@ -1,10 +1,9 @@
-import time
-
 import numpy as np
 from astropy.table import Table
 from torch.utils.data import Dataset, IterableDataset
 
 from hyrax.data_sets.data_set_registry import HyraxDataset
+from hyrax.data_sets.timing import report_duration_to_tensorboard
 
 INVALID_VALUES = {
     "nan": np.nan,
@@ -137,12 +136,10 @@ class HyraxRandomDatasetBase:
 
         self.data_location = data_location
 
+    @report_duration_to_tensorboard
     def get_image(self, idx: int) -> np.ndarray:
         """Get the image at the given index as a NumPy array."""
-        start_time = time.monotonic_ns()
-        image = self.data[idx]
-        self.log_duration_tensorboard("get_image", start_time)
-        return image
+        return self.data[idx]
 
     def get_label(self, idx: int) -> str:
         """Get the label at the given index."""

--- a/src/hyrax/data_sets/random/hyrax_random_dataset.py
+++ b/src/hyrax/data_sets/random/hyrax_random_dataset.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 from astropy.table import Table
 from torch.utils.data import Dataset, IterableDataset
@@ -137,7 +139,10 @@ class HyraxRandomDatasetBase:
 
     def get_image(self, idx: int) -> np.ndarray:
         """Get the image at the given index as a NumPy array."""
-        return self.data[idx]
+        start_time = time.monotonic_ns()
+        image = self.data[idx]
+        self.log_duration_tensorboard("get_image", start_time)
+        return image
 
     def get_label(self, idx: int) -> str:
         """Get the label at the given index."""

--- a/src/hyrax/data_sets/timing.py
+++ b/src/hyrax/data_sets/timing.py
@@ -1,0 +1,53 @@
+import contextlib
+import functools
+import time
+from typing import Callable
+
+
+def report_duration_to_tensorboard(report_every: int = 100):
+    """
+    Decorator for dataset instance methods that reports total run time to
+    tensorboard via `self.log_duration_tensorboard(method_name, start_ns)`.
+
+    Usage:
+      @report_duration_to_tensorboard
+      def get_image(...): ...
+
+      @report_duration_to_tensorboard(50)
+      def get_image(...): ...
+
+    The emitted metric name will always be the wrapped method's __name__.
+    """
+    # Support using the decorator without parentheses: @report_duration_to_tensorboard
+    if callable(report_every):
+        fn = report_every  # type: ignore
+        report_every = 100
+        return report_duration_to_tensorboard(report_every)(fn)
+
+    def decorator(fn: Callable):
+        @functools.wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            start_ns = time.monotonic_ns()
+            result = fn(self, *args, **kwargs)
+
+            # ensure counter storage on the instance
+            counters = getattr(self, "_timing_counters", None)
+            if counters is None:
+                counters = {}
+                self._timing_counters = counters
+
+            evt_name = fn.__name__
+            cnt = counters.get(evt_name, 0) + 1
+            counters[evt_name] = cnt
+
+            if report_every > 0 and (cnt % report_every == 0):
+                log_fn = getattr(self, "log_duration_tensorboard", None)
+                if callable(log_fn):
+                    with contextlib.suppress(Exception):
+                        # pass the method name to the logger
+                        log_fn(evt_name, start_ns)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -717,7 +717,7 @@ def create_trainer(
         logger.debug(f"Epoch {trainer.state.epoch} run time: {trainer.state.times['EPOCH_COMPLETED']:.2f}[s]")
         logger.debug(f"Epoch {trainer.state.epoch} metrics: {trainer.state.output}")
         tensorboardx_logger.add_scalar(
-            "training/training/epoch_duration_sec",
+            "training/epoch_duration_sec",
             trainer.state.times["EPOCH_COMPLETED"],
             trainer.state.epoch,
         )

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -716,6 +716,11 @@ def create_trainer(
     def log_training_loss(trainer):
         logger.debug(f"Epoch {trainer.state.epoch} run time: {trainer.state.times['EPOCH_COMPLETED']:.2f}[s]")
         logger.debug(f"Epoch {trainer.state.epoch} metrics: {trainer.state.output}")
+        tensorboardx_logger.add_scalar(
+            "training/training/epoch_duration_sec",
+            trainer.state.times["EPOCH_COMPLETED"],
+            trainer.state.epoch,
+        )
 
     trainer.add_event_handler(HyraxEvents.HYRAX_EPOCH_COMPLETED, latest_checkpoint)
     trainer.add_event_handler(HyraxEvents.HYRAX_EPOCH_COMPLETED, best_checkpoint)


### PR DESCRIPTION
This PR adds timing diagnostics in lots of places all around Hyrax. 
- Moved `_log_duration_tensorboard` out of `fits_image_dataset` into `HyraxDataset` so that all datasets have access to this function.
- Added an example of logging durations to `HyraxRandomDataset`.
- Added duration metric to end of epoch hook in `pytorch_ignite` for the trainer engine