### PR TITLE
Fix bug in Pydantic validation

### DIFF
--- a/src/hyrax/config_schemas/data_request.py
+++ b/src/hyrax/config_schemas/data_request.py
@@ -113,6 +113,8 @@ class DataRequestDefinition(BaseConfigModel):
     def collect_additional_datasets(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Capture arbitrary dataset keys beyond train/validate/infer."""
 
+        # Copy to avoid mutating the caller's dict
+        values = dict(values)
         known = {"train", "validate", "infer"}
         extra = {k: v for k, v in values.items() if k not in known}
         for key in extra:


### PR DESCRIPTION
## Solution Description

The collect_additional_datasets model validator modified the input dict in-place, which is not good practice.  When reusing such an input (e.g., adding 'infer' after setting 'train'), the empty 'other_datasets' would cause DataProvider to fail with "No datasets were requested in data_request".

While simply preventing the in-place mutation fixes the bug, and I have that in a separate commit, I decided to completely remove this part of validation entirely, since we already know that we want lighter validation.

## Code Quality
- [X] I have read the Contribution Guide and agree to the Code of Conduct
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation
