### PR TITLE
Remove an extraneous sentence from the learning rate scheduler notebook

### DIFF
--- a/docs/pre_executed/using_lr_schedulers.ipynb
+++ b/docs/pre_executed/using_lr_schedulers.ipynb
@@ -374,7 +374,7 @@
    "source": [
     "## Note on ChainedScheduler and SequentialLR\n",
     "\n",
-    "Hyrax config does not support the [ChainedScheduler](https://docs.pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ChainedScheduler.html) or [SequentialLR](https://docs.pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.SequentialLR.html) scheduler; those must be directly defined in the model if desired to be used. This notebook will walk through the default LR used in Hyrax as well as defining an ExponentialLR defined in the config."
+    "Hyrax config does not support the [ChainedScheduler](https://docs.pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ChainedScheduler.html) or [SequentialLR](https://docs.pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.SequentialLR.html) scheduler; those must be directly defined in the model if desired to be used."
    ]
   }
  ],


### PR DESCRIPTION
There was a confusing sentence that I forgot to delete at the end of the learning rate scheduler notebook which was missed on the first pass. I deleted it now.