### PR TITLE
Pass LSDB open_catalog kwargs through to HyraxHATSDataset

### DIFF
--- a/src/hyrax/datasets/hats_dataset.py
+++ b/src/hyrax/datasets/hats_dataset.py
@@ -19,13 +19,13 @@ class HyraxHATSDataset(HyraxDataset):
 
         self.data_location = data_location
         requested_columns = self._requested_columns_from_config(config)
+        open_catalog_kwargs = self._open_catalog_kwargs_from_config(config)
+        if requested_columns and "columns" not in open_catalog_kwargs:
+            open_catalog_kwargs["columns"] = requested_columns
 
         import lsdb
 
-        if requested_columns:
-            catalog = lsdb.read_hats(data_location, columns=requested_columns)
-        else:
-            catalog = lsdb.read_hats(data_location)
+        catalog = lsdb.open_catalog(data_location, **open_catalog_kwargs)
         self.dataframe = catalog.compute()
         self.column_names = list(self.dataframe.columns)
 
@@ -73,6 +73,9 @@ class HyraxHATSDataset(HyraxDataset):
                     requested_columns.add(join_field)
 
         return sorted(requested_columns)
+
+    def _open_catalog_kwargs_from_config(self, config: dict) -> dict:
+        return dict((config.get("data_set") or {}).get(type(self).__name__, {}).get("open_catalog") or {})
 
     def __len__(self) -> int:
         return len(self.dataframe)

--- a/tests/hyrax/test_hats_dataset.py
+++ b/tests/hyrax/test_hats_dataset.py
@@ -93,3 +93,35 @@ def test_hats_dataset_with_data_request_fields_only_builds_requested_getters(hat
     assert hasattr(hats_dataset, "get_coord_ra")
     assert not hasattr(hats_dataset, "get_coord_dec")
     assert not hasattr(hats_dataset, "get_mag-r")
+
+
+def test_hats_dataset_open_catalog_filters_from_dataset_config(hats_catalog_path: Path):
+    h = hyrax.Hyrax()
+    h.config["data_request"] = {
+        "train": {
+            "data": {
+                "dataset_class": "HyraxHATSDataset",
+                "data_location": str(hats_catalog_path),
+                "fields": ["coord_ra"],
+                "primary_id_field": "object_id",
+                "split_fraction": 1.0,
+                "dataset_config": {
+                    "HyraxHATSDataset": {
+                        "open_catalog": {
+                            "filters": [("coord_ra", ">", 150.15)],
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    dataset = h.prepare()
+    hats_dataset = dataset["train"]._primary_or_first_dataset()
+
+    assert len(hats_dataset) == 2
+    assert hasattr(hats_dataset, "get_object_id")
+    assert hasattr(hats_dataset, "get_coord_ra")
+    assert not hasattr(hats_dataset, "get_coord_dec")
+    assert not hasattr(hats_dataset, "get_mag-r")
+    assert hats_dataset.get_object_id(0) == 1002


### PR DESCRIPTION
### Motivation
- Allow callers to pass any LSDB `open_catalog`-style filtering/options via dataset config so Hyrax can leverage LSDB filtering without hardcoding individual parameters. 
- Keep the configuration surface compatible with the existing TOML/nested-dict dataset_config mechanism and avoid preferring individual `open_catalog` parameters in code. 

### Description
- Load HATS catalogs using `lsdb.open_catalog(data_location, **open_catalog_kwargs)` instead of the previous `lsdb.read_hats` call. 
- Add `_open_catalog_kwargs_from_config` to read `data_set.HyraxHATSDataset.open_catalog` from the runtime config and pass it verbatim to `open_catalog`. 
- Preserve previous requested-field behavior by auto-populating the `columns` kwarg from requested fields only when `columns` is not already provided in the passthrough config. 
- Add a test `test_hats_dataset_open_catalog_filters_from_dataset_config` that supplies `open_catalog.filters` via `dataset_config` and asserts filtered rows and getter registration. 

### Testing
- Ran `python -m compileall src/hyrax/datasets/hats_dataset.py tests/hyrax/test_hats_dataset.py` which completed successfully. 
- Attempted `pytest -q tests/hyrax/test_hats_dataset.py` but the test run failed to start due to a missing runtime dependency (`ModuleNotFoundError: No module named 'numpy'`) in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea982181dc8331a61e15bb251f4661)