### PR TITLE
Introducing verb-specific batch functions in models to fix the `torch.no_grad` issue with the `test` verb

### DIFF
--- a/docs/data_flow.rst
+++ b/docs/data_flow.rst
@@ -24,7 +24,7 @@ The ``prepare_inputs`` function is responsible for taking in the output of the `
 Model Input and Output Pipeline
 -------------------------------
 
-The data is then either sent to ``pytorch`` ignite for training or to ``onnx`` for inference. In the case of training, the data is converted into a tensor and passed into the model's ``train_step`` function. The model processes the data and returns the output predictions. If the user wishes to perform data augmentations, these can be set up in the model's ``train_step`` function as well.
+The data is then either sent to ``pytorch`` ignite for training or to ``onnx`` for inference. In the case of training, the data is converted into a tensor and passed into the model's ``train_batch`` function. The model processes the data and returns the output predictions. If the user wishes to perform data augmentations, these can be set up in the model's ``train_batch`` function as well.
 
 In the ``onnx`` case, the data remains a numpy array throughout the model evaluation and to the result. Both paths result in the output being a numpy array.
 

--- a/docs/external_libraries.rst
+++ b/docs/external_libraries.rst
@@ -43,7 +43,7 @@ Defining a Model
 ----------------
 
 Models must be written as a subclasses of ``torch.nn.Module``, use pytorch for computation, and
-be decorated with ``@hyrax_model``. Models must minimally define ``__init__``, ``forward``, and ``train_step``
+be decorated with ``@hyrax_model``. Models must minimally define ``__init__``, ``prepare_inputs``, ``infer_batch``, and ``train_batch``
 methods.
 
 In order to get the ``@hyrax_model`` decorator you can import it with ``from hyrax.models import hyrax_model``.
@@ -59,21 +59,21 @@ to allow your model class to adjust architecture or check that the provided data
 the first iterable axis of the numpy array.
 
 
-``forward(self, x)``
+``infer_batch(self, x)``
 ....................
 Hyrax calls this function, which evaluates your model on a single input ``x``. ``x`` is guaranteed to be a numpy array with
 the shape passed to ``__init__``.
 
-``forward()`` should return a numpy array that is the output of your model.
+``infer_batch(self, x)`` should return a numpy array that is the output of your model.
 
 
-``train_step(self, batch)``
+``train_batch(self, batch)``
 ...........................
 This is called several times every training epoch with a batch of input numpy arrays for your model, and is the
 inner training loop for your model. This is where you compute loss, perform back propagation, etc depending on
 how your model is trained.
 
-``train_step`` returns a dictionary with a "loss" key who's value is a list of loss values for the individual
+``train_batch`` returns a dictionary with a "loss" key who's value is a list of loss values for the individual
 items in the batch. This loss is logged to MLflow and tensorboard.
 
 Optional Methods

--- a/src/hyrax/models/hsc_autoencoder.py
+++ b/src/hyrax/models/hsc_autoencoder.py
@@ -43,7 +43,7 @@ class HSCAutoencoder(nn.Module):  # These shapes work with [3,258,258] inputs
         decoded = self.decoder(encoded)
         return decoded
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         """
         This function contains the logic for a single training step. i.e. the
         contents of the inner loop of a ML training process.
@@ -51,7 +51,8 @@ class HSCAutoencoder(nn.Module):  # These shapes work with [3,258,258] inputs
         Parameters
         ----------
         batch : tuple
-            A tuple containing the two values the loss function
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
 
         Returns
         -------
@@ -68,3 +69,74 @@ class HSCAutoencoder(nn.Module):  # These shapes work with [3,258,258] inputs
         self.optimizer.step()
 
         return {"loss": loss.item()}
+
+    def validate_batch(self, batch):
+        """
+        This function contains the logic for a single validation step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML validation process.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+
+        data = batch[0]
+
+        decoded = self.forward(data)
+        loss = self.criterion(decoded, data)
+
+        return {"loss": loss.item()}
+
+    def test_batch(self, batch):
+        """
+        This function contains the logic for a single testing step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML testing process. In this case, it is identical to `validate_batch`.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+
+        data = batch[0]
+
+        decoded = self.forward(data)
+        loss = self.criterion(decoded, data)
+
+        return {"loss": loss.item()}
+
+    def infer_batch(self, batch):
+        """
+        This function contains the logic for a single inference step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML inference process.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Reconstructed outputs : torch.Tensor
+            The reconstructed outputs from the autoencoder.
+        """
+
+        data = batch[0]
+        return self.forward(data)

--- a/src/hyrax/models/hyrax_autoencoder.py
+++ b/src/hyrax/models/hyrax_autoencoder.py
@@ -20,7 +20,7 @@ class HyraxAutoencoder(nn.Module):
     This example model is taken from this
     `autoenocoder tutorial <https://uvadlc-notebooks.readthedocs.io/en/latest/tutorial_notebooks/tutorial9/AE_CIFAR10.html>`_
 
-    The train function has been converted into train_step for use with pytorch-ignite.
+    The train function has been converted into train_batch for use with pytorch-ignite.
     """
 
     def __init__(self, config, data_sample=None):
@@ -109,14 +109,15 @@ class HyraxAutoencoder(nn.Module):
     def forward(self, batch):
         return self._eval_encoder(batch)
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         """This function contains the logic for a single training step. i.e. the
         contents of the inner loop of a ML training process.
 
         Parameters
         ----------
         batch : tuple
-            A tuple containing the inputs and labels for the current batch.
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
 
         Returns
         -------
@@ -135,6 +136,69 @@ class HyraxAutoencoder(nn.Module):
         self.optimizer.step()
 
         return {"loss": loss.item()}
+
+    def validate_batch(self, batch):
+        """This function contains the logic for a single validation step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML validation process.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+        z = self._eval_encoder(batch)
+        x_hat = self._eval_decoder(z)
+        loss = F.mse_loss(batch, x_hat, reduction="none")
+        loss = loss.sum(dim=[1, 2, 3]).mean(dim=[0])
+
+        return {"loss": loss.item()}
+
+    def test_batch(self, batch):
+        """This function contains the logic for a single testing step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML testing process. In this case, it is identical to `validate_batch`.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+        z = self._eval_encoder(batch)
+        x_hat = self._eval_decoder(z)
+        loss = F.mse_loss(batch, x_hat, reduction="none")
+        loss = loss.sum(dim=[1, 2, 3]).mean(dim=[0])
+
+        return {"loss": loss.item()}
+
+    def infer_batch(self, batch):
+        """This function contains the logic for a single inference step. i.e. the
+        contents of the inner loop of a ML inference process.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Reconstructed inputs : torch.Tensor
+            The reconstructed inputs from the autoencoder.
+        """
+        return self.forward(batch)
 
     @staticmethod
     def prepare_inputs(data_dict) -> tuple:

--- a/src/hyrax/models/hyrax_cnn.py
+++ b/src/hyrax/models/hyrax_cnn.py
@@ -75,9 +75,10 @@ class HyraxCNN(nn.Module):
         x = self.fc3(x)
         return x
 
-    def train_step(self, batch):
-        """This function contains the logic for a single training step. i.e. the
-        contents of the inner loop of a ML training process.
+    def train_batch(self, batch):
+        """This function contains the logic for a single training step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML training process.
 
         Parameters
         ----------
@@ -97,6 +98,65 @@ class HyraxCNN(nn.Module):
         loss.backward()
         self.optimizer.step()
         return {"loss": loss.item()}
+
+    def validate_batch(self, batch):
+        """This function contains the logic for a single validation step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML validation process. In this case it is identical to `test_batch`.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the inputs and labels for the current batch.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+        _, labels = batch
+
+        outputs = self(batch)
+        loss = self.criterion(outputs, labels)
+        return {"loss": loss.item()}
+
+    def test_batch(self, batch):
+        """This function contains the logic for a single testing step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML testing process. In this case, it is identical to `validate_batch`.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the inputs and labels for the current batch.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+        _, labels = batch
+
+        outputs = self(batch)
+        loss = self.criterion(outputs, labels)
+        return {"loss": loss.item()}
+
+    def infer_batch(self, batch):
+        """This function contains the logic for a single inference step that will
+        process a single batch of data. i.e. the contents of the inner loop of a
+        ML inference process.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the inputs and labels for the current batch.
+
+        Returns
+        -------
+        Model outputs : Tensor
+            Tensor containing the model outputs for the current batch.
+        """
+        return self(batch)
 
     @staticmethod
     def prepare_inputs(data_dict) -> tuple:

--- a/src/hyrax/models/hyrax_loopback.py
+++ b/src/hyrax/models/hyrax_loopback.py
@@ -36,7 +36,22 @@ class HyraxLoopback(nn.Module):
             x, _ = x
         return x
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         """Training is a noop"""
         logger.debug(f"Batch length: {len(batch)}")
         return {"loss": 0.0}
+
+    def validate_batch(self, batch):
+        """Validation is just a forward pass"""
+        logger.debug(f"Batch length: {len(batch)}")
+        return {"loss": 0.0}
+
+    def test_batch(self, batch):
+        """Testing is just a forward pass"""
+        logger.debug(f"Batch length: {len(batch)}")
+        return {"loss": 0.0}
+
+    def infer_batch(self, batch):
+        """Inference is just a forward pass"""
+        logger.debug(f"Batch length: {len(batch)}")
+        return self.forward(batch)

--- a/src/hyrax/models/image_dcae.py
+++ b/src/hyrax/models/image_dcae.py
@@ -185,13 +185,14 @@ class ImageDCAE(nn.Module):
 
         return reconstructed
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         """This function contains the logic for a single training step.
 
         Parameters
         ----------
         batch : tuple
-            A tuple containing the two values the loss function
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
 
         Returns
         -------
@@ -216,6 +217,84 @@ class ImageDCAE(nn.Module):
         self.optimizer.step()
 
         return {"loss": loss.item()}
+
+    def validate_batch(self, batch):
+        """This function contains the logic for a single validation step that will
+        process a single batch of data.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+        data = batch
+
+        # Store original spatial dimensions for decoding
+        self.original_size = data.shape[2:]
+
+        # Encode to latent space
+        latent, skip_connections, encoded_shape = self.encode(data)
+
+        # Decode back to image
+        decoded = self.decode(latent, skip_connections, encoded_shape)
+
+        # Compute loss
+        loss = self.criterion(decoded, data)
+
+        return {"loss": loss.item()}
+
+    def test_batch(self, batch):
+        """This function contains the logic for a single testing step that will
+        process a single batch of data. In this case, it is identical to `validate_batch`.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Current loss value : dict
+            Dictionary containing the loss value for the current batch.
+        """
+        data = batch
+
+        # Store original spatial dimensions for decoding
+        self.original_size = data.shape[2:]
+
+        # Encode to latent space
+        latent, skip_connections, encoded_shape = self.encode(data)
+
+        # Decode back to image
+        decoded = self.decode(latent, skip_connections, encoded_shape)
+
+        # Compute loss
+        loss = self.criterion(decoded, data)
+
+        return {"loss": loss.item()}
+
+    def infer_batch(self, batch):
+        """This function contains the logic for a single inference step.
+
+        Parameters
+        ----------
+        batch : tuple
+            A tuple containing the input data for the current batch, possibly
+            with labels that are ignored.
+
+        Returns
+        -------
+        Reconstructed images : torch.Tensor
+            Tensor containing the reconstructed images for the current batch.
+        """
+        return self.forward(batch)
 
     @staticmethod
     def prepare_inputs(data_dict):

--- a/src/hyrax/models/model_registry.py
+++ b/src/hyrax/models/model_registry.py
@@ -239,7 +239,7 @@ def hyrax_model(cls):
         cls.prepare_inputs = staticmethod(default_prepare_inputs)
 
     # Update required methods to include prepare_inputs
-    required_methods = ["train_step", "forward", "__init__", "prepare_inputs"]
+    required_methods = ["train_batch", "infer_batch", "__init__", "prepare_inputs"]
     for name in required_methods:
         if not hasattr(cls, name):
             logger.error(f"Hyrax model {cls.__name__} missing required method {name}.")

--- a/tests/hyrax/test_plugin_utils.py
+++ b/tests/hyrax/test_plugin_utils.py
@@ -165,7 +165,7 @@ def test_torch_load_with_map_location(tmp_path):
         def forward(self, x):
             return self.linear(x)
 
-        def train_step(self, batch):
+        def train_batch(self, batch):
             return {"loss": 0.0}
 
     # Create config

--- a/tests/hyrax/test_prepare_inputs_migration.py
+++ b/tests/hyrax/test_prepare_inputs_migration.py
@@ -27,7 +27,7 @@ def test_model_with_only_to_tensor():
         def forward(self, x):
             return x
 
-        def train_step(self, batch):
+        def train_batch(self, batch):
             return {"loss": 0.0}
 
     h = Hyrax()
@@ -60,7 +60,7 @@ def test_model_without_prepare_inputs_or_to_tensor():
         def forward(self, x):
             return x
 
-        def train_step(self, batch):
+        def train_batch(self, batch):
             return {"loss": 0.0}
 
     h = Hyrax()
@@ -95,7 +95,7 @@ def test_model_without_prepare_inputs_or_to_tensor_raises_error():
         def forward(self, x):
             return x
 
-        def train_step(self, batch):
+        def train_batch(self, batch):
             return {"loss": 0.0}
 
     h = Hyrax()
@@ -140,7 +140,7 @@ def test_save_and_load_model_with_to_tensor_warns(tmp_path, caplog):
         def forward(self, x):
             return x
 
-        def train_step(self, batch):
+        def train_batch(self, batch):
             return {"loss": 0.0}
 
     h = Hyrax()
@@ -203,7 +203,7 @@ def test_load_model_with_old_to_tensor_file(tmp_path, caplog):
         def forward(self, x):
             return x
 
-        def train_step(self, batch):
+        def train_batch(self, batch):
             return {"loss": 0.0}
 
     h = Hyrax()
@@ -259,7 +259,7 @@ def test_load_model_with_no_serialized_input_functions(tmp_path, caplog):
         def forward(self, x):
             return x
 
-        def train_step(self, batch):
+        def train_batch(self, batch):
             return {"loss": 0.0}
 
     h = Hyrax()


### PR DESCRIPTION
Renaming all instances of `train_step` to `train_batch` for clarity.
Introducing`validate|test|infer_batch` methods to all existing models.
Updated engine creation code to look for appropriate model methods when creating the engine. i.e. the trainer engine looks for `train_batch`, the validation engine looks for `validate_batch`.
Search/replaced instances of `train_step` with `train_batch` in the docs and tests.

