### PR TITLE
Fix artifact download and conda environment activation

### DIFF
--- a/agent_scripts/claude_code_web_setup_container.sh
+++ b/agent_scripts/claude_code_web_setup_container.sh
@@ -19,7 +19,10 @@ ENV_DIR="$HOME/hyrax-venv"
 AUTH_HEADER=(-H "Authorization: Bearer $GITHUB_TOKEN")
 
 ARTIFACT_ID=$(curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts?per_page=100" | jq -r ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -n1)
-curl -fsSL "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" -o /tmp/hyrax-agent-conda-env.zip
+# GitHub redirects to a signed Azure Blob URL; follow the redirect manually so the
+# Bearer token is not forwarded to Azure (Azure rejects it with 503).
+DOWNLOAD_URL=$(curl -s -o /dev/null -w '%{redirect_url}' "${AUTH_HEADER[@]}" "https://api.github.com/repos/${ARTIFACT_REPO}/actions/artifacts/${ARTIFACT_ID}/zip")
+curl -fsSL "$DOWNLOAD_URL" -o /tmp/hyrax-agent-conda-env.zip
 
 rm -rf "$ENV_DIR"
 mkdir -p "$ENV_DIR"
@@ -29,8 +32,7 @@ TARBALL_PATH=$(find /tmp/hyrax-agent-conda-env -name '*.tar.gz' | head -n1)
 tar -xzf "$TARBALL_PATH" -C "$ENV_DIR"
 
 echo "activating env..."
-source "$(conda info --base)/etc/profile.d/conda.sh"
-conda activate "$ENV_DIR"
+source "$ENV_DIR/bin/activate"
 conda-unpack
 
 echo "installing hyrax..."


### PR DESCRIPTION
## Change Description

This PR fixes two issues in the container setup script:

1. **Artifact download**: GitHub's artifact API redirects to a signed Azure Blob URL. The previous implementation forwarded the Bearer token to Azure, which rejects it with a 503 error. Now we extract the redirect URL first and download from it without the Authorization header.

2. **Conda environment activation**: Simplified the conda activation to use the standard `source` command directly on the unpacked environment's activation script, rather than relying on conda's shell initialization and the `conda activate` command.

## Solution Description

- Modified the artifact download to use `curl` with `-w '%{redirect_url}'` to capture the Azure Blob URL, then download from that URL without authentication headers
- Replaced the conda initialization and activation sequence with a direct source of the environment's `bin/activate` script
- Added explanatory comments about the Azure redirect behavior

These changes ensure the setup script works correctly with GitHub's artifact API and properly activates the conda environment from the extracted tarball.

## Code Quality
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

https://claude.ai/code/session_012Xfp2h6KyrbZ3VXL3jRj2b