### PR TITLE
[AUTO-MERGE] Testing to see if we can remove the numba pinning.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
     "tqdm", # Used to show progress bars
     "qdrant-client", # Vector database for similarity search
     "colorama", # Used to color terminal output
-    "numba==0.63.1",
     "lancedb", # Used for columnar storage of inference results
     "pyarrow", # Used by lancedb for data interchange
     "pylance", # Used by lancedb for Lance dataset access


### PR DESCRIPTION
## Change Description
Closes #583
Removed the pin from the pyproject.toml file to see if the CI would pass, and indeed it does. I believe that we can simply remove this dependency pin now. 

