### PR TITLE
HyraxQL's `dataset_config` now accepts a full sub-config

### DIFF
--- a/benchmarks/data_cache_benchmarks.py
+++ b/benchmarks/data_cache_benchmarks.py
@@ -38,6 +38,7 @@ class DataCacheBenchmarks:
                     "dataset_class": "HSCDataSet",
                     "data_location": str(hsc_data_dir),
                     "fields": ["image"],
+                    "primary_id_field": "object_id",
                 }
             },
         }

--- a/benchmarks/data_request_benchmarks.py
+++ b/benchmarks/data_request_benchmarks.py
@@ -22,6 +22,7 @@ class DatasetRequestBenchmarks:
                     "dataset_class": "HyraxRandomDataset",
                     "data_location": str(self.input_dir),
                     "fields": ["image", "label", "object_id"],
+                    "primary_id_field": "object_id",
                 }
             },
             "infer": {
@@ -29,6 +30,7 @@ class DatasetRequestBenchmarks:
                     "dataset_class": "HyraxRandomDataset",
                     "data_location": str(self.input_dir),
                     "fields": ["image", "label", "object_id"],
+                    "primary_id_field": "object_id",
                 }
             },
         }

--- a/benchmarks/vector_db_benchmarks.py
+++ b/benchmarks/vector_db_benchmarks.py
@@ -28,6 +28,7 @@ class VectorDBInsertBenchmarks:
             "train": {
                 "data": {
                     "dataset_class": "HyraxRandomDataset",
+                    "data_location": "./data",
                     "fields": ["image", "label", "object_id"],
                     "primary_id_field": "object_id",
                 },
@@ -35,6 +36,7 @@ class VectorDBInsertBenchmarks:
             "infer": {
                 "data": {
                     "dataset_class": "HyraxRandomDataset",
+                    "data_location": "./data",
                     "fields": ["image", "label", "object_id"],
                     "primary_id_field": "object_id",
                 },
@@ -102,6 +104,7 @@ class VectorDBSearchBenchmarks:
             "train": {
                 "data": {
                     "dataset_class": "HyraxRandomDataset",
+                    "data_location": "./data",
                     "fields": ["image", "label", "object_id"],
                     "primary_id_field": "object_id",
                 },
@@ -109,6 +112,7 @@ class VectorDBSearchBenchmarks:
             "infer": {
                 "data": {
                     "dataset_class": "HyraxRandomDataset",
+                    "data_location": "./data",
                     "fields": ["image", "label", "object_id"],
                     "primary_id_field": "object_id",
                 },

--- a/src/hyrax/data_sets/data_provider.py
+++ b/src/hyrax/data_sets/data_provider.py
@@ -533,7 +533,7 @@ class DataProvider:
             tmp_config = {}
             for k, v in dataset_definition["dataset_config"].items():
                 if k in DATASET_REGISTRY:
-                    tmp_config["data_set"] = {k: v}
+                    tmp_config.setdefault("data_set", {})[k] = v
                 else:
                     tmp_config[k] = v
 

--- a/src/hyrax/data_sets/data_provider.py
+++ b/src/hyrax/data_sets/data_provider.py
@@ -434,16 +434,19 @@ class DataProvider:
         If no ``dataset_config`` is provided in the ``dataset_definition`` dict,
         the original base config will be returned unmodified.
 
-        Example of a dataset definition dictionary:
+        Data request dictionary examples:
 
+        1) Requesting a built-in Hyrax dataset, "MyDataset"
         .. code-block:: python
 
             "my_dataset": {
                 "dataset_class": "MyDataset",
                 "data_location": "/path/to/data",
                 "dataset_config": {
-                    "param1": "value1",
-                    "param2": "value2"
+                    "MyDataset": {
+                        "param1": "value1",
+                        "param2": "value2"
+                    }
                 },
                 "fields": ["field1", "field2"]
             }
@@ -457,13 +460,49 @@ class DataProvider:
             dataset_class = "MyDataset"
             data_location = "/path/to/data"
             fields = ["field1", "field2"]
-            [data_request.my_dataset.dataset_config]
+            [data_request.my_dataset.dataset_config.MyDataset]
             param1 = "value1"
             param2 = "value2"
 
-        In this example, the ``dataset_config`` dictionary will be merged into
+        Here the ``dataset_config`` dictionary will be merged into
         the original base config, overriding the values of param1 and param2
         when creating an instance of ``MyDataset``.
+
+        2) Requesting an external dataset (not built-in), "ExternalDataset"
+        Note that the dictionary nesting under "dataset_config" will match the
+        dictionary structure in the external dataset's default_config file.
+        .. code-block:: python
+
+            "my_dataset": {
+                "dataset_class": "ExternalDataset",
+                "data_location": "/path/to/data",
+                "dataset_config": {
+                    "external_example": {
+                        "MyDataset": {
+                            "param1": "value1",
+                            "param2": "value2"
+                        },
+                    },
+                },
+                "fields": ["field1", "field2"]
+            }
+
+        or equivalently in a .toml file:
+
+        .. code-block:: toml
+
+            [data_request]
+            [data_request.my_dataset]
+            dataset_class = "ExternalDataset"
+            data_location = "/path/to/data"
+            fields = ["field1", "field2"]
+            [data_request.my_dataset.dataset_config.external_example.MyDataset]
+            param1 = "value1"
+            param2 = "value2"
+
+        Here the ``dataset_config`` dictionary will be merged into
+        the original base config, overriding the values of param1 and param2
+        when creating an instance of ``ExternalDataset``.
 
         Parameters
         ----------
@@ -486,17 +525,17 @@ class DataProvider:
 
         cm = ConfigManager()
 
-        # NOTE: This assumes that the dataset-specific configuration options
-        # are nested under a top-level key that matches the dataset class name.
-        # i.e. "data_set": {"MyDataset": {<dataset-specific-options>}}. Or in toml
-        # [data_set.MyDataset]
-        # <dataset-specific-options>
-        # See: https://github.com/lincc-frameworks/hyrax/issues/417
-
+        # NOTE: This assume that the dittionary nesting under dataset_config will
+        # either 1) match the built-in dataset class name (e.g. "MyDataset") or
+        # 2) match the dictionary structure in the external dataset's default_config
+        # file (e.g. "external_example.ExternalDataset").
         if "dataset_config" in dataset_definition:
-            tmp_config = {
-                "data_set": {dataset_definition["dataset_class"]: dataset_definition["dataset_config"]}
-            }
+            tmp_config = {}
+            for k, v in dataset_definition["dataset_config"].items():
+                if k in DATASET_REGISTRY:
+                    tmp_config["data_set"] = {k: v}
+                else:
+                    tmp_config[k] = v
 
             # Note that `merge_configs` makes a copy of self.config, so the original
             # config will not be modified.

--- a/src/hyrax/data_sets/data_provider.py
+++ b/src/hyrax/data_sets/data_provider.py
@@ -429,6 +429,7 @@ class DataProvider:
         Data request dictionary examples:
 
         1) Requesting a built-in Hyrax dataset, "MyDataset"
+
         .. code-block:: python
 
             "my_dataset": {
@@ -463,6 +464,7 @@ class DataProvider:
         2) Requesting an external dataset (not built-in), "ExternalDataset"
         Note that the dictionary nesting under "dataset_config" will match the
         dictionary structure in the external dataset's default_config file.
+
         .. code-block:: python
 
             "my_dataset": {
@@ -470,7 +472,7 @@ class DataProvider:
                 "data_location": "/path/to/data",
                 "dataset_config": {
                     "external_example": {
-                        "MyDataset": {
+                        "ExternalDataset": {
                             "param1": "value1",
                             "param2": "value2"
                         },
@@ -517,7 +519,7 @@ class DataProvider:
 
         cm = ConfigManager()
 
-        # NOTE: This assume that the dittionary nesting under dataset_config will
+        # NOTE: This assumes that the dictionary nesting under dataset_config will
         # either 1) match the built-in dataset class name (e.g. "MyDataset") or
         # 2) match the dictionary structure in the external dataset's default_config
         # file (e.g. "external_example.ExternalDataset").

--- a/tests/hyrax/conftest.py
+++ b/tests/hyrax/conftest.py
@@ -118,7 +118,9 @@ def multimodal_config():
                 "data_location": "./in_memory_0",
                 "fields": ["object_id", "image", "label"],
                 "dataset_config": {
-                    "shape": [2, 16, 16],
+                    "HyraxRandomDataset": {
+                        "shape": [2, 16, 16],
+                    },
                 },
                 "primary_id_field": "object_id",
             },
@@ -127,8 +129,10 @@ def multimodal_config():
                 "data_location": "./in_memory_1",
                 "fields": ["image"],
                 "dataset_config": {
-                    "shape": [5, 16, 16],
-                    "seed": 4200,
+                    "HyraxRandomDataset": {
+                        "shape": [5, 16, 16],
+                        "seed": 4200,
+                    },
                 },
             },
         },
@@ -138,7 +142,9 @@ def multimodal_config():
                 "data_location": "./in_memory_0",
                 "fields": ["object_id", "image", "label"],
                 "dataset_config": {
-                    "shape": [2, 16, 16],
+                    "HyraxRandomDataset": {
+                        "shape": [2, 16, 16],
+                    },
                 },
                 "primary_id_field": "object_id",
             },
@@ -147,8 +153,10 @@ def multimodal_config():
                 "data_location": "./in_memory_1",
                 "fields": ["image"],
                 "dataset_config": {
-                    "shape": [5, 16, 16],
-                    "seed": 4200,
+                    "HyraxRandomDataset": {
+                        "shape": [5, 16, 16],
+                        "seed": 4200,
+                    },
                 },
             },
         },

--- a/tests/hyrax/test_data_provider.py
+++ b/tests/hyrax/test_data_provider.py
@@ -33,7 +33,7 @@ def test_generate_data_request_passes_model_inputs():
                 "data_location": "./data",
                 "primary_id_field": "object_id",
                 "fields": ["image"],
-                "dataset_config": {"shape": [1, 2, 3], "seed": 1},
+                "dataset_config": {"HyraxRandomDataset": {"shape": [1, 2, 3], "seed": 1}},
             }
         }
     }
@@ -280,6 +280,142 @@ def test_apply_configurations(multimodal_config):
     assert merged_config["general"] == base_config["general"]
 
 
+def test_apply_configurations_external_dataset():
+    """Test that _apply_configurations places external (non-registry)
+    dataset_config keys at the top level of the merged config, not
+    under 'data_set'."""
+
+    from hyrax import Hyrax
+
+    h = Hyrax()
+    base_config = h.config
+
+    dataset_definition = {
+        "dataset_class": "SomeExternalDataset",
+        "data_location": "/path/to/data",
+        "dataset_config": {
+            "external_example": {
+                "ExternalDataset": {
+                    "param1": "value1",
+                    "param2": 42,
+                },
+            },
+        },
+    }
+
+    merged = DataProvider._apply_configurations(base_config, dataset_definition)
+
+    assert "external_example" in merged
+    assert merged["external_example"]["ExternalDataset"]["param1"] == "value1"
+    assert merged["external_example"]["ExternalDataset"]["param2"] == 42
+    # External keys should NOT appear under data_set
+    assert "external_example" not in merged["data_set"]
+    # Unrelated sections should be unchanged
+    assert merged["general"] == base_config["general"]
+
+
+def test_apply_configurations_mixed_builtin_and_external():
+    """Test that _apply_configurations correctly routes built-in keys
+    under 'data_set' and external keys at the top level when both
+    are present in the same dataset_config."""
+
+    from hyrax import Hyrax
+
+    h = Hyrax()
+    base_config = h.config
+
+    dataset_definition = {
+        "dataset_class": "SomeDataset",
+        "dataset_config": {
+            "HyraxRandomDataset": {
+                "shape": [3, 3, 3],
+            },
+            "ext_lib": {
+                "ExtDS": {
+                    "foo": "bar",
+                },
+            },
+        },
+    }
+
+    merged = DataProvider._apply_configurations(base_config, dataset_definition)
+
+    # Built-in key should be merged under data_set
+    assert merged["data_set"]["HyraxRandomDataset"]["shape"] == [3, 3, 3]
+    # External key should be at top level
+    assert merged["ext_lib"]["ExtDS"]["foo"] == "bar"
+    assert "ext_lib" not in merged["data_set"]
+    assert merged["general"] == base_config["general"]
+
+
+def test_apply_configurations_no_dataset_config():
+    """Test that _apply_configurations returns the base_config unmodified
+    when dataset_definition has no 'dataset_config' key."""
+
+    from hyrax import Hyrax
+
+    h = Hyrax()
+    base_config = h.config
+
+    dataset_definition = {
+        "dataset_class": "HyraxRandomDataset",
+        "data_location": "/path/to/data",
+    }
+
+    result = DataProvider._apply_configurations(base_config, dataset_definition)
+
+    # The else branch returns base_config directly (identity)
+    assert result is base_config
+
+
+def test_apply_configurations_empty_dataset_config():
+    """Test that _apply_configurations with an empty dataset_config
+    returns a config equivalent to the base."""
+
+    from hyrax import Hyrax
+
+    h = Hyrax()
+    base_config = h.config
+
+    dataset_definition = {
+        "dataset_class": "HyraxRandomDataset",
+        "dataset_config": {},
+    }
+
+    merged = DataProvider._apply_configurations(base_config, dataset_definition)
+
+    assert merged["data_set"] == base_config["data_set"]
+    assert merged["general"] == base_config["general"]
+
+
+def test_apply_configurations_multiple_builtin_keys():
+    """Test that _apply_configurations preserves all built-in keys
+    when multiple are present in a single dataset_config."""
+
+    from hyrax import Hyrax
+
+    h = Hyrax()
+    base_config = h.config
+
+    dataset_definition = {
+        "dataset_class": "SomeDataset",
+        "dataset_config": {
+            "HyraxRandomDataset": {
+                "shape": [7, 7, 7],
+            },
+            "HyraxCSVDataset": {
+                "some_param": "some_value",
+            },
+        },
+    }
+
+    merged = DataProvider._apply_configurations(base_config, dataset_definition)
+
+    # Both built-in keys should survive under data_set
+    assert merged["data_set"]["HyraxRandomDataset"]["shape"] == [7, 7, 7]
+    assert merged["data_set"]["HyraxCSVDataset"]["some_param"] == "some_value"
+
+
 def test_primary_dataset(multimodal_config):
     """Test primary dataset selection behavior:
     - uses the dataset with a defined ``primary_id_field`` as primary,
@@ -399,7 +535,9 @@ def test_sample_data():
             "data_directory": "./in_memory_0",
             "fields": ["object_id", "image", "label"],
             "dataset_config": {
-                "shape": [2, 16, 16],
+                "HyraxRandomDataset": {
+                    "shape": [2, 16, 16],
+                },
             },
             "primary_id_field": "object_id",
         },
@@ -408,8 +546,10 @@ def test_sample_data():
             "data_directory": "./in_memory_1",
             "fields": ["image"],
             "dataset_config": {
-                "shape": [5, 16, 16],
-                "seed": 4200,
+                "HyraxRandomDataset": {
+                    "shape": [5, 16, 16],
+                    "seed": 4200,
+                },
             },
         },
     }
@@ -437,6 +577,11 @@ def test_sample_data():
         if friendly_name == "random_0":
             assert "object_id" in dataset_sample
             assert "label" in dataset_sample
+
+    # Verify the dataset_config overrides actually took effect
+    # (default shape is [2, 5, 5] — these should differ)
+    assert sample["random_0"]["image"].shape == (2, 16, 16)
+    assert sample["random_1"]["image"].shape == (5, 16, 16)
 
 
 def test_data_provider_get_item(data_provider):
@@ -576,12 +721,14 @@ def test_primary_id_field_fetched_when_not_in_fields():
             "fields": ["image", "label"],  # Note: "object_id" is NOT included
             "primary_id_field": "object_id",  # But this field is set as primary
             "dataset_config": {
-                "shape": [2, 3, 3],
-                "size": 5,
-                "seed": 42,
-                "provided_labels": ["cat", "dog"],
-                "number_invalid_values": 0,
-                "invalid_value_type": "nan",
+                "HyraxRandomDataset": {
+                    "shape": [2, 3, 3],
+                    "size": 5,
+                    "seed": 42,
+                    "provided_labels": ["cat", "dog"],
+                    "number_invalid_values": 0,
+                    "invalid_value_type": "nan",
+                },
             },
         }
     }
@@ -609,6 +756,9 @@ def test_primary_id_field_fetched_when_not_in_fields():
     # object_id should NOT be in dataset data since it wasn't requested in fields
     assert "object_id" not in data["test_dataset"]
 
+    # Verify the dataset_config overrides took effect (default shape is [2, 5, 5])
+    assert data["test_dataset"]["image"].shape == (2, 3, 3)
+
 
 def test_primary_id_field_reused_when_already_in_fields():
     """Test that primary_id_field is reused when already in fields list.
@@ -631,12 +781,14 @@ def test_primary_id_field_reused_when_already_in_fields():
             "fields": ["object_id", "image", "label"],  # object_id already included
             "primary_id_field": "object_id",
             "dataset_config": {
-                "shape": [2, 3, 3],
-                "size": 5,
-                "seed": 42,
-                "provided_labels": ["cat", "dog"],
-                "number_invalid_values": 0,
-                "invalid_value_type": "nan",
+                "HyraxRandomDataset": {
+                    "shape": [2, 3, 3],
+                    "size": 5,
+                    "seed": 42,
+                    "provided_labels": ["cat", "dog"],
+                    "number_invalid_values": 0,
+                    "invalid_value_type": "nan",
+                },
             },
         }
     }
@@ -674,6 +826,9 @@ def test_primary_id_field_reused_when_already_in_fields():
 
     # The top-level object_id should match the dataset's object_id (reused value)
     assert data["object_id"] == data["test_dataset"]["object_id"]
+
+    # Verify the dataset_config overrides took effect (default shape is [2, 5, 5])
+    assert data["test_dataset"]["image"].shape == (2, 3, 3)
 
 
 def test_collate_function(data_provider):


### PR DESCRIPTION
## Change Description
Modified `dataset_config` syntax to accept a full sub-configuration.
Closes #576 

## Solution Description
See the `dataset_config` section below. Note that you can pass a full set of nested dictionaries there. If the key is a known Hyrax built-in dataset class you don't need to build the full nested dictionary structure. If it's an external class like "galaxy10_dataset" shown here, the user will build the full nested dictionary that is present in the external default_config.toml file. A copy of this example's toml file is shown below as well.

``` python
data_request = {
    "train": {
        "data": {
            "dataset_class": "external_hyrax_example.datasets.galaxy10_dataset.Galaxy10Dataset",
            "data_location": "/home/drew/code/external_hyrax_example/docs/pre_executed/data/galaxy_10",
            "fields": ["image", "label"],
            "primary_id_field": "object_id",
            "split_fraction": 0.8,
            "dataset_config": {
                "external_hyrax_example": {
                    "galaxy10_dataset": {
                        "channels_first": True,
                    },
                },
                "HyraxRandomDataset": {
                    "size": 42,
                },
            },
        },
    },
}
```


``` toml
[external_hyrax_example]

[external_hyrax_example.galaxy10_dataset]
# When false, the images will be in (N, H, W, C) format.
# When true, the images will be transposed to (N, C, H, W) format.
channels_first = false
```