### PR TITLE
Once inside Hyrax, all "object_id" values are strings.

### DIFF
--- a/src/hyrax/datasets/data_provider.py
+++ b/src/hyrax/datasets/data_provider.py
@@ -588,7 +588,7 @@ class DataProvider:
             tensorboardx_logger.log_duration_ts(f"{prefix}/cache_hit_s", start_time)
             return cached_data
 
-        returned_data: dict[str, dict[str, Any]] = {}
+        returned_data: dict[str, dict[str, Any] | str] = {}
 
         for friendly_name, fields in self.requested_fields.items():
             getters = self.dataset_getters[friendly_name]

--- a/src/hyrax/datasets/data_provider.py
+++ b/src/hyrax/datasets/data_provider.py
@@ -568,7 +568,7 @@ class DataProvider:
         """
         return [self.get_object_id(idx) for idx in range(len(self))]
 
-    def resolve_data(self, idx: int) -> dict:
+    def resolve_data(self, idx: int) -> dict[str, dict[str, Any] | str]:
         """This method requests the field data from the prepared datasets by index.
 
         Parameters
@@ -578,8 +578,11 @@ class DataProvider:
 
         Returns
         -------
-        dict
+        dict[str, dict[str, Any] | str]
             A dictionary containing the requested data from the prepared datasets.
+            Each key is a dataset friendly name mapped to a dict of field values.
+            If a primary dataset is configured, the top-level ``"object_id"`` key
+            holds a string representation of the primary ID.
         """
         start_time = time.monotonic_ns()
         prefix = self.__class__.__name__

--- a/src/hyrax/datasets/data_provider.py
+++ b/src/hyrax/datasets/data_provider.py
@@ -549,20 +549,22 @@ class DataProvider:
         """
         return self[0]
 
-    def get_object_id(self, idx) -> Any:
+    def get_object_id(self, idx: int) -> str:
         """Returns the ID at a particular index.
 
         IDs are provided by the primary dataset's primary ID column.
         """
-        return self.dataset_getters[self.primary_dataset][self.primary_dataset_id_field_name](idx)
+        primary_dataset = self.dataset_getters[self.primary_dataset]
+        primary_dataset_object_id = primary_dataset[self.primary_dataset_id_field_name](idx)
+        return str(primary_dataset_object_id)
 
-    def ids(self) -> list[Any]:
-        """Returns the IDs of the dataset.
+    def ids(self) -> list[str]:
+        """Returns the IDs of the primary dataset.
 
-        IDs flow from the primary dataset and the primary ID column.
-
-        data_provider.ids() is canonically the same as
-        [data_provider.get_object_id(i) for i in range(len(data_provider))]
+        Returns
+        -------
+        list of str
+            A list of string IDs corresponding to the primary dataset, ordered by index.
         """
         return [self.get_object_id(idx) for idx in range(len(self))]
 
@@ -602,7 +604,7 @@ class DataProvider:
             else:
                 object_id = returned_data[self.primary_dataset][self.primary_dataset_id_field_name]
 
-            returned_data["object_id"] = object_id
+            returned_data["object_id"] = str(object_id)
 
         self.data_cache.insert_into_cache(idx, returned_data)
         tensorboardx_logger.log_duration_ts(f"{prefix}/cache_miss_s", start_time)

--- a/tests/hyrax/test_data_provider.py
+++ b/tests/hyrax/test_data_provider.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from hyrax import Hyrax
+from hyrax.datasets import HyraxDataset
 from hyrax.datasets.data_provider import DataProvider, generate_data_request_from_config
 
 
@@ -913,3 +914,44 @@ def test_custom_collate_function_applied(custom_collate_data_provider):
 
     # assert that the object_id key is a numpy array
     assert isinstance(collated_batch["object_id"], np.ndarray)
+
+
+def test_object_id_is_string():
+    """Ensure that the object_id field is returned as a string at the top level of
+    the sample, even if the dataset's get_object_id method returns an int. And
+    also ensure that the original integer ID is preserved within the dataset-specific
+    entry."""
+
+    class IntIDDataset(HyraxDataset):
+        """Toy dataset class that returns object_id as an integer."""
+
+        def __init__(self, config, data_location):
+            super().__init__(config)
+
+        def __len__(self):
+            return 1
+
+        def get_object_id(self, idx):
+            return idx
+
+    h = Hyrax()
+    data_request = {
+        "train": {
+            "int_id_dataset": {
+                "dataset_class": "IntIDDataset",
+                "data_location": "./test_data",
+                "fields": ["object_id"],
+                "primary_id_field": "object_id",
+            }
+        }
+    }
+    h.config["data_request"] = data_request
+
+    dp = DataProvider(h.config, data_request["train"])
+    dp.prepare_datasets()
+
+    sample = dp[0]
+    assert "object_id" in sample
+    assert isinstance(sample["object_id"], str)
+    assert sample["object_id"] == "0"
+    assert sample["int_id_dataset"]["object_id"] == 0

--- a/tests/hyrax/test_data_provider.py
+++ b/tests/hyrax/test_data_provider.py
@@ -932,6 +932,7 @@ def test_object_id_is_string():
             return 1
 
         def get_object_id(self, idx):
+            """Return the integer object_id for the given index."""
             return idx
 
     h = Hyrax()


### PR DESCRIPTION
## Change Description
Use DataProvider as the pinch point to ensure that primary_id_field values are always cast to strings.

This closes out a rather old bug from before the time when we really landed on all ids should be strings. I believe that most built in dataset classes return string ids at this point, but the intent of this change is to ensure that the "object_id" key that is returned on the outside of the data sample is converted to a string.

Note: I intentionally _do not_ convert the internal object id into a string because that seems like it would be surprising to the user.

An example input and return value:
```python
class MyDataset():
    def get_object_id(self, index) -> int:  # note this returns an integer
        return 1  # just an example

data_request = {
    'data': {
        'dataset_class': 'MyDataset',
        'fields': ['object_id'],
        'primary_id_field': 'object_id',
     }
}

# returned_value
{
    'data': {
        'object_id': 1,  # <-- Note: type is the same as what is returned from dataset class get_object_id method.
    },
    'object_id': '1',  # <-- Note: type is coerced to string
}
```

## Solution Description
- `DataProvider.get_object_id()` and the top-level `returned_data["object_id"]` assignment in `resolve_data()` now cast the primary ID to `str`.
- The `returned_data` local variable type annotation and the return type of `resolve_data()` have both been updated to `dict[str, dict[str, Any] | str]` to accurately reflect the mixed structure (nested field dicts per dataset, plus the top-level string `"object_id"` key).
- `DataProvider.ids()` typing and documentation updated to reflect string IDs.
- A regression test was added to verify that the top-level `object_id` is coerced to a string even when the dataset's `get_object_id` method returns an integer.

## Code Quality
- [ ] I have read the Contribution Guide and agree to the Code of Conduct
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.