### PR TITLE
[AUTO-MERGE] Second round of removing iterable dataset references and support.

### DIFF
--- a/src/hyrax/data_sets/__init__.py
+++ b/src/hyrax/data_sets/__init__.py
@@ -70,7 +70,7 @@ from .random.hyrax_random_dataset import (
 from .inference_dataset import InferenceDataSet
 from .result_dataset import ResultDataset, ResultDatasetWriter
 from .result_factories import create_results_writer, load_results_dataset
-from .data_set_registry import HyraxDataset, iterable_dataset_collate
+from .data_set_registry import HyraxDataset
 from .hyrax_cifar_dataset import HyraxCifarBase
 from .hyrax_csv_dataset import HyraxCSVDataset
 from .data_cache import DataCache
@@ -91,6 +91,5 @@ __all__ = [
     "HyraxRandomDataset",
     "HyraxRandomDatasetBase",
     "HyraxCSVDataset",
-    "iterable_dataset_collate",
     "DataCache",
 ]

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -145,7 +145,7 @@ class HyraxDataset:
 
         # We only require a user to implement a __len__ method.
         if not hasattr(cls, "__len__"):
-            msg = f"Hyrax data set {cls.__name__} is missing required length function."
+            msg = f"Hyrax data set {cls.__name__} is missing required length function. "
             msg += "__len__ must be defined."
             raise RuntimeError(msg)
 

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -152,20 +152,6 @@ class HyraxDataset:
         # Ensure the class is in the registry so the config system can find it
         update_registry(DATASET_REGISTRY, cls.__name__, cls)
 
-    # TODO: I believe that this method should simply be deprecated. `DataProvider`
-    # TODO: exposes a `sample_data()` method that should be used instead.
-    # def sample_data(self) -> dict:
-    #     """Get a sample from the dataset. This is a convenience function that returns
-    #     the first sample from the dataset. Often this will be used to instantiate
-    #     a model that adjusts its form based on the shape of the data."""
-
-    #     if self.is_map():
-    #         return self[0]
-    #     else:
-    #         raise NotImplementedError(
-    #             "You must define __getitem__ or __iter__ to use the default `get_sample()` method."
-    #         )
-
     def metadata_fields(self) -> list[str]:
         """Returns a list of metadata fields supported by this object
 

--- a/src/hyrax/data_sets/data_set_registry.py
+++ b/src/hyrax/data_sets/data_set_registry.py
@@ -24,7 +24,7 @@ class HyraxDataset:
             def __init__(self, config: dict):
                 super().__init__(config)
 
-            def __len__ ():
+            def __len__(self):
                 # Your len function goes here
                 pass
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -8,8 +8,6 @@ from typing import Any, Union
 import ignite.distributed as idist
 import numpy as np
 
-from hyrax.data_sets.data_set_registry import fetch_dataset_class
-
 with warnings.catch_warnings():
     warnings.simplefilter(action="ignore", category=DeprecationWarning)
     import mlflow
@@ -53,26 +51,12 @@ class SubsetSequentialSampler(Sampler[int]):
         return len(self.indices)
 
 
-def is_iterable_dataset_requested(data_request: dict) -> bool:
-    """This function checks each of the datasets included in the data_request.
-    If any of them are iterable-style datasets, we return True.
-    """
-
-    is_iterable = False
-    for _, value in data_request.items():
-        for _, dataset_definition in value.items():
-            if fetch_dataset_class(dataset_definition["dataset_class"]).is_iterable():
-                is_iterable = True
-                break
-    return is_iterable
-
-
 def setup_dataset(
     config: dict,
     *,
     splits: tuple[str, ...] | None = None,
     shuffle: bool = True,
-) -> DataProvider:
+) -> dict[str, DataProvider]:
     """This function creates an instance of the requested dataset(s) specified in the
     runtime configuration for the given splits (data_groups).
 
@@ -95,9 +79,8 @@ def setup_dataset(
 
     Returns
     -------
-    DataProvider
-        An instance of a DataProvider that encapsulates the dataset classes
-        specified in the split (data_group) passed in.
+    dict[str, DataProvider]
+        A dictionary mapping data group names to DataProvider instances.
     """
 
     dataset = {}
@@ -950,7 +933,7 @@ def create_save_batch_callback(dataset, results_dir):
 
     data_writer = create_results_writer(dataset, results_dir)
 
-    def _save_batch(batch: Union[torch.Tensor, list, tuple, dict], batch_results: torch.Tensor):
+    def _save_batch(batch: dict, batch_results: torch.Tensor):
         """Receive and write batch results to results_dir immediately."""
         nonlocal data_writer
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -196,9 +196,6 @@ def dist_data_loader(
     For multiple splits, we return a dictionary where the keys are the names of the splits
     and the value is either a Dataloader as described above or the value None if the split
     was not configured.
-
-    If an iterable dataset is passed, we cannot create multiple splits with a pyTorch sampler object
-    so we return the same thing for all splits, which is a dataloader representing the entire iterable
     """
 
     # Extract the config dictionary that will be provided as kwargs to the DataLoader

--- a/src/hyrax/verbs/train.py
+++ b/src/hyrax/verbs/train.py
@@ -75,9 +75,6 @@ class Train(Verb):
 
         # We know that `dataset` will always be returned as a dictionary with at least
         # a `train` and `infer` key. There may be a `validate` key as well.
-        # The only instance in which a dataset would not be a dictionary is if
-        # the user has requested an iterable dataset. But we don't want to support that
-        # for training right now.
         #
         # There are three ways splits can be defined:
         #

--- a/tests/hyrax/test_pytorch_ignite.py
+++ b/tests/hyrax/test_pytorch_ignite.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -6,13 +6,13 @@ from hyrax.pytorch_ignite import setup_dataset
 
 
 class TestSetupDataset:
-    """Tests for the setup_dataset function, specifically focused on iterable dataset handling."""
+    """Tests for the setup_dataset function."""
 
     def test_setup_dataset_missing_dataset_class_raises_error(self):
         """Test that missing dataset_class raises appropriate RuntimeError."""
         # Create a minimal config that would trigger iterable dataset path
         config = {
-            "model_inputs": {
+            "data_request": {
                 "train": {
                     "test_dataset": {
                         # Intentionally missing "dataset_class"
@@ -28,24 +28,17 @@ class TestSetupDataset:
             }
         }
 
-        # Mock the functions that would be called before our code
-        with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
-            with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                # Set up mocks to trigger the iterable dataset path
-                mock_generate.return_value = config["model_inputs"]
-                mock_is_iterable.return_value = True
+        # This should raise RuntimeError from DataProvider when dataset_class is missing
+        with pytest.raises(RuntimeError) as exc_info:
+            setup_dataset(config)
 
-                # This should raise RuntimeError with our specific message
-                with pytest.raises(RuntimeError) as exc_info:
-                    setup_dataset(config)
-
-                assert "dataset_class must be specified in 'data_request'." in str(exc_info.value)
+        assert "does not specify a 'dataset_class'" in str(exc_info.value)
 
     def test_setup_dataset_invalid_dataset_class_raises_error(self):
-        """Test that providing an invalid dataset_class raises appropriate RuntimeError."""
+        """Test that providing an invalid dataset_class raises appropriate ValueError."""
         # Create a config with an invalid dataset_class
         config = {
-            "model_inputs": {
+            "data_request": {
                 "train": {
                     "test_dataset": {
                         "dataset_class": "NonExistentDatasetClass",
@@ -61,100 +54,89 @@ class TestSetupDataset:
             }
         }
 
-        # Mock the functions that would be called before our code
-        with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
-            with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                # Set up mocks to trigger the iterable dataset path
-                mock_generate.return_value = config["model_inputs"]
-                mock_is_iterable.return_value = True
-                # Make the registry lookup fail by simulating the dataset class not being in registry
+        # DataProvider will try to look up the class in the registry and fail
+        with pytest.raises(ValueError) as exc_info:
+            setup_dataset(config)
 
-                # This should raise RuntimeError with our specific message
-                with pytest.raises(ValueError) as exc_info:
-                    setup_dataset(config)
-
-                assert "Class name NonExistentDatasetClass" in str(exc_info.value)
+        assert "Class name NonExistentDatasetClass" in str(exc_info.value)
 
     def test_setup_dataset_missing_data_location_uses_none(self):
-        """Test that missing data_location passes None to dataset constructor."""
+        """Test that setup_dataset creates DataProvider instances even when data_location is absent."""
         # Create a config with dataset_class but no data_location
         config = {
-            "model_inputs": {
+            "data_request": {
                 "train": {
                     "test_dataset": {
-                        "dataset_class": "HyraxRandomIterableDataset"
+                        "dataset_class": "HyraxRandomDataset"
                         # Intentionally missing "data_location"
                     },
                 },
                 "infer": {
                     "test_dataset": {
-                        "dataset_class": "HyraxRandomIterableDataset"
+                        "dataset_class": "HyraxRandomDataset"
                         # Intentionally missing "data_location"
                     },
                 },
             }
         }
 
-        # Mock dataset class and registry
-        mock_dataset_instance = MagicMock()
-        mock_dataset_cls = MagicMock(return_value=mock_dataset_instance)
+        # Use a real class (not MagicMock) so isinstance() in setup_dataset doesn't TypeError.
+        # __new__ intercepts construction and returns our sentinel instance.
+        sentinel = MagicMock()
+        sentinel.split_fraction = None
+        provider_calls = []
 
-        with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
-            with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                with patch("hyrax.pytorch_ignite.fetch_dataset_class") as mock_fetch_cls:
-                    # Set up mocks
-                    mock_generate.return_value = config["model_inputs"]
-                    mock_is_iterable.return_value = True
-                    mock_fetch_cls.return_value = mock_dataset_cls
+        class MockDataProvider:
+            def __new__(cls, config, request):
+                provider_calls.append((config, request))
+                return sentinel
 
-                    # Call the function
-                    result = setup_dataset(config)
+        with patch("hyrax.pytorch_ignite.DataProvider", MockDataProvider):
+            result = setup_dataset(config)
 
-                    # Verify the dataset constructor was called with data_location=None
-                    expected_call = call(config=config, data_location=None)
-                    assert mock_dataset_cls.call_count == 2
-                    mock_dataset_cls.assert_has_calls([expected_call, expected_call])
-                    assert result["train"] == mock_dataset_instance
-                    assert result["infer"] == mock_dataset_instance
+            # DataProvider should be created for each data group
+            assert len(provider_calls) == 2
+            assert (config, config["data_request"]["train"]) in provider_calls
+            assert (config, config["data_request"]["infer"]) in provider_calls
+            assert result["train"] is sentinel
+            assert result["infer"] is sentinel
 
     def test_setup_dataset_with_both_keys_present(self):
         """Test normal case where both dataset_class and data_location are present."""
         # Create a complete config
         config = {
-            "model_inputs": {
+            "data_request": {
                 "train": {
                     "test_dataset": {
-                        "dataset_class": "HyraxRandomIterableDataset",
+                        "dataset_class": "HyraxRandomDataset",
                         "data_location": "/some/valid/path",
                     },
                 },
                 "infer": {
                     "test_dataset": {
-                        "dataset_class": "HyraxRandomIterableDataset",
+                        "dataset_class": "HyraxRandomDataset",
                         "data_location": "/some/valid/path",
                     },
                 },
             }
         }
 
-        # Mock dataset class and registry
-        mock_dataset_instance = MagicMock()
-        mock_dataset_cls = MagicMock(return_value=mock_dataset_instance)
+        # Use a real class (not MagicMock) so isinstance() in setup_dataset doesn't TypeError.
+        sentinel = MagicMock()
+        sentinel.split_fraction = None
+        provider_calls = []
 
-        with patch("hyrax.data_sets.data_provider.generate_data_request_from_config") as mock_generate:
-            with patch("hyrax.pytorch_ignite.is_iterable_dataset_requested") as mock_is_iterable:
-                with patch("hyrax.pytorch_ignite.fetch_dataset_class") as mock_fetch_cls:
-                    # Set up mocks
-                    mock_generate.return_value = config["model_inputs"]
-                    mock_is_iterable.return_value = True
-                    mock_fetch_cls.return_value = mock_dataset_cls
+        class MockDataProvider:
+            def __new__(cls, config, request):
+                provider_calls.append((config, request))
+                return sentinel
 
-                    # Call the function
-                    result = setup_dataset(config)
+        with patch("hyrax.pytorch_ignite.DataProvider", MockDataProvider):
+            result = setup_dataset(config)
 
-                    # Verify the dataset constructor was called with correct parameters
-                    expected_call = call(config=config, data_location="/some/valid/path")
-                    assert mock_dataset_cls.call_count == 2
-                    mock_dataset_cls.assert_has_calls([expected_call, expected_call])
-                    assert result["train"] == mock_dataset_instance
-                    assert result["infer"] == mock_dataset_instance
+            # DataProvider should be created for each data group with the full request dict
+            assert len(provider_calls) == 2
+            assert (config, config["data_request"]["train"]) in provider_calls
+            assert (config, config["data_request"]["infer"]) in provider_calls
+            assert result["train"] is sentinel
+            assert result["infer"] is sentinel

--- a/tests/hyrax/test_pytorch_ignite.py
+++ b/tests/hyrax/test_pytorch_ignite.py
@@ -10,7 +10,7 @@ class TestSetupDataset:
 
     def test_setup_dataset_missing_dataset_class_raises_error(self):
         """Test that missing dataset_class raises appropriate RuntimeError."""
-        # Create a minimal config that would trigger iterable dataset path
+        # Create a minimal config that omits dataset_class in data_request
         config = {
             "data_request": {
                 "train": {


### PR DESCRIPTION
Second round of removing iterable dataset support and references from Hyrax. Most edits are happening in pytorch_ignite, dataset_registry, and updated unit tests. 

This PR intentionally does not touch documentation. 

Closes #736