### PR TITLE
Setup scripts for the web coding agents

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -11,7 +11,7 @@ fi
 
 VENV_PATH="$HOME/hyrax-venv"
 
-# Check if venv exists, if not create it
+# Check if venv exists, if not exit (venv must be created by the setup script)
 if [ ! -d "$VENV_PATH" ]; then
   echo "No virtual environment found... exiting"
   exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -17,6 +17,13 @@ if [ ! -d "$VENV_PATH" ]; then
   exit 0
 fi
 
-# Activate the venv and install dependencies
+# Activate the venv to capture environment modifications
 source "$VENV_PATH/bin/activate"
+
+# Persist environment variables to the Claude Code session
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$PATH\"" >> "$CLAUDE_ENV_FILE"
+  echo "export VIRTUAL_ENV=\"$VIRTUAL_ENV\"" >> "$CLAUDE_ENV_FILE"
+fi
+
 echo "Virtual environment activated: $VENV_PATH"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# SessionStart hook for Hyrax - activates the Python virtual environment
+
+# Only run in remote Claude Code on the web environment
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+VENV_PATH="/home/user/hyrax-venv"
+
+# Check if venv exists, if not create it
+if [ ! -d "$VENV_PATH" ]; then
+  echo "Creating virtual environment at $VENV_PATH..."
+  python -m venv "$VENV_PATH"
+fi
+
+# Activate the venv and install dependencies
+source "$VENV_PATH/bin/activate"
+echo "Virtual environment activated: $VENV_PATH"
+
+# Install hyrax in editable mode with dev dependencies
+echo "Installing hyrax with dev dependencies..."
+pip install -e '.[dev]'
+
+# Export the activation command so it's available for all subsequent commands in the session
+echo "export VIRTUAL_ENV=$VENV_PATH" >> "$CLAUDE_ENV_FILE"
+echo "export PATH=$VENV_PATH/bin:\$PATH" >> "$CLAUDE_ENV_FILE"
+
+echo "Setup complete!"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,30 +2,21 @@
 set -euo pipefail
 
 # SessionStart hook for Hyrax - activates the Python virtual environment
+# in a claude code web virtual environment
 
 # Only run in remote Claude Code on the web environment
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-VENV_PATH="/home/user/hyrax-venv"
+VENV_PATH="$HOME/hyrax-venv"
 
 # Check if venv exists, if not create it
 if [ ! -d "$VENV_PATH" ]; then
-  echo "Creating virtual environment at $VENV_PATH..."
-  python -m venv "$VENV_PATH"
+  echo "No virtual environment found... exiting"
+  exit 0
 fi
 
 # Activate the venv and install dependencies
 source "$VENV_PATH/bin/activate"
 echo "Virtual environment activated: $VENV_PATH"
-
-# Install hyrax in editable mode with dev dependencies
-echo "Installing hyrax with dev dependencies..."
-pip install -e '.[dev]'
-
-# Export the activation command so it's available for all subsequent commands in the session
-echo "export VIRTUAL_ENV=$VENV_PATH" >> "$CLAUDE_ENV_FILE"
-echo "export PATH=$VENV_PATH/bin:\$PATH" >> "$CLAUDE_ENV_FILE"
-
-echo "Setup complete!"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ mlruns/
 
 # Hyrax dataset join cache files
 .hyrax_join_cache_*.pkl
+
+# Claude code local settings file
+.claude/settings.local.json
+

--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# To use this script in claude code
+# edit your environment and put the following
+# as your setup script:
+#
+# #!/bin/bash
+# ./hyrax/agent_scripts/claude_code_web_setup_container.sh
+#
+# This works together with a session start hook to place
+# claude code in the created venv
+#
+# We use a venv because claude code's current container (Apr 2026)
+# Doesn't allow us to install all of hyrax's dependencies
+
+apt -y install pandoc
+
+echo "creating venv in $HOME/hyrax-venv"
+python -m venv $HOME/hyrax-venv
+
+echo "activating venv..."
+source $HOME/hyrax-venv/bin/activate
+
+echo "installing hyrax..."
+cd hyrax
+pip install -e '.[dev]'
+

--- a/agent_scripts/codex_maintain_container.sh
+++ b/agent_scripts/codex_maintain_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # To use this as your maintenance script in codex
-# put the following line into the maintenence script
+# put the following line into the maintenance script
 # setup box on the webpage:
 #
 # ./agent_scripts/codex_maintain_container.sh

--- a/agent_scripts/codex_maintain_container.sh
+++ b/agent_scripts/codex_maintain_container.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# To use this as your maintenance script in codex
+# put the following line into the maintenence script
+# setup box on the webpage:
+#
+# ./agent_scripts/codex_maintain_container.sh
+#
+
+pip install -e .'[dev]'
+pushd docs
+make clean
+popd
+

--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Container setup script for codex
+# Enable this by putting the following line
+# in your codex env setup script web box
+#
+# ./agent_scripts/codex_setup_container.sh
+# 
+
+pyenv global 3.11
+pip install --upgrade pip
+apt -y install pandoc
+pip install -e .'[dev]'
+


### PR DESCRIPTION
This has some setup scripts that I've iterated on in order to make the claude code web environment and the codex environment better able to run hyrax.

In order to use these, you have to paste some lines into your web interface, see the comments in each setup file.

They're designed to be a noop for CLI coding agents, which is part of why I put the relevant bash scripts in `agent_scripts`

## Change Description

Adds container setup/maintenance scripts and Claude Code hook configuration to improve running Hyrax inside web-based coding agent environments (Codex, Claude Code Web).

## Solution Description

- Add Codex container setup + maintenance scripts to install Hyrax (editable) and clean docs builds.
- Add Claude Code Web setup script plus a SessionStart hook to activate/persist a Hyrax venv for the session.
- Ignore Claude Code local settings file in `.gitignore`.
- Fixed misleading comment in `.claude/hooks/session-start.sh`: the hook exits (does not create) when the venv is missing — venv creation is the responsibility of the setup script.
- Fixed spelling typo in `agent_scripts/codex_maintain_container.sh`: "maintenence" → "maintenance".

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation