### PR TITLE
'data' key not required; can be any friendly name.

### DIFF
--- a/src/hyrax/config_schemas/data_request.py
+++ b/src/hyrax/config_schemas/data_request.py
@@ -180,10 +180,9 @@ with warnings.catch_warnings():
                 if value is not None:
                     # Handle both single config and dict of configs
                     if isinstance(value, dict):
-                        # Dict of configs - wrap each in {"data": ...}
+                        # Dict of configs - keys are already friendly names
                         output[name] = {
-                            key: {"data": cfg.as_dict(exclude_unset=exclude_unset)}
-                            for key, cfg in value.items()
+                            key: cfg.as_dict(exclude_unset=exclude_unset) for key, cfg in value.items()
                         }
                     else:
                         # Single config - wrap in {"data": ...}

--- a/tests/hyrax/test_data_request_config.py
+++ b/tests/hyrax/test_data_request_config.py
@@ -410,6 +410,6 @@ def test_as_dict_with_dict_configs():
     assert "train" in as_dict
     assert "data_0" in as_dict["train"]
     assert "data_1" in as_dict["train"]
-    assert as_dict["train"]["data_0"]["data"]["dataset_class"] == "HyraxRandomDataset"
-    assert as_dict["train"]["data_0"]["data"]["primary_id_field"] == "id"
-    assert as_dict["train"]["data_1"]["data"]["dataset_class"] == "HyraxCifarDataset"
+    assert as_dict["train"]["data_0"]["dataset_class"] == "HyraxRandomDataset"
+    assert as_dict["train"]["data_0"]["primary_id_field"] == "id"
+    assert as_dict["train"]["data_1"]["dataset_class"] == "HyraxCifarDataset"


### PR DESCRIPTION
Discovered while testing pre-executed notebooks.

## Solution Description

Previous testing incorrectly assumed that in a data request, the data source name had to be called 'data' if there weren't multiple sources.  This is not true.  Corrected both test and logic.

## Code Quality
- [X] I have read the Contribution Guide and agree to the Code of Conduct
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation
