### PR TITLE
[Automerge] Fixing warning that always fires when you h.set_config('data_request'…

### DIFF
--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -178,7 +178,7 @@ class ConfigManager:
         ["general", "data_dir"],
     ]
 
-    PYDANTIC_VALIDATED_KEYS = ["data_request", "model_inputs"]
+    PYDANTIC_VALIDATED_KEYS = ("data_request", "model_inputs")
 
     def __init__(
         self,
@@ -258,7 +258,7 @@ class ConfigManager:
             The value to set the key to.
         """
         keys = parse_dotted_key(key)
-        if key in ("data_request", "model_inputs"):
+        if key in ConfigManager.PYDANTIC_VALIDATED_KEYS:
             try:
                 value = self._validate_data_request(value)
             except ValidationError as e:

--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -178,6 +178,8 @@ class ConfigManager:
         ["general", "data_dir"],
     ]
 
+    PYDANTIC_VALIDATED_KEYS = ["data_request", "model_inputs"]
+
     def __init__(
         self,
         runtime_config_filepath: Union[Path, str] | None = None,
@@ -194,7 +196,7 @@ class ConfigManager:
         self.config = self._render_config(self.user_specific_config, self.hyrax_default_config)
 
         # Validate data_request/model_inputs if present in loaded config
-        for key in ("data_request", "model_inputs"):
+        for key in ConfigManager.PYDANTIC_VALIDATED_KEYS:
             if key in self.config:
                 value = self.config[key]
                 try:
@@ -475,9 +477,10 @@ class ConfigManager:
         """
         for key in runtime_config:
             if key not in default_config:
-                msg = f"Runtime config contains key or section '{key}' which has no default defined. "
-                msg += f"All configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
-                logger.warning(msg)
+                if key not in ConfigManager.PYDANTIC_VALIDATED_KEYS:
+                    msg = f"Runtime config contains key or section '{key}' which has no default defined. "
+                    msg += f"All configuration keys and sections must be defined in {DEFAULT_CONFIG_FILEPATH}"
+                    logger.warning(msg)
                 continue
 
             if isinstance(runtime_config[key], dict):


### PR DESCRIPTION
Thanks @SamSandwich07 for pairing on this and pointing out the bad UX

Both before and after this change we don't validate that dataset custom configs actually define a default in the same way that we do for normal configs.
