### PR TITLE
Speed up AI container startup.

### DIFF
--- a/.github/workflows/build-agent-env-artifact.yml
+++ b/.github/workflows/build-agent-env-artifact.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Build conda env
         shell: bash -l {0}
         run: |
-          conda install -y conda-pack pip
+          conda install -y conda-pack pip setuptools
           pip install '.[dev]'
+          conda list
+          conda install -y setuptools
+          conda list setuptools
           pip check
 
       - name: Pack conda env

--- a/.github/workflows/build-agent-env-artifact.yml
+++ b/.github/workflows/build-agent-env-artifact.yml
@@ -1,7 +1,7 @@
 name: Build agent conda environment artifact
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
   workflow_dispatch:
 

--- a/.github/workflows/build-agent-env-artifact.yml
+++ b/.github/workflows/build-agent-env-artifact.yml
@@ -26,10 +26,9 @@ jobs:
       - name: Build conda env
         shell: bash -l {0}
         run: |
-          conda install -y conda-pack pip setuptools
+          conda install -y conda-pack pip "setuptools<82"
           pip install '.[dev]'
           conda list
-          conda install -y setuptools
           conda list setuptools
           pip check
 

--- a/.github/workflows/build-agent-env-artifact.yml
+++ b/.github/workflows/build-agent-env-artifact.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -y conda-pack pip
-          pip install -e '.[dev]'
+          pip install '.[dev]'
           pip check
 
       - name: Pack conda env

--- a/.github/workflows/build-agent-env-artifact.yml
+++ b/.github/workflows/build-agent-env-artifact.yml
@@ -1,4 +1,4 @@
-name: Build agent Python environment artifact
+name: Build agent conda environment artifact
 
 on:
   pull_request:
@@ -16,29 +16,31 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          auto-activate-base: false
+          activate-environment: hyrax-env
           python-version: '3.11'
 
-      - name: Build venv
+      - name: Build conda env
+        shell: bash -l {0}
         run: |
-          python -m venv .venv-hyrax-dev
-          source .venv-hyrax-dev/bin/activate
-          pip install --upgrade pip
+          conda install -y conda-pack pip
           pip install -e '.[dev]'
           pip check
 
-      - name: Pack venv
+      - name: Pack conda env
+        shell: bash -l {0}
         run: |
-          tar -czf hyrax-agent-venv-linux-x86_64-py311.tar.gz -C .venv-hyrax-dev .
+          conda-pack -n hyrax-env -o hyrax-agent-conda-env.tar.gz
 
       - name: Upload artifact
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: hyrax-agent-venv-main
-          path: hyrax-agent-venv-linux-x86_64-py311.tar.gz
+          name: hyrax-agent-conda-env-main
+          path: hyrax-agent-conda-env.tar.gz
           retention-days: 90
 
       - name: Delete older artifacts with same name
@@ -49,7 +51,7 @@ jobs:
           script: |
             const currentArtifactId = Number(process.env.CURRENT_ARTIFACT_ID)
             const { owner, repo } = context.repo
-            const artifactName = 'hyrax-agent-venv-main'
+            const artifactName = 'hyrax-agent-conda-env-main'
             const artifacts = await github.paginate(github.rest.actions.listArtifactsForRepo, {
               owner,
               repo,

--- a/.github/workflows/build-agent-env-artifact.yml
+++ b/.github/workflows/build-agent-env-artifact.yml
@@ -1,0 +1,67 @@
+name: Build agent Python environment artifact
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  build-agent-env:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Build venv
+        run: |
+          python -m venv .venv-hyrax-dev
+          source .venv-hyrax-dev/bin/activate
+          pip install --upgrade pip
+          pip install -e '.[dev]'
+          pip check
+
+      - name: Pack venv
+        run: |
+          tar -czf hyrax-agent-venv-linux-x86_64-py311.tar.gz -C .venv-hyrax-dev .
+
+      - name: Upload artifact
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: hyrax-agent-venv-main
+          path: hyrax-agent-venv-linux-x86_64-py311.tar.gz
+          retention-days: 90
+
+      - name: Delete older artifacts with same name
+        uses: actions/github-script@v8
+        env:
+          CURRENT_ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+        with:
+          script: |
+            const currentArtifactId = Number(process.env.CURRENT_ARTIFACT_ID)
+            const { owner, repo } = context.repo
+            const artifactName = 'hyrax-agent-venv-main'
+            const artifacts = await github.paginate(github.rest.actions.listArtifactsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+            })
+
+            for (const artifact of artifacts) {
+              if (artifact.name === artifactName && artifact.id !== currentArtifactId) {
+                await github.rest.actions.deleteArtifact({
+                  owner,
+                  repo,
+                  artifact_id: artifact.id,
+                })
+              }
+            }

--- a/agent_scripts/README.md
+++ b/agent_scripts/README.md
@@ -1,0 +1,89 @@
+# Agent environment artifact setup (Codex Cloud + Claude Code Web)
+
+This repo ships setup scripts that download a prebuilt conda environment artifact from GitHub Actions and unpack it in the web agent container.
+
+- `agent_scripts/codex_setup_container.sh` → for **Codex Cloud**
+- `agent_scripts/claude_code_web_setup_container.sh` → for **Claude Code Web**
+
+The artifact is built by `.github/workflows/build-agent-env-artifact.yml` on pushes to `main` (and can also be run manually with **workflow_dispatch**).
+
+## Network access requirements
+
+These setup scripts require outbound internet access. They will not work in a fully offline or no-egress container.
+
+### If you use restricted egress / custom allow-lists
+
+Use the provider defaults for package managers, then add only the GitHub artifact domains.
+
+- **Codex Cloud**: enable **Common Dependencies** domain allow-list.
+- **Claude Code Web**: choose **Custom** domains and check **also include default list of package managers**.
+
+Then add these custom domains:
+
+- `api.github.com`
+- `*.blob.core.windows.net`
+
+## 1) Create a GitHub token for artifact download
+
+You need a token because the setup scripts call the GitHub Actions Artifacts API.
+
+### Recommended: Fine-grained personal access token
+
+1. In GitHub, open **Settings → Developer settings → Personal access tokens → Fine-grained tokens**.
+2. Click **Generate new token**.
+3. Select the `lincc-frameworks/hyrax` repository.
+4. Grant these repository permissions:
+   - **Actions: Read**
+   - **Contents: Read**
+5. Set an expiration date and create the token.
+6. Copy it once and store it securely.
+
+> You can also use a classic PAT with `repo` scope if your org policy requires it, but fine-grained + least privilege is preferred.
+
+## 2) Ensure the artifact exists
+
+Before provisioning a web environment, make sure the artifact has been built at least once from `main`:
+
+1. Go to **Actions → Build agent conda environment artifact**.
+2. Confirm a successful run on `main`.
+3. Confirm artifact `hyrax-agent-conda-env-main` exists.
+
+## 3) Provision on Codex Cloud
+
+In your Codex Cloud web environment configuration:
+
+1. Add environment variable:
+   - `GITHUB_TOKEN=<your token>`
+2. Set setup script to:
+
+```bash
+./agent_scripts/codex_setup_container.sh
+```
+
+What happens:
+- Installs `pandoc`
+- Downloads `hyrax-agent-conda-env-main`
+- Unpacks to `$HOME/hyrax-venv`
+- Runs `conda-unpack`
+- Runs `pip install -e '.[dev]'` in this repo
+
+## 4) Provision on Claude Code Web
+
+In your Claude Code Web environment:
+
+1. Add environment variable:
+   - `GITHUB_TOKEN=<your token>`
+2. Use this setup script:
+
+```bash
+#!/bin/bash
+./hyrax/agent_scripts/claude_code_web_setup_container.sh
+```
+
+This script performs the same environment restoration and editable install as Codex Cloud.
+
+## Troubleshooting
+
+- **401/403 from GitHub API**: token is missing/invalid, expired, or lacks `Actions: Read`.
+- **No artifact found**: workflow has not run successfully on `main` yet.
+- **`conda-unpack` not found**: artifact may be stale/corrupt; re-run workflow on `main`.

--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # To use this script in claude code
 # edit your environment and put the following
@@ -15,13 +16,24 @@
 
 apt -y install pandoc
 
-echo "creating venv in $HOME/hyrax-venv"
-python -m venv $HOME/hyrax-venv
+ARTIFACT_REPO="${HYRAX_REPO:-lincc-frameworks/hyrax}"
+ARTIFACT_NAME="${HYRAX_ENV_ARTIFACT_NAME:-hyrax-agent-venv-main}"
+VENV_DIR="${HYRAX_VENV_DIR:-$HOME/hyrax-venv}"
+
+ARTIFACT_ID=$(curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
+curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
+
+rm -rf "$VENV_DIR"
+mkdir -p "$VENV_DIR"
+rm -rf /tmp/hyrax-agent-venv
+unzip -q /tmp/hyrax-agent-venv.zip -d /tmp/hyrax-agent-venv
+TARBALL_PATH=$(find /tmp/hyrax-agent-venv -name '*.tar.gz' | head -n1)
+tar -xzf "$TARBALL_PATH" -C "$VENV_DIR"
 
 echo "activating venv..."
-source $HOME/hyrax-venv/bin/activate
+source "$VENV_DIR/bin/activate"
 
 echo "installing hyrax..."
-cd hyrax
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
 pip install -e '.[dev]'
-

--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -9,27 +9,28 @@ set -euo pipefail
 # ./hyrax/agent_scripts/claude_code_web_setup_container.sh
 #
 # This works together with a session start hook to place
-# claude code in the created venv
+# claude code in the created conda env
 
 apt -y install pandoc
 
 ARTIFACT_REPO="lincc-frameworks/hyrax"
 ARTIFACT_NAME="hyrax-agent-conda-env-main"
-VENV_DIR="$HOME/hyrax-venv"
+ENV_DIR="$HOME/hyrax-venv"
 AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
 
 ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
 curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
 
-rm -rf "$VENV_DIR"
-mkdir -p "$VENV_DIR"
+rm -rf "$ENV_DIR"
+mkdir -p "$ENV_DIR"
 rm -rf /tmp/hyrax-agent-conda-env
 unzip -q /tmp/hyrax-agent-conda-env.zip -d /tmp/hyrax-agent-conda-env
 TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
-tar -xzf "$TARBALL_PATH" -C "$VENV_DIR"
+tar -xzf "$TARBALL_PATH" -C "$ENV_DIR"
 
 echo "activating env..."
-source "$VENV_DIR/bin/activate"
+source "$(conda info --base)/etc/profile.d/conda.sh"
+conda activate "$ENV_DIR"
 conda-unpack
 
 echo "installing hyrax..."

--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -10,38 +10,27 @@ set -euo pipefail
 #
 # This works together with a session start hook to place
 # claude code in the created venv
-#
-# We use a venv because claude code's current container (Apr 2026)
-# Doesn't allow us to install all of hyrax's dependencies
 
 apt -y install pandoc
 
-ARTIFACT_REPO="${HYRAX_REPO:-lincc-frameworks/hyrax}"
-ARTIFACT_NAME="${HYRAX_ENV_ARTIFACT_NAME:-hyrax-agent-venv-main}"
-ARTIFACT_ID="${HYRAX_ENV_ARTIFACT_ID:-}"
-VENV_DIR="${HYRAX_VENV_DIR:-$HOME/hyrax-venv}"
-GITHUB_TOKEN_VALUE="${HYRAX_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
-AUTH_HEADER=()
+ARTIFACT_REPO="lincc-frameworks/hyrax"
+ARTIFACT_NAME="hyrax-agent-conda-env-main"
+VENV_DIR="$HOME/hyrax-venv"
+AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
 
-if [ -n "$GITHUB_TOKEN_VALUE" ]; then
-    AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN_VALUE")
-fi
-
-if [ -z "$ARTIFACT_ID" ]; then
-    ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
-fi
-
-curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
+ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
+curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
 
 rm -rf "$VENV_DIR"
 mkdir -p "$VENV_DIR"
-rm -rf /tmp/hyrax-agent-venv
-unzip -q /tmp/hyrax-agent-venv.zip -d /tmp/hyrax-agent-venv
-TARBALL_PATH=$(find /tmp/hyrax-agent-venv -name '*.tar.gz' | head -n1)
+rm -rf /tmp/hyrax-agent-conda-env
+unzip -q /tmp/hyrax-agent-conda-env.zip -d /tmp/hyrax-agent-conda-env
+TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
 tar -xzf "$TARBALL_PATH" -C "$VENV_DIR"
 
-echo "activating venv..."
+echo "activating env..."
 source "$VENV_DIR/bin/activate"
+conda-unpack
 
 echo "installing hyrax..."
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)

--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -19,7 +19,10 @@ ENV_DIR="$HOME/hyrax-venv"
 AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
 
 ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
-curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
+# GitHub redirects to a signed Azure Blob URL; follow the redirect manually so the
+# Bearer token is not forwarded to Azure (Azure rejects it with 503).
+DOWNLOAD_URL=$(curl -s -o /dev/null -w '%{redirect_url}' "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip")
+curl -fsSL "$DOWNLOAD_URL" -o /tmp/hyrax-agent-conda-env.zip
 
 rm -rf "$ENV_DIR"
 mkdir -p "$ENV_DIR"
@@ -29,8 +32,7 @@ TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
 tar -xzf "$TARBALL_PATH" -C "$ENV_DIR"
 
 echo "activating env..."
-source "$(conda info --base)/etc/profile.d/conda.sh"
-conda activate "$ENV_DIR"
+source "$ENV_DIR/bin/activate"
 conda-unpack
 
 echo "installing hyrax..."

--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -18,10 +18,20 @@ apt -y install pandoc
 
 ARTIFACT_REPO="${HYRAX_REPO:-lincc-frameworks/hyrax}"
 ARTIFACT_NAME="${HYRAX_ENV_ARTIFACT_NAME:-hyrax-agent-venv-main}"
+ARTIFACT_ID="${HYRAX_ENV_ARTIFACT_ID:-}"
 VENV_DIR="${HYRAX_VENV_DIR:-$HOME/hyrax-venv}"
+GITHUB_TOKEN_VALUE="${HYRAX_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
+AUTH_HEADER=()
 
-ARTIFACT_ID=$(curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
-curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
+if [ -n "$GITHUB_TOKEN_VALUE" ]; then
+    AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN_VALUE")
+fi
+
+if [ -z "$ARTIFACT_ID" ]; then
+    ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
+fi
+
+curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
 
 rm -rf "$VENV_DIR"
 mkdir -p "$VENV_DIR"

--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -38,4 +38,4 @@ conda-unpack
 echo "installing hyrax..."
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
-pip install -e '.[dev]'
+python -m pip install -e '.[dev]'

--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -13,20 +13,21 @@ apt -y install pandoc
 
 ARTIFACT_REPO="lincc-frameworks/hyrax"
 ARTIFACT_NAME="hyrax-agent-conda-env-main"
-VENV_DIR="$HOME/hyrax-venv"
+ENV_DIR="$HOME/hyrax-venv"
 AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
 
 ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
 curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
 
-rm -rf "$VENV_DIR"
-mkdir -p "$VENV_DIR"
+rm -rf "$ENV_DIR"
+mkdir -p "$ENV_DIR"
 rm -rf /tmp/hyrax-agent-conda-env
 unzip -q /tmp/hyrax-agent-conda-env.zip -d /tmp/hyrax-agent-conda-env
 TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
-tar -xzf "$TARBALL_PATH" -C "$VENV_DIR"
+tar -xzf "$TARBALL_PATH" -C "$ENV_DIR"
 
-source "$VENV_DIR/bin/activate"
+source "$(conda info --base)/etc/profile.d/conda.sh"
+conda activate "$ENV_DIR"
 conda-unpack
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)

--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -13,10 +13,20 @@ apt -y install pandoc
 
 ARTIFACT_REPO="${HYRAX_REPO:-lincc-frameworks/hyrax}"
 ARTIFACT_NAME="${HYRAX_ENV_ARTIFACT_NAME:-hyrax-agent-venv-main}"
+ARTIFACT_ID="${HYRAX_ENV_ARTIFACT_ID:-}"
 VENV_DIR="${HYRAX_VENV_DIR:-$HOME/hyrax-venv}"
+GITHUB_TOKEN_VALUE="${HYRAX_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
+AUTH_HEADER=()
 
-ARTIFACT_ID=$(curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
-curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
+if [ -n "$GITHUB_TOKEN_VALUE" ]; then
+    AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN_VALUE")
+fi
+
+if [ -z "$ARTIFACT_ID" ]; then
+    ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
+fi
+
+curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
 
 rm -rf "$VENV_DIR"
 mkdir -p "$VENV_DIR"

--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -14,7 +14,7 @@ apt -y install pandoc
 ARTIFACT_REPO="lincc-frameworks/hyrax"
 ARTIFACT_NAME="hyrax-agent-conda-env-main"
 ENV_DIR="$HOME/hyrax-venv"
-AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
+AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN:?GITHUB_TOKEN must be set}")
 
 ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
 curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
@@ -26,10 +26,12 @@ unzip -q /tmp/hyrax-agent-conda-env.zip -d /tmp/hyrax-agent-conda-env
 TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
 tar -xzf "$TARBALL_PATH" -C "$ENV_DIR"
 
-source "$(conda info --base)/etc/profile.d/conda.sh"
-conda activate "$ENV_DIR"
+# shellcheck disable=SC1091
+set +u
+source "${ENV_DIR}/bin/activate"
+set -u
 conda-unpack
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
-pip install -e '.[dev]'
+python -m pip install -e '.[dev]'

--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -11,31 +11,24 @@ set -euo pipefail
 pyenv global 3.11
 apt -y install pandoc
 
-ARTIFACT_REPO="${HYRAX_REPO:-lincc-frameworks/hyrax}"
-ARTIFACT_NAME="${HYRAX_ENV_ARTIFACT_NAME:-hyrax-agent-venv-main}"
-ARTIFACT_ID="${HYRAX_ENV_ARTIFACT_ID:-}"
-VENV_DIR="${HYRAX_VENV_DIR:-$HOME/hyrax-venv}"
-GITHUB_TOKEN_VALUE="${HYRAX_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
-AUTH_HEADER=()
+ARTIFACT_REPO="lincc-frameworks/hyrax"
+ARTIFACT_NAME="hyrax-agent-conda-env-main"
+VENV_DIR="$HOME/hyrax-venv"
+AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
 
-if [ -n "$GITHUB_TOKEN_VALUE" ]; then
-    AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN_VALUE")
-fi
-
-if [ -z "$ARTIFACT_ID" ]; then
-    ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
-fi
-
-curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
+ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
+curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
 
 rm -rf "$VENV_DIR"
 mkdir -p "$VENV_DIR"
-rm -rf /tmp/hyrax-agent-venv
-unzip -q /tmp/hyrax-agent-venv.zip -d /tmp/hyrax-agent-venv
-TARBALL_PATH=$(find /tmp/hyrax-agent-venv -name '*.tar.gz' | head -n1)
+rm -rf /tmp/hyrax-agent-conda-env
+unzip -q /tmp/hyrax-agent-conda-env.zip -d /tmp/hyrax-agent-conda-env
+TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
 tar -xzf "$TARBALL_PATH" -C "$VENV_DIR"
 
 source "$VENV_DIR/bin/activate"
+conda-unpack
+
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
 pip install -e '.[dev]'

--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -1,14 +1,31 @@
 #!/bin/bash
+set -euo pipefail
 
 # Container setup script for codex
 # Enable this by putting the following line
 # in your codex env setup script web box
 #
 # ./agent_scripts/codex_setup_container.sh
-# 
+#
 
 pyenv global 3.11
-pip install --upgrade pip
 apt -y install pandoc
-pip install -e .'[dev]'
 
+ARTIFACT_REPO="${HYRAX_REPO:-lincc-frameworks/hyrax}"
+ARTIFACT_NAME="${HYRAX_ENV_ARTIFACT_NAME:-hyrax-agent-venv-main}"
+VENV_DIR="${HYRAX_VENV_DIR:-$HOME/hyrax-venv}"
+
+ARTIFACT_ID=$(curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
+curl -fsSL "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-venv.zip
+
+rm -rf "$VENV_DIR"
+mkdir -p "$VENV_DIR"
+rm -rf /tmp/hyrax-agent-venv
+unzip -q /tmp/hyrax-agent-venv.zip -d /tmp/hyrax-agent-venv
+TARBALL_PATH=$(find /tmp/hyrax-agent-venv -name '*.tar.gz' | head -n1)
+tar -xzf "$TARBALL_PATH" -C "$VENV_DIR"
+
+source "$VENV_DIR/bin/activate"
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
+pip install -e '.[dev]'


### PR DESCRIPTION
### Motivation
- Avoid installing Hyrax's full dependency set inside constrained agent/container environments by providing a prebuilt Python venv artifact.
- Centralize and reuse a single environment artifact produced from `main` to ensure consistent dev dependencies across agent sessions.
- Clean up older artifacts to prevent clutter and reduce storage/lookup ambiguity.

### Description
- Add GitHub Actions workflow `/.github/workflows/build-agent-env-artifact.yml` that sets up Python 3.11, creates a venv, runs `pip install -e '.[dev]'`, runs `pip check`, packs the venv into a tarball, uploads it as artifact `hyrax-agent-venv-main`, and deletes older artifacts with the same name.
- Update `agent_scripts/claude_code_web_setup_container.sh` to download the artifact zip via the GitHub Actions API, extract the contained tarball into a configurable `VENV_DIR`, activate the venv, and install the repo in editable dev mode; add `set -euo pipefail` and robust repo root detection.
- Update `agent_scripts/codex_setup_container.sh` with the same artifact-download-and-extract flow, activation of the prebuilt venv, and `set -euo pipefail`, and make artifact repo/name and venv dir configurable via `HYRAX_*` env vars.
- Remove previous local venv creation steps and direct pip installs in these scripts so they rely on the prebuilt artifact instead.

### Testing
- No automated tests were executed as part of this PR; CI has not been triggered by this change yet.
- The new workflow includes a `pip check` step which will validate installed package dependencies when the workflow runs on CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e907fdf1808331aa3e6cc8405bcd5d)