### PR TITLE
Fix _get_available_bands_from_manifest to find complete band entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
     "sphinx-togglebutton",
     "sphinx-rtd-theme",
     "lsdb", # Used to test lsst dataset classes
+    "cdshealpix <= 0.7.1",
 ]
 
 [build-system]

--- a/src/hyrax/data_sets/downloaded_lsst_dataset.py
+++ b/src/hyrax/data_sets/downloaded_lsst_dataset.py
@@ -394,7 +394,7 @@ class DownloadedLSSTDataset(LSSTDataset, TensorCacheMixin):
 
         # Now find first 5 entries where downloaded_bands has the expected count
         complete_entries = []
-        give_up_idx = min(len(manifest), 1000)  
+        give_up_idx = min(len(manifest), 1000)
 
         for i in range(give_up_idx):
             if len(complete_entries) >= 5:

--- a/src/hyrax/data_sets/downloaded_lsst_dataset.py
+++ b/src/hyrax/data_sets/downloaded_lsst_dataset.py
@@ -419,7 +419,7 @@ class DownloadedLSSTDataset(LSSTDataset, TensorCacheMixin):
             raise RuntimeError(
                 f"No entries found with complete band coverage. Expected {expected_band_count} bands "
                 f"based on cutout_shape, but less than 5 downloaded entries have all bands present. "
-                f"Cannot automatically deterrmine consistent band structure."
+                f"Cannot automatically determine consistent band structure."
             )
 
         # Check that all complete entries have identical band lists

--- a/src/hyrax/data_sets/downloaded_lsst_dataset.py
+++ b/src/hyrax/data_sets/downloaded_lsst_dataset.py
@@ -371,17 +371,33 @@ class DownloadedLSSTDataset(LSSTDataset, TensorCacheMixin):
         return np.argmax([len(str(id)) for id in object_ids])
 
     def _get_available_bands_from_manifest(self, manifest):
-        """Best effort to get available bands by looking at first 10 successful downloads for consistency."""
+        """Get available bands by finding entries with complete band coverage.
+
+        Uses cutout_shape[0] to determine the expected number of bands, then finds
+        entries where downloaded_bands has that many entries (i.e., complete downloads).
+        """
         if len(manifest) == 0:
             return None, None
 
-        successful_entries = []
+        # First, find the expected number of bands from cutout_shape
+        # Look for the first entry with a valid cutout_shape
+        expected_band_count = None
+        for i in range(min(len(manifest), 1000)):
+            shape = manifest["cutout_shape"][i]
+            if shape is not None and len(shape) > 0 and shape[0] > 0:
+                expected_band_count = shape[0]
+                break
 
-        # Attempt to find first 10 successful downloads.
-        # For long manifests (e.g. 1 million undownloaded cutouts), avoid iterating too far to find these 10.
-        give_up_idx = min(len(manifest), 1000)
+        if expected_band_count is None:
+            # No valid cutout_shape found
+            return None, None
+
+        # Now find first 5 entries where downloaded_bands has the expected count
+        complete_entries = []
+        give_up_idx = min(len(manifest), 1000)  
+
         for i in range(give_up_idx):
-            if len(successful_entries) >= 10:
+            if len(complete_entries) >= 5:
                 break
 
             filename = manifest["filename"][i]
@@ -395,19 +411,25 @@ class DownloadedLSSTDataset(LSSTDataset, TensorCacheMixin):
                 and str(downloaded_bands_str).strip()
             ):
                 bands = [b.strip() for b in str(downloaded_bands_str).split(",") if b.strip()]
-                if bands:  # Non-empty band list
-                    successful_entries.append(bands)
+                # Only include entries with complete band coverage
+                if len(bands) == expected_band_count:
+                    complete_entries.append(bands)
 
-        if not successful_entries:
-            return None, None
+        if not complete_entries:
+            raise RuntimeError(
+                f"No entries found with complete band coverage. Expected {expected_band_count} bands "
+                f"based on cutout_shape, but less than 5 downloaded entries have all bands present. "
+                f"Cannot automatically deterrmine consistent band structure."
+            )
 
-        # Check that all successful entries have identical band lists
-        first_bands = successful_entries[0]
-        for i, bands in enumerate(successful_entries[1:], 1):
+        # Check that all complete entries have identical band lists
+        first_bands = complete_entries[0]
+        for i, bands in enumerate(complete_entries[1:], 1):
             if bands != first_bands:
                 raise RuntimeError(
-                    f"Inconsistent band ordering in manifest. Entry 0 has {first_bands}, "
-                    f"but entry {i} has {bands}. Cannot determine consistent band structure."
+                    f"Inconsistent band ordering in manifest among complete downloads. "
+                    f"Entry 0 has {first_bands}, but entry {i} has {bands}. "
+                    f"Cannot determine consistent band structure."
                 )
 
         return set(first_bands), first_bands

--- a/src/hyrax/data_sets/downloaded_lsst_dataset.py
+++ b/src/hyrax/data_sets/downloaded_lsst_dataset.py
@@ -417,9 +417,10 @@ class DownloadedLSSTDataset(LSSTDataset, TensorCacheMixin):
 
         if not complete_entries:
             raise RuntimeError(
-                f"No entries found with complete band coverage. Expected {expected_band_count} bands "
-                f"based on cutout_shape, but less than 5 downloaded entries have all bands present. "
-                f"Cannot automatically determine consistent band structure."
+                f"We checked the first 1000 manifest entries and found no entries with complete band"
+                f"coverage. Expected {expected_band_count} bands based on cutout_shape, but less than 5"
+                f"downloaded entries have all bands present. Cannot automatically determine consistent"
+                f"band structure."
             )
 
         # Check that all complete entries have identical band lists

--- a/tests/hyrax/test_downloaded_lsst_dataset.py
+++ b/tests/hyrax/test_downloaded_lsst_dataset.py
@@ -9,6 +9,7 @@ LSST Science Pipelines or a Butler repository.
 import mocks
 import pytest
 import torch
+import torchvision  # noqa: F401  # Import before mock contexts to prevent kernel re-registration
 from mocks import lsst_config, mock_lsst_environment, sample_catalog, sample_catalog_saved  # noqa: F401
 
 from hyrax.data_sets.downloaded_lsst_dataset import DownloadedLSSTDataset

--- a/tests/hyrax/test_downloaded_lsst_dataset.py
+++ b/tests/hyrax/test_downloaded_lsst_dataset.py
@@ -428,6 +428,39 @@ def test_failed_band_download(mock_lsst_environment, lsst_config, tmp_path):  # 
     assert torch.all(cutout[2] == cutout[2])
 
 
+def test_band_detection_with_partial_downloads(mock_lsst_environment, lsst_config, tmp_path):  # noqa: F811
+    """
+    Test that _get_available_bands_from_manifest correctly identifies bands
+    from complete downloads, ignoring partial downloads that may appear earlier
+    in the manifest.
+    """
+    # Configure 4 bands
+    lsst_config["data_set"]["filters"] = ["g", "r", "i", "z"]
+
+    with mock_lsst_environment():
+        # Make g and r bands fail for the FIRST 5 downloads each, then succeed
+        # Early entries will have only i,z (partial), later entries will have all 4
+        dataset = DownloadedLSSTDatasetMocked(
+            lsst_config,
+            data_location=str(tmp_path),
+            patcher=mock_lsst_environment,
+            patcher_kwargs={"band_fail_before_n": {"g": 5, "r": 5}},
+        )
+        _manifest = dataset.download_cutouts()
+
+    # Request only g,r,i bands - triggers _get_available_bands_from_manifest
+    # which must find complete 4-band entries to determine available bands
+    lsst_config["data_set"]["filters"] = ["g", "r", "i"]
+
+    dataset = DownloadedLSSTDatasetMocked(
+        lsst_config, data_location=str(tmp_path), patcher=mock_lsst_environment
+    )
+
+    # Verify band filtering found complete entries and set up correctly
+    assert dataset._is_filtering_bands is True
+    assert set(dataset.BANDS) == {"g", "r", "i"}
+
+
 def test_catalog_ordering(mock_lsst_environment, lsst_config, tmp_path, sample_catalog):  # noqa: F811
     """
     Test that after a download the ordering of a new dataset object is given in the same order

--- a/tests/hyrax/test_lsst_dataset.py
+++ b/tests/hyrax/test_lsst_dataset.py
@@ -10,6 +10,7 @@ import unittest.mock as mock
 
 import mocks
 import torch
+import torchvision  # noqa: F401  # Import before mock contexts to prevent kernel re-registration
 from mocks import lsst_config, mock_lsst_environment, sample_catalog, sample_catalog_saved  # noqa: F401
 
 


### PR DESCRIPTION
We previously had a hacky solution to determining the reasonably consistent band structure in the manifest file. I am now attepmpting to define this more rigorously:- 

- While downloading files, `DownloadedLSSTDataset` always saves the tensor with as many bands as the number of bands requested (e.g., 6 for u, g, r, i, z, y) and just pads with NaNs for the bands not available and skips that band in the `downloaded_bands` entry in the manifest file

- To detect the band structure used during download (needed to filter correctly), we now look for the first 5 entries where as many bands were downloaded  as the number of tensor filters being saved (i.e., a full set download -- no bands missing) 

- We make sure all the 5 are consistent 

- We go with the common structure as our detected band structure 


In terms of primary changes:
- I updated the `get_available_bands_from_manifest` to have the new logic
- I put in a new test to check for this intended behaviour now. 