### PR TITLE
Fix typos and reword for clarity in checkpointing notebook

### DIFF
--- a/docs/pre_executed/hyrax_checkpointing.ipynb
+++ b/docs/pre_executed/hyrax_checkpointing.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Checkpoint with Hyrax\n",
     "\n",
-    "The notebook demonstrates how to use save and resume checkpointed models in Hyrax."
+    "This notebook demonstrates how to save and resume models with checkpointing in Hyrax."
    ]
   },
   {
@@ -118,7 +118,9 @@
    "id": "6bddd166",
    "metadata": {},
    "source": [
-    "The resumed training data will create its own timestamped results directory with new checkpoints and will not overwrite the previous one. Note that if a model that should run for `n` epochs finishes its training and the checkpoint is loaded with the number of epochs still being `n`, then the model will be trained for `n` more epochs. This can be seen in TensorBoard as well; the validation loss is plotted against each epoch and the red curve represents the validation loss from the initial training while the blue curve is the validation loss from the additional 3 epochs.\n",
+    "The resumed training data will create its own timestamped results directory with new checkpoints and will not overwrite the previous one. Note that if a model that should run for `n` epochs finishes its training and the checkpoint is loaded with the number of epochs still being `n`, then the model will be trained for `n` more epochs.\n",
+    "\n",
+    "Additional training from a checkpoint can be seen in TensorBoard as well; the validation loss is plotted against each epoch and the red curve represents the validation loss from the initial training while the blue curve is the validation loss from the additional 3 epochs.\n",
     "\n",
     "![tensorboard_checkpoint_val_loss.png](../_static/screenshots/tensorboard_checkpoint_val_loss.png)"
    ]


### PR DESCRIPTION
Fixes typos and updates some wording for clarity in checkpointing notebook.