### PR TITLE
codex_setup_container: require GITHUB_TOKEN, use venv activate, and call pip via python

### DIFF
--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -14,7 +14,7 @@ apt -y install pandoc
 ARTIFACT_REPO="lincc-frameworks/hyrax"
 ARTIFACT_NAME="hyrax-agent-conda-env-main"
 ENV_DIR="$HOME/hyrax-venv"
-AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
+AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN:?GITHUB_TOKEN must be set}")
 
 ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
 curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
@@ -26,10 +26,12 @@ unzip -q /tmp/hyrax-agent-conda-env.zip -d /tmp/hyrax-agent-conda-env
 TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
 tar -xzf "$TARBALL_PATH" -C "$ENV_DIR"
 
-source "$(conda info --base)/etc/profile.d/conda.sh"
-conda activate "$ENV_DIR"
+# shellcheck disable=SC1091
+set +u
+source "${ENV_DIR}/bin/activate"
+set -u
 conda-unpack
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
-pip install -e '.[dev]'
+python -m pip install -e '.[dev]'


### PR DESCRIPTION
### Motivation
- Make the container setup script fail early if `GITHUB_TOKEN` is unset and reliably activate the unpacked virtualenv while using the interpreter-bound pip.

### Description
- Require `GITHUB_TOKEN` with parameter expansion in `AUTH_HEADER` using `(${GITHUB_TOKEN:?GITHUB_TOKEN must be set})` to fail fast when the token is missing.
- Replace sourcing `conda.sh` and `conda activate` with a direct `source "${ENV_DIR}/bin/activate"` wrapped with `set +u`/`set -u` and a `# shellcheck disable=SC1091` to robustly activate the unpacked environment.
- Use `python -m pip install -e '.[dev]'` instead of the bare `pip` to ensure the correct interpreter's pip is used.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e944ad47f883319504fe0cb2f3ce65)