### PR TITLE
[auto-merge] [Fix smoketests] Pin lance-namespace below 0.7 for lancedb compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ dependencies = [
     # This issue is NOT noted in release notes (https://github.com/lancedb/lancedb/releases/tag/python-v0.30.0)
     # We have filed this bug: https://github.com/lancedb/lancedb/issues/3153
     "lancedb < 0.30.0", # Used for columnar storage of inference results
+    # lance-namespace 0.7 removed CreateEmptyTableRequest and breaks lancedb<0.30 imports.
+    # Track upstream compatibility in lancedb before removing this cap.
+    "lance-namespace < 0.7.0",
     "pyarrow", # Used by lancedb for data interchange
     "pylance", # Used by lancedb for Lance dataset access
 ]


### PR DESCRIPTION
### Motivation
- Smoketests failed during collection with `ImportError` because `lancedb` attempted to import `CreateEmptyTableRequest` from `lance_namespace` and that symbol was removed in `lance-namespace==0.7.0`. 
- The project pins `lancedb < 0.30.0`, and newer `lance-namespace` releases are not API-compatible with that `lancedb` version, so a dependency constraint is needed to avoid import-time breakage in fresh installs.

### Description
- Add an explicit dependency cap to `pyproject.toml`: `"lance-namespace < 0.7.0"` with an inline comment explaining the compatibility issue. 
- This keeps the existing `lancedb < 0.30.0` path working until upstream `lancedb` releases a version compatible with `lance-namespace>=0.7`.

### Testing
- Reproduced the original failure with `python -c "import lancedb"` which raised the `CreateEmptyTableRequest` import error prior to the change. 
- Installed `lance-namespace<0.7.0` and verified `python -c "import lancedb, lance_namespace"` succeeds. 
- Ran the test suite with `python -m pytest -m "not slow" -q`, which completed successfully (`373 passed, 10 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9221d50208331bfb941e8c5417a8c)