### PR TITLE
[AUTO-MERGE] Adding data request examples notebook.

### DIFF
--- a/docs/common_workflows.rst
+++ b/docs/common_workflows.rst
@@ -5,6 +5,7 @@ Common workflows
    :maxdepth: 1
 
    Configuration basics <notebooks/config_basics>
+   Data requests <notebooks/data_requests>
    List available models and dataset classes <notebooks/list_available_models_and_datasets>
    Working with result datasets <pre_executed/working_with_results_data>
    Look up results by ID <notebooks/lookup_results_by_id>

--- a/docs/notebooks/data_requests.ipynb
+++ b/docs/notebooks/data_requests.ipynb
@@ -141,8 +141,17 @@
     "Hyrax also supports dataset splits defined as fractions of a single directory.\n",
     "This is useful when all files live together and it would be impractical to move them into separate directories.\n",
     "\n",
-    "Hyrax automatically verifies that the split fractions for a given verb and data location sum to ≤ 1.0.\n",
-    "In the example below, `\"train\"` and `\"validate\"` both point to `./all_data` and the fractions sum to 1.0."
+    "Hyrax validates `split_fraction` across the **active data groups** that share the same `data_location`.\n",
+    "**Active data groups** are the groups that the current verb actually processes — for example,\n",
+    "when running `train`, the active groups are `\"train\"` and `\"validate\"` (if present).\n",
+    "\n",
+    "Two rules are enforced:\n",
+    "1. If *any* active group for a given `data_location` sets `split_fraction`, then *all* active groups\n",
+    "   for that `data_location` must also set `split_fraction`.\n",
+    "2. The `split_fraction` values across all active groups for a `data_location` must sum to ≤ 1.0.\n",
+    "\n",
+    "In the example below, `\"train\"` and `\"validate\"` are both active and both point to `./all_data`,\n",
+    "so both must set `split_fraction` and the fractions sum to 1.0."
    ]
   },
   {
@@ -166,7 +175,7 @@
     "            \"dataset_class\": \"HyraxCifarDataset\",\n",
     "            \"data_location\": \"./all_data\",\n",
     "            \"primary_id_field\": \"object_id\",\n",
-    "            \"split_fraction\": 0.2,  # <- The sum of all split fractions for given verb and data location should sum to <= 1.0\n",
+    "            \"split_fraction\": 0.2,  # <- The split fractions for all active groups sharing a data_location must sum to <= 1.0\n",
     "        }\n",
     "    },\n",
     "}"

--- a/docs/notebooks/data_requests.ipynb
+++ b/docs/notebooks/data_requests.ipynb
@@ -20,15 +20,9 @@
     "A few terms are helpful to keep in mind while working through this notebook.\n",
     "\n",
     "- **data request** : The structured specification of what data Hyrax should use for a given task or verb.\n",
-    "- **data group** : A grouping of datasets requested for a particular task (e.g. `\"train\"`, `\"test\"`, `\"infer\"`).\n",
+    "- **data group** : A grouping of datasets requested for a particular task (e.g. `\"train\"`, `\"validate\"`, `\"infer\"`).\n",
     "- **dataset** : One specific source of data within a data group.\n",
-    "- **friendly name** : The user-assigned name for a particular dataset within a data group.\n",
-    "- **dataset field** : The smallest unit of data exposed by a dataset, e.g. an image, label, or metadata column.\n",
-    "\n",
-    "A note about data groups: some Hyrax verbs require specific data group names.\n",
-    "For example, the `infer` verb requires a data group named `\"infer\"`, and the `train` verb requires\n",
-    "a data group named `\"train\"`. The `train` verb will also run a validation epoch after each training epoch\n",
-    "if an optional `\"validate\"` data group is present."
+    "- **friendly name** : The user-assigned name for a particular dataset within a data group.\n"
    ]
   },
   {
@@ -75,7 +69,8 @@
     "In practice, once the data request is defined, we would need to add it to the Hyrax runtime configuration.\n",
     "To ensure that the configuration is fully resolved, use the `set_config()` method.\n",
     "\n",
-    "This is demonstrated in the next cell, but after that, we'll only show examples of using the data request syntax."
+    "Some Hyrax verbs require specific data group names.\n",
+    "For example, the `infer` verb requires a group named `\"infer\"`, and the `train` verb requires a group named `\"train\"`.\n"
    ]
   },
   {
@@ -98,12 +93,11 @@
    "source": [
     "## Optional data groups with train and validate\n",
     "\n",
-    "Some verbs accept additional, optional data groups.\n",
     "The `train` verb _requires_ a `\"train\"` data group and optionally accepts a `\"validate\"` data group.\n",
     "When the `\"validate\"` data group is present, a validation epoch is run after each training epoch.\n",
     "\n",
     "Note that the `data_location` values differ between the two groups below.\n",
-    "This is how Hyrax supports data splits defined as separate sets of files."
+    "This is how Hyrax supports data splits defined as separate sets of files.\n"
    ]
   },
   {
@@ -117,14 +111,14 @@
     "    \"train\": {\n",
     "        \"my_data\": {\n",
     "            \"dataset_class\": \"HyraxCifarDataset\",\n",
-    "            \"data_location\": \"./train_data\",  # <- Note the location here\n",
+    "            \"data_location\": \"./train_data\",\n",
     "            \"primary_id_field\": \"object_id\",\n",
     "        }\n",
     "    },\n",
     "    \"validate\": {\n",
-    "        \"my_data\": {  # <- Using the same friendly name here for simplicity.\n",
+    "        \"my_data\": {  # <- Same friendly name as in \"train\"\n",
     "            \"dataset_class\": \"HyraxCifarDataset\",\n",
-    "            \"data_location\": \"./validate_data\",  # <- Note the location here\n",
+    "            \"data_location\": \"./validate_data\",  # <- Different location for the validation split\n",
     "            \"primary_id_field\": \"object_id\",\n",
     "        }\n",
     "    },\n",
@@ -141,17 +135,10 @@
     "Hyrax also supports dataset splits defined as fractions of a single directory.\n",
     "This is useful when all files live together and it would be impractical to move them into separate directories.\n",
     "\n",
-    "Hyrax validates `split_fraction` across the **active data groups** that share the same `data_location`.\n",
-    "**Active data groups** are the groups that the current verb actually processes — for example,\n",
-    "when running `train`, the active groups are `\"train\"` and `\"validate\"` (if present).\n",
+    "All active groups sharing the same `data_location` must declare `split_fraction`, and their values must sum to ≤ 1.0.\n",
+    "**Active data groups** are the groups the current verb actually processes — when running `train`, that means `\"train\"` and `\"validate\"` (if present).\n",
     "\n",
-    "Two rules are enforced:\n",
-    "1. If *any* active group for a given `data_location` sets `split_fraction`, then *all* active groups\n",
-    "   for that `data_location` must also set `split_fraction`.\n",
-    "2. The `split_fraction` values across all active groups for a `data_location` must sum to ≤ 1.0.\n",
-    "\n",
-    "In the example below, `\"train\"` and `\"validate\"` are both active and both point to `./all_data`,\n",
-    "so both must set `split_fraction` and the fractions sum to 1.0."
+    "Fractions may sum to less than 1.0; using a small fraction is a common way to speed up iteration during early experimentation.\n"
    ]
   },
   {
@@ -182,15 +169,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "80136343",
-   "metadata": {},
-   "source": [
-    "Split fractions may sum to less than 1.0. Using a small fraction is a common way to\n",
-    "speed up iteration during early experimentation, since less data is processed per run."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "75e9279d",
@@ -203,7 +181,7 @@
     "            \"dataset_class\": \"HyraxCifarDataset\",\n",
     "            \"data_location\": \"./all_data\",\n",
     "            \"primary_id_field\": \"object_id\",\n",
-    "            \"split_fraction\": 0.01,  # <- Very small fraction for quick testing in the notebook\n",
+    "            \"split_fraction\": 0.01,\n",
     "        }\n",
     "    },\n",
     "    \"validate\": {\n",
@@ -211,7 +189,7 @@
     "            \"dataset_class\": \"HyraxCifarDataset\",\n",
     "            \"data_location\": \"./all_data\",\n",
     "            \"primary_id_field\": \"object_id\",\n",
-    "            \"split_fraction\": 0.002,  # <- Note that the sum of split fractions for train and validate is <= 1.0\n",
+    "            \"split_fraction\": 0.002,  # <- train + validate fractions sum to 0.012, well under 1.0\n",
     "        }\n",
     "    },\n",
     "}"
@@ -231,7 +209,8 @@
     "By default, a data request will consume _all_ fields a dataset class exposes.\n",
     "Use the `fields` parameter to request only the fields you need.\n",
     "\n",
-    "Note: `primary_id_field` is always fetched regardless of the `fields` list, so there is no need to include it explicitly."
+    "Note: `primary_id_field` is always fetched so that Hyrax can track and save results.\n",
+    "But unless it is included in the `fields` list it will not be included in the data passed to models."
    ]
   },
   {
@@ -355,10 +334,10 @@
     "For classes defined in an external package, provide the fully qualified import path as the `dataset_class` value.\n",
     "This is the dotted path you would use in an import statement.\n",
     "\n",
-    "For example, `\"my_package.my_dataset.MyDatasetClass\"` corresponds to:\n",
+    "For example, `\"my_package.datasets.my_dataset.MyDatasetClass\"` corresponds to:\n",
     "\n",
     "```python\n",
-    "from my_package.my_dataset import MyDatasetClass\n",
+    "from my_package.datasets.my_dataset import MyDatasetClass\n",
     "```"
    ]
   },
@@ -372,7 +351,7 @@
     "data_request = {\n",
     "    \"train\": {\n",
     "        \"my_external_data\": {\n",
-    "            \"dataset_class\": \"my_package.my_dataset.MyDatasetClass\",  # <- dotted path\n",
+    "            \"dataset_class\": \"my_package.datasets.my_dataset.MyDatasetClass\",  # <- dotted path\n",
     "            \"data_location\": \"./data\",\n",
     "            \"primary_id_field\": \"object_id\",\n",
     "        }\n",
@@ -387,16 +366,22 @@
    "source": [
     "### Dataset config for external dataset classes\n",
     "\n",
-    "External dataset classes should define their default configuration in a `.toml` file.\n",
+    "External dataset classes should define their default configurations in a `default_config.toml` file.\n",
     "For the hypothetical class above, the defaults might look like:\n",
     "\n",
     "```toml\n",
-    "[my_package.my_dataset.MyDatasetClass]\n",
+    "[my_package.MyDatasetClass]\n",
     "parameter_a = true\n",
     "parameter_b = 100\n",
     "```\n",
     "\n",
-    "To override these values inside a data request, mirror the same nesting under `dataset_config`:"
+    "We can override default values inside a data request by mirroring the same nesting under `dataset_config`\n",
+    "\n",
+    "Note that the TOML structure is not required to match the package structure.\n",
+    "i.e. the location of the class in the package does not have to match the nested tables in TOML.\n",
+    "```\n",
+    "my_package.datasets.my_dataset.MyDatasetClass (package) != my_package.MyDatasetClass (toml)\n",
+    "```"
    ]
   },
   {
@@ -409,16 +394,14 @@
     "data_request = {\n",
     "    \"train\": {\n",
     "        \"my_external_data\": {\n",
-    "            \"dataset_class\": \"my_package.my_dataset.MyDatasetClass\",\n",
+    "            \"dataset_class\": \"my_package.datasets.my_dataset.MyDatasetClass\",\n",
     "            \"data_location\": \"./data\",\n",
     "            \"primary_id_field\": \"object_id\",\n",
     "            \"dataset_config\": {\n",
-    "                \"my_package\": {  # <- Note that this nesting matches the nesting in the toml file\n",
-    "                    \"my_dataset\": {\n",
-    "                        \"MyDatasetClass\": {\n",
-    "                            \"parameter_a\": False,\n",
-    "                            \"parameter_b\": 42,\n",
-    "                        }\n",
+    "                \"my_package\": {  # <- Note the nesting matches table nesting in the toml file\n",
+    "                    \"MyDatasetClass\": {\n",
+    "                        \"parameter_a\": False,\n",
+    "                        \"parameter_b\": 42,\n",
     "                    }\n",
     "                }\n",
     "            },\n",
@@ -434,8 +417,8 @@
    "source": [
     "## Converting to TOML\n",
     "\n",
-    "When a Hyrax verb uses a data request, it will be converted to a TOML representation and stored in the runtime_config.toml file along with any other output.\n",
-    "Typically a user wouldn't write the TOML directly, but for educational purposes, we'll demonstrate a Python dictionary data request followed by the TOML representation."
+    "When Hyrax runs a verb, the data request is serialized to TOML and saved alongside the output in `runtime_config.toml`.\n",
+    "The equivalent TOML for the data request defined in the next cell is shown below.\n"
    ]
   },
   {
@@ -458,10 +441,9 @@
     "            \"dataset_class\": \"HyraxCifarDataset\",\n",
     "            \"data_location\": \"./data\",\n",
     "            \"primary_id_field\": \"object_id\",\n",
-    "            \"dataset_config\": {  # <- Pass specific configurations just for this dataset\n",
-    "                \"HyraxCifarDataset\": {  # <- This matches the dataset_class value\n",
+    "            \"dataset_config\": {\n",
+    "                \"HyraxCifarDataset\": {\n",
     "                    \"use_training_data\": False,\n",
-    "                    # Additional dataset-specific configurations can be passed here\n",
     "                }\n",
     "            },\n",
     "        }\n",
@@ -474,7 +456,7 @@
    "id": "7e74159c",
    "metadata": {},
    "source": [
-    "The TOML representation:\n",
+    "The TOML representation of the data request defined above:\n",
     "```toml\n",
     "[data_request.train.my_data]\n",
     "dataset_class = \"HyraxCifarDataset\"\n",
@@ -489,6 +471,26 @@
     "[data_request.validate.my_data.dataset_config.HyraxCifarDataset]\n",
     "use_training_data = false\n",
     "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "563212c8",
+   "metadata": {},
+   "source": [
+    "## Best practices\n",
+    "\n",
+    "### Use the same friendly name for the same data across different data groups.\n",
+    "\n",
+    "For instance, given a data source of spectra data using for both training, validation and inference,\n",
+    "use the same friendly name, such as \"specta_data\" in each of the \"train\", \"validate\" and \"infer\" groups.\n",
+    "\n",
+    "### Ensure that multi-modal data requests have datasets that are *index aligned*.\n",
+    "\n",
+    "Here *index aligned* means that for a given index `i`, each dataset must return data corresponding to the same object.\n",
+    "For example, if two datasets hold images and spectra respectively, `images[i]` and `spectra[i]` must refer to the same object.\n",
+    "This doesn't necessarily mean that the datasets must be exactly the same size.\n",
+    "The non-primary datasets can be larger than the primary dataset, but they shouldn't be smaller.\n"
    ]
   }
  ],

--- a/docs/notebooks/data_requests.ipynb
+++ b/docs/notebooks/data_requests.ipynb
@@ -1,0 +1,507 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8dc4b706",
+   "metadata": {},
+   "source": [
+    "# Requesting data with Hyrax\n",
+    "## How to tell Hyrax what data to use.\n",
+    "\n",
+    "One of the core aspects of Hyrax is its ability to move data around in a reproducible way.\n",
+    "To support this, the user must tell Hyrax what data is meant to be used and for what purpose.\n",
+    "\n",
+    "This information is provided to Hyrax as a \"data request\".\n",
+    "In this notebook we explain how to construct a data request.\n",
+    "Throughout this notebook we define data requests as Python dictionaries, as you would in a notebook workflow.\n",
+    "They can just as easily be defined in a TOML config file.\n",
+    "\n",
+    "## Terminology\n",
+    "A few terms are helpful to keep in mind while working through this notebook.\n",
+    "\n",
+    "- **data request** : The structured specification of what data Hyrax should use for a given task or verb.\n",
+    "- **data group** : A grouping of datasets requested for a particular task (e.g. `\"train\"`, `\"test\"`, `\"infer\"`).\n",
+    "- **dataset** : One specific source of data within a data group.\n",
+    "- **friendly name** : The user-assigned name for a particular dataset within a data group.\n",
+    "- **dataset field** : The smallest unit of data exposed by a dataset, e.g. an image, label, or metadata column.\n",
+    "\n",
+    "A note about data groups: some Hyrax verbs require specific data group names.\n",
+    "For example, the `infer` verb requires a data group named `\"infer\"`, and the `train` verb requires\n",
+    "a data group named `\"train\"`. The `train` verb will also run a validation epoch after each training epoch\n",
+    "if an optional `\"validate\"` data group is present."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7f1a583",
+   "metadata": {},
+   "source": [
+    "## Basic data request\n",
+    "\n",
+    "Here we define a minimal request for inference data.\n",
+    "\n",
+    "Every dataset requires the following fields:\n",
+    "- `friendly_name` (the dictionary key): A human-readable name for the dataset, e.g. `\"my_data\"`. This key appears in every sample returned by the DataProvider, so choose a descriptive name.\n",
+    "- `dataset_class`: The name of the dataset class to use. For built-in Hyrax datasets, use just the class name (e.g. `\"HyraxCifarDataset\"`). For external datasets, use the fully qualified import path (e.g. `\"my_package.my_module.MyClass\"`).\n",
+    "- `data_location`: The path to the data directory.\n",
+    "- `primary_id_field`: The name of the dataset field that provides a unique identifier for each sample (e.g. `\"object_id\"`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c087f3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"infer\": {\n",
+    "        \"my_data\": {  # <- The friendly name\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "        }\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72903e0a",
+   "metadata": {},
+   "source": [
+    "## Setting the data request\n",
+    "\n",
+    "In practice, once the data request is defined, we would need to add it to the Hyrax runtime configuration.\n",
+    "To ensure that the configuration is fully resolved, use the `set_config()` method.\n",
+    "\n",
+    "This is demonstrated in the next cell, but after that, we'll only show examples of using the data request syntax."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "654012cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hyrax import Hyrax\n",
+    "\n",
+    "h = Hyrax()\n",
+    "h.set_config(\"data_request\", data_request)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e2b7962",
+   "metadata": {},
+   "source": [
+    "## Optional data groups with train and validate\n",
+    "\n",
+    "Some verbs accept additional, optional data groups.\n",
+    "The `train` verb _requires_ a `\"train\"` data group and optionally accepts a `\"validate\"` data group.\n",
+    "When the `\"validate\"` data group is present, a validation epoch is run after each training epoch.\n",
+    "\n",
+    "Note that the `data_location` values differ between the two groups below.\n",
+    "This is how Hyrax supports data splits defined as separate sets of files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce8583e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./train_data\",  # <- Note the location here\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "        }\n",
+    "    },\n",
+    "    \"validate\": {\n",
+    "        \"my_data\": {  # <- Using the same friendly name here for simplicity.\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./validate_data\",  # <- Note the location here\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "        }\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a260414",
+   "metadata": {},
+   "source": [
+    "## Defining a split fraction\n",
+    "\n",
+    "Hyrax also supports dataset splits defined as fractions of a single directory.\n",
+    "This is useful when all files live together and it would be impractical to move them into separate directories.\n",
+    "\n",
+    "Hyrax automatically verifies that the split fractions for a given verb and data location sum to ≤ 1.0.\n",
+    "In the example below, `\"train\"` and `\"validate\"` both point to `./all_data` and the fractions sum to 1.0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2dda8a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./all_data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"split_fraction\": 0.8,  # <- Optionally specify a split fraction to split the data into train/validate\n",
+    "        }\n",
+    "    },\n",
+    "    \"validate\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./all_data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"split_fraction\": 0.2,  # <- The sum of all split fractions for given verb and data location should sum to <= 1.0\n",
+    "        }\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80136343",
+   "metadata": {},
+   "source": [
+    "Split fractions may sum to less than 1.0. Using a small fraction is a common way to\n",
+    "speed up iteration during early experimentation, since less data is processed per run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75e9279d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./all_data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"split_fraction\": 0.01,  # <- Very small fraction for quick testing in the notebook\n",
+    "        }\n",
+    "    },\n",
+    "    \"validate\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./all_data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"split_fraction\": 0.002,  # <- Note that the sum of split fractions for train and validate is <= 1.0\n",
+    "        }\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39495cc4",
+   "metadata": {},
+   "source": [
+    "## Requesting specific fields\n",
+    "\n",
+    "Dataset classes in Hyrax expose data via field getter methods.\n",
+    "A field is the smallest unit of data for a given sample, such as a label or an image.\n",
+    "Some dataset classes expose many fields — for example, `HyraxCSVDataset` presents each CSV column as a separate field.\n",
+    "\n",
+    "By default, a data request will consume _all_ fields a dataset class exposes.\n",
+    "Use the `fields` parameter to request only the fields you need.\n",
+    "\n",
+    "Note: `primary_id_field` is always fetched regardless of the `fields` list, so there is no need to include it explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6cd5ce3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./all_data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"fields\": [\"image\", \"label\"],\n",
+    "        }\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "151f8269",
+   "metadata": {},
+   "source": [
+    "## Using multiple data sources\n",
+    "\n",
+    "The friendly name exists so that data from multiple sources can be combined in a single data group.\n",
+    "Hyrax joins them at runtime — no pre-processing step or on-disk merge is required.\n",
+    "\n",
+    "\n",
+    "**Important:** When using multiple datasets, Hyrax requires them to be *index-aligned*.\n",
+    "This means that for a given index `i`, each dataset must return data corresponding to the same object.\n",
+    "For example, if your two datasets hold images and spectra respectively,\n",
+    "`images[i]` and `spectra[i]` must refer to the same object.\n",
+    "\n",
+    "Note that `primary_id_field` is only required on one \"primary\" dataset.\n",
+    "Hyrax uses that dataset's identifiers when storing results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b314d9d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./all_data\",\n",
+    "            \"primary_id_field\": \"object_id\",  # <- Now tagged as the primary dataset\n",
+    "            \"fields\": [\"image\", \"label\"],\n",
+    "        },\n",
+    "        \"random_data\": {\n",
+    "            \"dataset_class\": \"HyraxRandomDataset\",\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"fields\": [\"image\"],\n",
+    "        },\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96b6f00b",
+   "metadata": {},
+   "source": [
+    "## Per-source dataset configuration\n",
+    "\n",
+    "Dataset class parameters are normally set once in a config file before a run.\n",
+    "However, when the same dataset class is used for two data sources that require different parameters,\n",
+    "you can provide those overrides inline using the `dataset_config` key.\n",
+    "\n",
+    "In the example below, `HyraxCifarDataset` is used for both training and validation.\n",
+    "For validation we need to set `use_training_data = False`, which would conflict with the training\n",
+    "configuration if set globally — so we scope it to just the `\"validate\"` data source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d29883dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "        }\n",
+    "    },\n",
+    "    \"validate\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"dataset_config\": {  # <- Pass specific configurations just for this dataset\n",
+    "                \"HyraxCifarDataset\": {  # <- This matches the dataset_class value\n",
+    "                    \"use_training_data\": False,\n",
+    "                    # Additional dataset-specific configurations can be passed here\n",
+    "                }\n",
+    "            },\n",
+    "        }\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc60dff1",
+   "metadata": {},
+   "source": [
+    "## Requesting an external dataset class\n",
+    "\n",
+    "Hyrax ships with a small number of built-in dataset classes.\n",
+    "For classes defined in an external package, provide the fully qualified import path as the `dataset_class` value.\n",
+    "This is the dotted path you would use in an import statement.\n",
+    "\n",
+    "For example, `\"my_package.my_dataset.MyDatasetClass\"` corresponds to:\n",
+    "\n",
+    "```python\n",
+    "from my_package.my_dataset import MyDatasetClass\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "308a661a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_external_data\": {\n",
+    "            \"dataset_class\": \"my_package.my_dataset.MyDatasetClass\",  # <- dotted path\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "        }\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1edefe9",
+   "metadata": {},
+   "source": [
+    "### Dataset config for external dataset classes\n",
+    "\n",
+    "External dataset classes should define their default configuration in a `.toml` file.\n",
+    "For the hypothetical class above, the defaults might look like:\n",
+    "\n",
+    "```toml\n",
+    "[my_package.my_dataset.MyDatasetClass]\n",
+    "parameter_a = true\n",
+    "parameter_b = 100\n",
+    "```\n",
+    "\n",
+    "To override these values inside a data request, mirror the same nesting under `dataset_config`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "531f2d19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_external_data\": {\n",
+    "            \"dataset_class\": \"my_package.my_dataset.MyDatasetClass\",\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"dataset_config\": {\n",
+    "                \"my_package\": {  # <- Note that this nesting matches the nesting in the toml file\n",
+    "                    \"my_dataset\": {\n",
+    "                        \"MyDatasetClass\": {\n",
+    "                            \"parameter_a\": False,\n",
+    "                            \"parameter_b\": 42,\n",
+    "                        }\n",
+    "                    }\n",
+    "                }\n",
+    "            },\n",
+    "        }\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c04d7dd",
+   "metadata": {},
+   "source": [
+    "## Converting to TOML\n",
+    "\n",
+    "When a Hyrax verb uses a data request, it will be converted to a TOML representation and stored in the runtime_config.toml file along with any other output.\n",
+    "Typically a user wouldn't write the TOML directly, but for educational purposes, we'll demonstrate a Python dictionary data request followed by the TOML representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca44c8f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_request = {\n",
+    "    \"train\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "        }\n",
+    "    },\n",
+    "    \"validate\": {\n",
+    "        \"my_data\": {\n",
+    "            \"dataset_class\": \"HyraxCifarDataset\",\n",
+    "            \"data_location\": \"./data\",\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"dataset_config\": {  # <- Pass specific configurations just for this dataset\n",
+    "                \"HyraxCifarDataset\": {  # <- This matches the dataset_class value\n",
+    "                    \"use_training_data\": False,\n",
+    "                    # Additional dataset-specific configurations can be passed here\n",
+    "                }\n",
+    "            },\n",
+    "        }\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e74159c",
+   "metadata": {},
+   "source": [
+    "The TOML representation:\n",
+    "```toml\n",
+    "[data_request.train.my_data]\n",
+    "dataset_class = \"HyraxCifarDataset\"\n",
+    "data_location = \"./data\"\n",
+    "primary_id_field = \"object_id\"\n",
+    "\n",
+    "[data_request.validate.my_data]\n",
+    "dataset_class = \"HyraxCifarDataset\"\n",
+    "data_location = \"./data\"\n",
+    "primary_id_field = \"object_id\"\n",
+    "\n",
+    "[data_request.validate.my_data.dataset_config.HyraxCifarDataset]\n",
+    "use_training_data = false\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hyrax",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Change Description
Added a notebook that shows a bunch of examples of defining a data request.

I would love some input on the opening paragraphs, too wordy, not useful info, etc... I'm always happy to try to trim it down.

## Solution Description
- Added `docs/notebooks/data_requests.ipynb` with end-to-end `data_request` examples (basic, split fractions, fields selection, multi-source, dataset_config, TOML representation).
- Added the notebook to the Sphinx toctree in `docs/common_workflows.rst`.
- Clarified the `split_fraction` validation description to accurately define **active data groups** (the groups the current verb actually processes), and to explicitly state both validation rules: (1) if any active group for a `data_location` sets `split_fraction`, all must; and (2) the fractions across active groups for a `data_location` must sum to ≤ 1.0.

## Code Quality
- [ ] I have read the Contribution Guide and agree to the Code of Conduct
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.