### PR TITLE
`visualize` verb should find all its inputs from config.

### DIFF
--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -20,6 +20,13 @@ class Visualize(Verb):
     cli_name = "visualize"
     add_parser_kwargs = {}
 
+    # Dataset groups that the Visualize verb knows about.
+    # REQUIRED_SPLITS must be present in the data request configuration.
+    # OPTIONAL_SPLITS are used when present but do not cause an error if absent.
+    # Note: "umap" results may also be required in the future.
+    REQUIRED_SPLITS = ("infer",)
+    OPTIONAL_SPLITS = ()
+
     @staticmethod
     def setup_parser(parser: ArgumentParser):
         """CLI not implemented for this verb"""
@@ -113,14 +120,18 @@ class Visualize(Verb):
         # Build a DataProvider from the live config for metadata access.
         # This avoids implicit coupling between result datasets and their original data sources.
         datasets = setup_dataset(self.config)
-        if "infer" not in datasets:
+        if not Visualize.REQUIRED_SPLITS.intersection(set(datasets.keys())):
+            required_keys = ", ".join(sorted(Visualize.REQUIRED_SPLITS))
             available_keys = ", ".join(sorted(datasets.keys())) or "<none>"
             msg = (
-                "Visualize requires an 'infer' dataset entry in the data request configuration, "
-                f"but none was found. Available dataset keys: {available_keys}"
+                f"Visualize requires dataset entries {required_keys} in the data request configuration "
+                f"Available dataset keys: {available_keys}"
             )
             raise RuntimeError(msg)
-        self.metadata_provider = datasets["infer"]
+        # NOTE: this presently depends on only a single required
+        # split, but here is here the data provider logic would be
+        # extended if needed.
+        self.metadata_provider = datasets[Visualize.REQUIRED_SPLITS[0]]
 
         available_fields = self.metadata_provider.metadata_fields()
         for field in fields.copy():

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -113,7 +113,14 @@ class Visualize(Verb):
         # Build a DataProvider from the live config for metadata access.
         # This avoids implicit coupling between result datasets and their original data sources.
         data_request = generate_data_request_from_config(self.config)
-        infer_request = data_request.get("infer", next(iter(data_request.values())))
+        if "infer" not in data_request:
+            available_keys = ", ".join(sorted(data_request.keys())) or "<none>"
+            msg = (
+                "Visualize requires an 'infer' dataset entry in the data request configuration, "
+                f"but none was found. Available dataset keys: {available_keys}"
+            )
+            raise RuntimeError(msg)
+        infer_request = data_request["infer"]
         self.metadata_provider = DataProvider(self.config, infer_request)
 
         available_fields = self.metadata_provider.metadata_fields()

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -133,7 +133,17 @@ class Visualize(Verb):
         # extended if needed.
         self.metadata_provider = datasets[Visualize.REQUIRED_SPLITS[0]]
 
-        available_fields = self.metadata_provider.metadata_fields()
+        # Determine the dataset friendly name, if possible, so that we can request
+        # unsuffixed metadata field names that match the plain names from config.
+        friendly_name = None
+        if isinstance(infer_request, dict) and len(infer_request) == 1:
+            friendly_name = next(iter(infer_request))
+
+        if friendly_name is not None:
+            available_fields = set(self.metadata_provider.metadata_fields(friendly_name=friendly_name))
+        else:
+            # Fallback to the original behavior if we cannot determine a single friendly name.
+            available_fields = set(self.metadata_provider.metadata_fields())
         for field in fields.copy():
             if field not in available_fields:
                 logger.warning(f"Field {field} is unavailable for this dataset")

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -78,8 +78,8 @@ class Visualize(Verb):
         from holoviews.streams import Lasso, Params, RangeXY, SelectionXY, Tap
         from scipy.spatial import KDTree
 
-        from hyrax.data_sets.data_provider import DataProvider, generate_data_request_from_config
         from hyrax.data_sets.result_factories import load_results_dataset
+        from hyrax.pytorch_ignite import setup_dataset
 
         if self.config["data_set"]["object_id_column_name"]:
             self.object_id_column_name = self.config["data_set"]["object_id_column_name"]
@@ -112,16 +112,15 @@ class Visualize(Verb):
 
         # Build a DataProvider from the live config for metadata access.
         # This avoids implicit coupling between result datasets and their original data sources.
-        data_request = generate_data_request_from_config(self.config)
-        if "infer" not in data_request:
-            available_keys = ", ".join(sorted(data_request.keys())) or "<none>"
+        datasets = setup_dataset(self.config)
+        if "infer" not in datasets:
+            available_keys = ", ".join(sorted(datasets.keys())) or "<none>"
             msg = (
                 "Visualize requires an 'infer' dataset entry in the data request configuration, "
                 f"but none was found. Available dataset keys: {available_keys}"
             )
             raise RuntimeError(msg)
-        infer_request = data_request["infer"]
-        self.metadata_provider = DataProvider(self.config, infer_request)
+        self.metadata_provider = datasets["infer"]
 
         available_fields = self.metadata_provider.metadata_fields()
         for field in fields.copy():

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -321,7 +321,7 @@ class Visualize(Verb):
 
         if np.any(np.isinf([x_range, y_range])):
             # Show all points without filtering
-            points = np.array([point.numpy() for point in self.umap_results])
+            points = np.array([np.asarray(point) for point in self.umap_results])
             point_indices = list(range(len(self.umap_results)))
         else:
             # Use existing filtering logic
@@ -371,7 +371,7 @@ class Visualize(Verb):
             self.points, self.points_id, self.points_idx = self.poly_select_points(kwargs["geometry"])
         elif self._called_tap(kwargs):
             _, idx = self.tree.query([kwargs["x"], kwargs["y"]])
-            self.points = np.array([self.umap_results[idx].numpy()])
+            self.points = np.array([np.asarray(self.umap_results[idx])])
             self.points_id = np.array([list(self.umap_results.ids())[idx]])
             self.points_idx = np.array([idx])
         elif self._called_box_select(kwargs):
@@ -432,7 +432,7 @@ class Visualize(Verb):
         # Coarse grain the points within the axis-aligned bounding box of the geometry
         (xmin, xmax, ymin, ymax) = Visualize._bounding_box(geometry)
         point_indexes_coarse = self.box_select_indexes([xmin, xmax], [ymin, ymax])
-        points_coarse = self.umap_results[point_indexes_coarse].numpy()
+        points_coarse = np.asarray(self.umap_results[point_indexes_coarse])
 
         tri = Delaunay(geometry)
         mask = tri.find_simplex(points_coarse) != -1
@@ -469,7 +469,7 @@ class Visualize(Verb):
 
         indexes = self.box_select_indexes(x_range, y_range)
         ids = np.array(list(self.umap_results.ids()))[indexes]
-        points = self.umap_results[indexes].numpy()
+        points = np.asarray(self.umap_results[indexes])
         return points, ids, indexes
 
     def box_select_indexes(self, x_range: Union[tuple, list], y_range: Union[tuple, list]):
@@ -508,7 +508,7 @@ class Visualize(Verb):
             return x > xmin and x < xmax and y > ymin and y < ymax
 
         # Filter for points properly inside the box
-        return [i for i in indexes if _inside_box(self.umap_results[i].numpy())]
+        return [i for i in indexes if _inside_box(np.asarray(self.umap_results[i]))]
 
     def selected_objects(self, **kwargs):
         """
@@ -564,8 +564,10 @@ class Visualize(Verb):
         return (xmin, xmax, ymin, ymax)
 
     def _even_aspect_bounding_box(self):
+        import numpy as np
+
         # Bring aspect ratio to 1:1 by expanding the smaller axis range
-        (xmin, xmax, ymin, ymax) = Visualize._bounding_box(point.numpy() for point in self.umap_results)
+        (xmin, xmax, ymin, ymax) = Visualize._bounding_box(np.asarray(point) for point in self.umap_results)
 
         x_dim = xmax - xmin
         x_center = (xmax + xmin) / 2.0
@@ -709,12 +711,12 @@ class Visualize(Verb):
                         if len(self.torch_tensor_bands) == 1:
                             # Single-band extraction
                             band_idx = self.torch_tensor_bands[0]
-                            arr = tensor[band_idx].numpy()
+                            arr = np.asarray(tensor[band_idx])
                         else:
                             # RGB extraction (3 bands)
                             rgb_arrays = []
                             for band_idx in self.torch_tensor_bands:
-                                rgb_arrays.append(tensor[band_idx].numpy())
+                                rgb_arrays.append(np.asarray(tensor[band_idx]))
                             # Stack along new axis to create (H, W, 3) RGB array
                             arr = np.stack(rgb_arrays, axis=-1)
                     else:

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -133,17 +133,7 @@ class Visualize(Verb):
         # extended if needed.
         self.metadata_provider = datasets[Visualize.REQUIRED_SPLITS[0]]
 
-        # Determine the dataset friendly name, if possible, so that we can request
-        # unsuffixed metadata field names that match the plain names from config.
-        friendly_name = None
-        if isinstance(infer_request, dict) and len(infer_request) == 1:
-            friendly_name = next(iter(infer_request))
-
-        if friendly_name is not None:
-            available_fields = set(self.metadata_provider.metadata_fields(friendly_name=friendly_name))
-        else:
-            # Fallback to the original behavior if we cannot determine a single friendly name.
-            available_fields = set(self.metadata_provider.metadata_fields())
+        available_fields = self.metadata_provider.metadata_fields()
         for field in fields.copy():
             if field not in available_fields:
                 logger.warning(f"Field {field} is unavailable for this dataset")

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -115,12 +115,11 @@ class Visualize(Verb):
 
         # Get the umap data and put it in a kdtree for indexing.
         self.umap_results = load_results_dataset(self.config, results_dir=input_dir, verb="umap")
-        logger.info(f"Rendering UMAP from the following directory: {self.umap_results.results_dir}")
 
         # Build a DataProvider from the live config for metadata access.
         # This avoids implicit coupling between result datasets and their original data sources.
         datasets = setup_dataset(self.config)
-        if not Visualize.REQUIRED_SPLITS.intersection(set(datasets.keys())):
+        if not set(Visualize.REQUIRED_SPLITS).intersection(set(datasets.keys())):
             required_keys = ", ".join(sorted(Visualize.REQUIRED_SPLITS))
             available_keys = ", ".join(sorted(datasets.keys())) or "<none>"
             msg = (


### PR DESCRIPTION
Rather that assuming that the dataset provides its own breadcrumbs to its input, use the session-wide config to locate that data and its necessary metadata.

## Change Description

Closes #709 .

## Code Quality
- [X] I have read the Contribution Guide and agree to the Code of Conduct
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation
