### PR TITLE
Restrict artifact build CI to main and document web provisioning

### DIFF
--- a/.github/workflows/build-agent-env-artifact.yml
+++ b/.github/workflows/build-agent-env-artifact.yml
@@ -1,7 +1,7 @@
 name: Build agent conda environment artifact
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
   workflow_dispatch:
 

--- a/agent_scripts/README.md
+++ b/agent_scripts/README.md
@@ -11,21 +11,17 @@ The artifact is built by `.github/workflows/build-agent-env-artifact.yml` on pus
 
 These setup scripts require outbound internet access. They will not work in a fully offline or no-egress container.
 
-### Minimum allow-list for artifact download
+### If you use restricted egress / custom allow-lists
 
-Using the current setup script flow (`list artifacts` + `download artifact zip`), the required domains are:
+Use the provider defaults for package managers, then add only the GitHub artifact domains.
 
-- `api.github.com` (GitHub Actions artifacts API)
-- `*.blob.core.windows.net` (signed Azure Blob URL that GitHub redirects to for artifact bytes)
+- **Codex Cloud**: enable **Common Dependencies** domain allow-list.
+- **Claude Code Web**: choose **Custom** domains and check **also include default list of package managers**.
 
-In a live query against this repo, the redirect resolved to `productionresultssa14.blob.core.windows.net` (the exact subdomain can vary), so allow-list the wildcard form.
+Then add these custom domains:
 
-### Additional domains commonly needed by the full setup scripts
-
-Both setup scripts also run package install steps, so most environments should additionally allow:
-
-- Ubuntu/Debian apt mirrors (for `apt -y install pandoc`)
-- Python package index endpoints (for `python -m pip install -e '.[dev]'`, typically `pypi.org` and `files.pythonhosted.org`)
+- `api.github.com`
+- `*.blob.core.windows.net`
 
 ## 1) Create a GitHub token for artifact download
 

--- a/agent_scripts/README.md
+++ b/agent_scripts/README.md
@@ -1,0 +1,73 @@
+# Agent environment artifact setup (Codex Cloud + Claude Code Web)
+
+This repo ships setup scripts that download a prebuilt conda environment artifact from GitHub Actions and unpack it in the web agent container.
+
+- `agent_scripts/codex_setup_container.sh` → for **Codex Cloud**
+- `agent_scripts/claude_code_web_setup_container.sh` → for **Claude Code Web**
+
+The artifact is built by `.github/workflows/build-agent-env-artifact.yml` on pushes to `main` (and can also be run manually with **workflow_dispatch**).
+
+## 1) Create a GitHub token for artifact download
+
+You need a token because the setup scripts call the GitHub Actions Artifacts API.
+
+### Recommended: Fine-grained personal access token
+
+1. In GitHub, open **Settings → Developer settings → Personal access tokens → Fine-grained tokens**.
+2. Click **Generate new token**.
+3. Select the `lincc-frameworks/hyrax` repository.
+4. Grant these repository permissions:
+   - **Actions: Read**
+   - **Contents: Read**
+5. Set an expiration date and create the token.
+6. Copy it once and store it securely.
+
+> You can also use a classic PAT with `repo` scope if your org policy requires it, but fine-grained + least privilege is preferred.
+
+## 2) Ensure the artifact exists
+
+Before provisioning a web environment, make sure the artifact has been built at least once from `main`:
+
+1. Go to **Actions → Build agent conda environment artifact**.
+2. Confirm a successful run on `main`.
+3. Confirm artifact `hyrax-agent-conda-env-main` exists.
+
+## 3) Provision on Codex Cloud
+
+In your Codex Cloud web environment configuration:
+
+1. Add environment variable:
+   - `GITHUB_TOKEN=<your token>`
+2. Set setup script to:
+
+```bash
+./agent_scripts/codex_setup_container.sh
+```
+
+What happens:
+- Installs `pandoc`
+- Downloads `hyrax-agent-conda-env-main`
+- Unpacks to `$HOME/hyrax-venv`
+- Runs `conda-unpack`
+- Runs `pip install -e '.[dev]'` in this repo
+
+## 4) Provision on Claude Code Web
+
+In your Claude Code Web environment:
+
+1. Add environment variable:
+   - `GITHUB_TOKEN=<your token>`
+2. Use this setup script:
+
+```bash
+#!/bin/bash
+./hyrax/agent_scripts/claude_code_web_setup_container.sh
+```
+
+This script performs the same environment restoration and editable install as Codex Cloud.
+
+## Troubleshooting
+
+- **401/403 from GitHub API**: token is missing/invalid, expired, or lacks `Actions: Read`.
+- **No artifact found**: workflow has not run successfully on `main` yet.
+- **`conda-unpack` not found**: artifact may be stale/corrupt; re-run workflow on `main`.

--- a/agent_scripts/README.md
+++ b/agent_scripts/README.md
@@ -7,6 +7,26 @@ This repo ships setup scripts that download a prebuilt conda environment artifac
 
 The artifact is built by `.github/workflows/build-agent-env-artifact.yml` on pushes to `main` (and can also be run manually with **workflow_dispatch**).
 
+## Network access requirements
+
+These setup scripts require outbound internet access. They will not work in a fully offline or no-egress container.
+
+### Minimum allow-list for artifact download
+
+Using the current setup script flow (`list artifacts` + `download artifact zip`), the required domains are:
+
+- `api.github.com` (GitHub Actions artifacts API)
+- `*.blob.core.windows.net` (signed Azure Blob URL that GitHub redirects to for artifact bytes)
+
+In a live query against this repo, the redirect resolved to `productionresultssa14.blob.core.windows.net` (the exact subdomain can vary), so allow-list the wildcard form.
+
+### Additional domains commonly needed by the full setup scripts
+
+Both setup scripts also run package install steps, so most environments should additionally allow:
+
+- Ubuntu/Debian apt mirrors (for `apt -y install pandoc`)
+- Python package index endpoints (for `python -m pip install -e '.[dev]'`, typically `pypi.org` and `files.pythonhosted.org`)
+
 ## 1) Create a GitHub token for artifact download
 
 You need a token because the setup scripts call the GitHub Actions Artifacts API.


### PR DESCRIPTION
### Motivation

- The web-agent setup now restores a CI-built conda environment tarball instead of computing dependencies in-situ to speed provisioning.
- The artifact build workflow should only run for canonical `main` pushes (not PRs) to avoid unnecessary CI runs. 
- Operators need clear instructions for generating a GitHub token and provisioning the web agents (Codex Cloud and Claude Code Web).

### Description

- Change the GitHub Actions trigger in `.github/workflows/build-agent-env-artifact.yml` from `pull_request` to `push` on `main` while keeping `workflow_dispatch` so artifacts are produced only from `main`.
- Add `agent_scripts/README.md` documenting how to create a GitHub token with the required permissions, verify the artifact, and configure the `agent_scripts/codex_setup_container.sh` and `agent_scripts/claude_code_web_setup_container.sh` setup scripts for Codex Cloud and Claude Code Web.
- Ensure the two setup scripts are syntactically valid (shell syntax checked).

### Testing

- Ran a shell syntax check with `bash -n agent_scripts/codex_setup_container.sh agent_scripts/claude_code_web_setup_container.sh`, which completed successfully (no syntax errors).
- No workflow run was triggered in this change set; the artifact build will run automatically on pushes to `main` or can be executed manually via `workflow_dispatch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94ffebed48331a0731e519d6af30b)