### PR TITLE
Tune Pydantic validation to user purpose

### DIFF
--- a/src/hyrax/config_schemas/data_request.py
+++ b/src/hyrax/config_schemas/data_request.py
@@ -73,7 +73,7 @@ with warnings.catch_warnings():
     class DataRequestDefinition(BaseConfigModel):
         """Typed representation of the full ``data_request`` table."""
 
-        model_config = ConfigDict(protected_namespaces=(), extra="allow")
+        model_config = ConfigDict(protected_namespaces=())
 
         train: DataRequestConfig | dict[str, DataRequestConfig] | None = Field(
             None, description="Dataset configuration(s) used for training."
@@ -152,7 +152,9 @@ with warnings.catch_warnings():
                 configs_dict = field_value if isinstance(field_value, dict) else {"_default": field_value}
 
                 # Count how many configs have primary_id_field set
-                primary_count = sum(1 for config in configs_dict.values() if config.primary_id_field is not None)
+                primary_count = sum(
+                    1 for config in configs_dict.values() if config.primary_id_field is not None
+                )
 
                 # Validate exactly one
                 if primary_count == 0:
@@ -180,7 +182,8 @@ with warnings.catch_warnings():
                     if isinstance(value, dict):
                         # Dict of configs - wrap each in {"data": ...}
                         output[name] = {
-                            key: {"data": cfg.as_dict(exclude_unset=exclude_unset)} for key, cfg in value.items()
+                            key: {"data": cfg.as_dict(exclude_unset=exclude_unset)}
+                            for key, cfg in value.items()
                         }
                     else:
                         # Single config - wrap in {"data": ...}

--- a/src/hyrax/config_schemas/data_request.py
+++ b/src/hyrax/config_schemas/data_request.py
@@ -36,7 +36,6 @@ class DataRequestConfig(BaseConfigModel):
         None, description="Name of the primary identifier field in the dataset."
     )
 
-    # Keep dataset_config as Any - it's a free-form dictionary for dataset-specific settings
     dataset_config: dict | None = Field(
         None,
         description="Dataset-specific configuration as a free-form dictionary.",

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -221,11 +221,11 @@ opset_version = 20
 input_model_directory = false
 
 
-[data_request]
+# [data_request]
 # Top-level table that defines the dataset(s) used for training, validation, and inference.
+# Configure with [data_request.train], [data_request.validate], or [data_request.infer] sections.
 
-
-[model_inputs]
+# [model_inputs]
 # DEPRECATED: Use [data_request] instead. This will be removed in the next major release.
 
 

--- a/tests/hyrax/test_config_validation_warnings.py
+++ b/tests/hyrax/test_config_validation_warnings.py
@@ -17,6 +17,7 @@ def test_set_config_warns_on_invalid_data_request(caplog):
     invalid_dict = {
         "train": {
             "dataset_class": "HyraxRandomDataset",
+            "data_location": "/dev/null",
             "fields": ["image"],
             # Missing primary_id_field - fails DataRequestDefinition validation
         }
@@ -43,6 +44,7 @@ def test_set_config_warns_on_invalid_model_inputs(caplog):
     invalid_dict = {
         "train": {
             "dataset_class": "HyraxRandomDataset",
+            "data_location": "/dev/null",
             # Missing primary_id_field
         }
     }
@@ -67,6 +69,7 @@ def test_set_config_no_warning_on_valid_data_request(caplog):
     valid_dict = {
         "train": {
             "dataset_class": "HyraxRandomDataset",
+            "data_location": "somewhere",
             "fields": ["image"],
             "primary_id_field": "object_id",
         }
@@ -97,6 +100,7 @@ dev_mode = true
 
 [data_request.train]
 dataset_class = "HyraxRandomDataset"
+data_location = "/dev/null"
 fields = ["image"]
 # Missing primary_id_field - fails validation
 """
@@ -139,6 +143,7 @@ dev_mode = true
 
 [data_request.train]
 dataset_class = "HyraxRandomDataset"
+data_location = "/dev/null"
 fields = ["image"]
 primary_id_field = "object_id"
 """
@@ -236,10 +241,12 @@ dev_mode = true
 
 [data_request.train]
 dataset_class = "HyraxRandomDataset"
+data_location = "/dev/null"
 # Missing primary_id_field - should trigger warning
 
 [model_inputs.validate]
 dataset_class = "HyraxCifarDataset"
+data_location = "/dev/null"
 # Missing primary_id_field - should also trigger warning
 """
     )

--- a/tests/hyrax/test_data_request_config.py
+++ b/tests/hyrax/test_data_request_config.py
@@ -35,8 +35,8 @@ def test_data_request_config_unwraps_data_key():
     assert cfg.primary_id_field == "oid"
 
 
-def test_data_request_definition_collects_known_and_extra():
-    """Collect train/validate/infer plus extra datasets."""
+def test_data_request_definition_collects_known_fields():
+    """Collect train/validate/infer fields."""
     definition = DataRequestDefinition(
         train={"dataset_class": "TrainDS", "primary_id_field": "id1", "data_location": "nowhere"},
         validate={"dataset_class": "ValidateDS", "primary_id_field": "id2", "data_location": "nowhere"},


### PR DESCRIPTION
Require data_location in dataset config.
Require at least one dataset in DataRequestDefinition: Add model validator to ensure at least one of 'train', 'validate', or 'infer' is provided when validating data_request config. Without this, completely invalid structures would pass validation silently due to `extra="allow"` and all fields being optional.

Also comment out empty placeholder sections in default config to avoid triggering the new validation requirement.

Also suppress Pydantic warning about 'validate' field name. The 'validate' field intentionally shadows `BaseModel.validate()` to match the TOML config structure. The legacy classmethod is not needed on this model, so suppress the warning to avoid alarming users.

## Solution Description


## Code Quality
- [X] I have read the Contribution Guide and agree to the Code of Conduct
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation
