### PR TITLE
Fixing MLFlow Tracking Directory

### DIFF
--- a/src/hyrax/verbs/train.py
+++ b/src/hyrax/verbs/train.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from colorama import Back, Fore, Style
 
@@ -89,7 +90,8 @@ class Train(Verb):
 
         monitor = GpuMonitor()
 
-        mlflow.set_tracking_uri("file://" + str(results_dir / "mlflow"))
+        results_root_dir = Path(config["general"]["results_dir"]).expanduser().resolve()
+        mlflow.set_tracking_uri("file://" + str(results_root_dir / "mlflow"))
 
         # Get experiment_name and cast to string (it's a tomlkit.string by default)
         experiment_name = str(config["train"]["experiment_name"])


### PR DESCRIPTION
In the last two weeks at some point, we had erroneously changed where the MLFlow results were being stored. 

We want the MLFlow results to be stored,not inside individual results directories, but at the root. This was the behaviour before. Not sure when it got changed. 