### PR TITLE
Add semi-hidden feature to allow recording metrics at the end of each training epoch

### DIFF
--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -717,6 +717,17 @@ def create_trainer(
         logger.debug(f"Epoch {trainer.state.epoch} run time: {trainer.state.times['EPOCH_COMPLETED']:.2f}[s]")
         logger.debug(f"Epoch {trainer.state.epoch} metrics: {trainer.state.output}")
 
+    @trainer.on(HyraxEvents.HYRAX_EPOCH_COMPLETED)
+    def log_epoch_metrics(trainer):
+        if hasattr(model, "log_epoch_metrics"):
+            epoch_number = trainer.state.epoch
+            epoch_metrics = model.log_epoch_metrics()
+            for m in epoch_metrics:
+                tensorboardx_logger.add_scalar(
+                    f"training/training/epoch/{m}", epoch_metrics[m], global_step=epoch_number
+                )
+                mlflow.log_metrics({f"training/epoch/{m}": epoch_metrics[m]}, step=epoch_number)
+
     trainer.add_event_handler(HyraxEvents.HYRAX_EPOCH_COMPLETED, latest_checkpoint)
     trainer.add_event_handler(HyraxEvents.HYRAX_EPOCH_COMPLETED, best_checkpoint)
 


### PR DESCRIPTION
This change add a new event handler to the training engine that will look for a model method named `log_epoch_metrics`. If found, it will call the method on the model at the end of each training epoch. 

It is expected (though not enforced) that `log_epoch_metrics` will return a dictionary similar to what `train_step` returns. We will then log each key of the dictionary under `training/training/epoch/<foo>` in TensorBoard or `training/epoch/<foo>` in MLFlow. 

The anticipated use case is that model developers will accumulate values in `train_step` over the course of an epoch, then use those values to calculate a metric at the end of the epoch before resetting the accumulators. 

Just a simple example after implementing `log_epoch_metrics` in HyraxAutoencoder that returns 3 "metrics" with random values over the course of training for 5 epochs.
<img width="1752" height="699" alt="Screenshot 2025-11-20 at 12 04 43 PM" src="https://github.com/user-attachments/assets/693fa505-6b74-436f-8fc4-2eadf52a2358" />
