### PR TITLE
[AUTO-MERGE] Add list of external libraries that we know will be called and do not have default configs files.

### DIFF
--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -20,6 +20,7 @@ DEFAULT_USER_CONFIG_FILEPATH = Path.cwd() / "hyrax_config.toml"
 # There are only a couple of configuration keys where we would expect to find an
 # external library string, so we specify those here.
 KEYS_WITH_EXTERNAL_LIBS = ["name", "dataset_class"]
+KNOWN_LIBS_WITHOUT_DEFAULT_CONFIGS = ["torch", "umap"]
 
 logger = logging.getLogger(__name__)
 
@@ -353,6 +354,8 @@ class ConfigManager:
                 # We expect that values we are interested in will be of type string.
                 if key in KEYS_WITH_EXTERNAL_LIBS and isinstance(value, str) and "." in value:
                     external_library = value.split(".")[0]
+                    if external_library in KNOWN_LIBS_WITHOUT_DEFAULT_CONFIGS:
+                        continue
                     if importlib_util.find_spec(external_library) is not None:
                         try:
                             lib = importlib.import_module(external_library)

--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -368,7 +368,7 @@ class ConfigManager:
                                 logger.warning(f"Cannot find default_config.toml for {value}.")
                         except ModuleNotFoundError:
                             logger.error(
-                                f"External library {external_library} not found. Please install it before running."
+                                f"External library {external_library} not found. Check installation."
                             )
                             raise
                     else:

--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -368,7 +368,7 @@ class ConfigManager:
                                 logger.warning(f"Cannot find default_config.toml for {value}.")
                         except ModuleNotFoundError:
                             logger.error(
-                                f"External library {lib} not found. Please install it before running."
+                                f"External library {external_library} not found. Please install it before running."
                             )
                             raise
                     else:


### PR DESCRIPTION
## Change Description
Closes #328 
The approach suggested in the issue seems reasoanble, implementing it in this PR. Basically a list of external libraries that we know we will be calling (PyTorch, UMAP) - and when we encounter a dotted path from one of those we won't bother looking for an external default config.

### This PR
<img width="951" height="99" alt="Screenshot 2026-03-13 150206" src="https://github.com/user-attachments/assets/caa20ea8-0b3d-4069-a363-27bbbf6fa6f0" />

### Before this PR
<img width="1011" height="152" alt="Screenshot 2026-03-13 150236" src="https://github.com/user-attachments/assets/1604c744-f054-400e-ba10-b99ca249e0a3" />
