### PR TITLE
Centering all figure captions

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,4 @@
+figure figcaption,
+figure figcaption p {
+  text-align: center;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,3 +130,5 @@ nitpick_ignore_regex = [
 ]
 
 html_theme = "sphinx_book_theme"
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]


### PR DESCRIPTION
Centers all figure captions. 

Can be overridden per-figure with local directives 