### PR TITLE
Limit HATS compute to requested LSDB columns

### DIFF
--- a/src/hyrax/datasets/hats_dataset.py
+++ b/src/hyrax/datasets/hats_dataset.py
@@ -18,10 +18,14 @@ class HyraxHATSDataset(HyraxDataset):
             raise ValueError("A `data_location` to a HATS catalog must be provided.")
 
         self.data_location = data_location
+        requested_columns = self._requested_columns_from_config(config)
 
         import lsdb
 
-        catalog = lsdb.read_hats(data_location)
+        if requested_columns:
+            catalog = lsdb.read_hats(data_location, columns=requested_columns)
+        else:
+            catalog = lsdb.read_hats(data_location)
         self.dataframe = catalog.compute()
         self.column_names = list(self.dataframe.columns)
 
@@ -45,6 +49,30 @@ class HyraxHATSDataset(HyraxDataset):
                 setattr(self, method_name, MethodType(_make_getter(col), self))
 
         super().__init__(config)
+
+    def _requested_columns_from_config(self, config: dict) -> list[str]:
+        data_request = config.get("data_request") or config.get("model_inputs") or {}
+        requested_columns = set()
+        target_location = str(Path(self.data_location).resolve())
+
+        for request_group in data_request.values():
+            for dataset_definition in request_group.values():
+                if dataset_definition.get("dataset_class") != type(self).__name__:
+                    continue
+                if str(Path(dataset_definition["data_location"]).resolve()) != target_location:
+                    continue
+
+                requested_columns.update(dataset_definition.get("fields", []))
+
+                primary_id_field = dataset_definition.get("primary_id_field")
+                if primary_id_field:
+                    requested_columns.add(primary_id_field)
+
+                join_field = dataset_definition.get("join_field")
+                if join_field:
+                    requested_columns.add(join_field)
+
+        return sorted(requested_columns)
 
     def __len__(self) -> int:
         return len(self.dataframe)

--- a/tests/hyrax/test_hats_dataset.py
+++ b/tests/hyrax/test_hats_dataset.py
@@ -72,7 +72,7 @@ def test_hats_dataset_sample_data(test_hyrax_hats_dataset):
     assert sample["data"]["mag-r"] == pytest.approx(19.1)
 
 
-def test_hats_dataset_with_data_request_fields_still_builds_all_getters(hats_catalog_path: Path):
+def test_hats_dataset_with_data_request_fields_only_builds_requested_getters(hats_catalog_path: Path):
     h = hyrax.Hyrax()
     h.config["data_request"] = {
         "train": {
@@ -91,5 +91,5 @@ def test_hats_dataset_with_data_request_fields_still_builds_all_getters(hats_cat
 
     assert hasattr(hats_dataset, "get_object_id")
     assert hasattr(hats_dataset, "get_coord_ra")
-    assert hasattr(hats_dataset, "get_coord_dec")
-    assert hasattr(hats_dataset, "get_mag-r")
+    assert not hasattr(hats_dataset, "get_coord_dec")
+    assert not hasattr(hats_dataset, "get_mag-r")


### PR DESCRIPTION
### Motivation
- Avoid expensive full-catalog `.compute()` calls in `HyraxHATSDataset` on every Hyrax verb by only materializing the LSDB columns that will actually be used. 
- Let the dataset constructor read the requested fields directly from the runtime `data_request` config so the golden-path stays simple and readable.

### Description
- Added `HyraxHATSDataset._requested_columns_from_config` which inspects `config['data_request']` (or deprecated `model_inputs`) and collects `fields` plus `primary_id_field` and `join_field` for matching dataset entries by `dataset_class` and resolved `data_location`.
- Pass the column list to `lsdb.read_hats(..., columns=...)` when any requested columns are found, falling back to the existing full read when none are discovered.
- Dynamic `get_<column>` getters are still created only for the loaded columns (so only requested/required getters are built when `fields` is provided).
- Updated tests to assert that when `fields` is specified only requested and required getters are present (renamed/adjusted test accordingly).

### Testing
- Compiled the modified dataset and test module with `python -m compileall src/hyrax/datasets/hats_dataset.py tests/hyrax/test_hats_dataset.py` and compilation succeeded.
- Ran `pytest` for the new/specific HATS test, but the run in this environment failed because `numpy` is not installed, so full test execution could not be completed.
- The change is limited to `HyraxHATSDataset` and the unit test; no modifications to `DataProvider` were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e958e055148331b6bf38bd88a9fbe5)