### PR TITLE
Add LanceDBDataset 

### DIFF
--- a/docs/common_workflows.rst
+++ b/docs/common_workflows.rst
@@ -7,6 +7,7 @@ Common workflows
    Configuration basics <notebooks/config_basics>
    Data requests <notebooks/data_requests>
    List available models and dataset classes <notebooks/list_available_models_and_datasets>
+   LanceDB dataset example <notebooks/lancedb_with_hyrax>
    Evaluating with TensorBoard and MLFlow <notebooks/using_tensorboard_and_mlflow>
    Working with result datasets <pre_executed/working_with_results_data>
    Look up results by ID <notebooks/lookup_results_by_id>

--- a/docs/notebooks/.gitignore
+++ b/docs/notebooks/.gitignore
@@ -1,0 +1,1 @@
+random_lancedb

--- a/docs/notebooks/lancedb_with_hyrax.ipynb
+++ b/docs/notebooks/lancedb_with_hyrax.ipynb
@@ -1,0 +1,91 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# LanceDB with Hyrax\n",
+        "\n",
+        "This notebook creates a small LanceDB database with two tables and reads one selected table with `LanceDBDataset`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import lancedb\n",
+        "import pyarrow as pa\n",
+        "import hyrax"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "db_path = Path('./random_lancedb')\n",
+        "db = lancedb.connect(str(db_path))\n",
+        "\n",
+        "observations = pa.table({\n",
+        "    'object_id': ['obj_0', 'obj_1', 'obj_2'],\n",
+        "    'flux': [10.2, 11.4, 9.8],\n",
+        "    'redshift': [0.12, 0.44, 0.31],\n",
+        "})\n",
+        "db.create_table('observations', observations, mode='overwrite')\n",
+        "\n",
+        "calibration = pa.table({\n",
+        "    'object_id': ['cal_0', 'cal_1'],\n",
+        "    'zeropoint': [25.1, 25.3],\n",
+        "})\n",
+        "db.create_table('calibration', calibration, mode='overwrite')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "h = hyrax.Hyrax()\n",
+        "h.config['data_set']['LanceDBDataset']['table_name'] = 'observations'\n",
+        "h.config['data_request'] = {\n",
+        "    'infer': {\n",
+        "        'lance': {\n",
+        "            'dataset_class': 'LanceDBDataset',\n",
+        "            'data_location': str(db_path),\n",
+        "            'primary_id_field': 'object_id',\n",
+        "            'fields': ['object_id', 'flux', 'redshift'],\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+        "prepared = h.prepare()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "prepared['infer'][0]['lance']"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/docs/notebooks/lancedb_with_hyrax.ipynb
+++ b/docs/notebooks/lancedb_with_hyrax.ipynb
@@ -1,91 +1,100 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# LanceDB with Hyrax\n",
-        "\n",
-        "This notebook creates a small LanceDB database with two tables and reads one selected table with `LanceDBDataset`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "\n",
-        "import lancedb\n",
-        "import pyarrow as pa\n",
-        "import hyrax"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "db_path = Path('./random_lancedb')\n",
-        "db = lancedb.connect(str(db_path))\n",
-        "\n",
-        "observations = pa.table({\n",
-        "    'object_id': ['obj_0', 'obj_1', 'obj_2'],\n",
-        "    'flux': [10.2, 11.4, 9.8],\n",
-        "    'redshift': [0.12, 0.44, 0.31],\n",
-        "})\n",
-        "db.create_table('observations', observations, mode='overwrite')\n",
-        "\n",
-        "calibration = pa.table({\n",
-        "    'object_id': ['cal_0', 'cal_1'],\n",
-        "    'zeropoint': [25.1, 25.3],\n",
-        "})\n",
-        "db.create_table('calibration', calibration, mode='overwrite')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "h = hyrax.Hyrax()\n",
-        "h.config['data_set']['LanceDBDataset']['table_name'] = 'observations'\n",
-        "h.config['data_request'] = {\n",
-        "    'infer': {\n",
-        "        'lance': {\n",
-        "            'dataset_class': 'LanceDBDataset',\n",
-        "            'data_location': str(db_path),\n",
-        "            'primary_id_field': 'object_id',\n",
-        "            'fields': ['object_id', 'flux', 'redshift'],\n",
-        "        }\n",
-        "    }\n",
-        "}\n",
-        "prepared = h.prepare()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "prepared['infer'][0]['lance']"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "110c05db",
+   "metadata": {},
+   "source": [
+    "# LanceDB with Hyrax\n",
+    "\n",
+    "This notebook creates a small LanceDB database with two tables and reads one selected table with `LanceDBDataset`."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f6be646",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import lancedb\n",
+    "import pyarrow as pa\n",
+    "import hyrax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3259f459",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db_path = Path(\"./random_lancedb\")\n",
+    "db = lancedb.connect(str(db_path))\n",
+    "\n",
+    "observations = pa.table(\n",
+    "    {\n",
+    "        \"object_id\": [\"obj_0\", \"obj_1\", \"obj_2\"],\n",
+    "        \"flux\": [10.2, 11.4, 9.8],\n",
+    "        \"redshift\": [0.12, 0.44, 0.31],\n",
+    "    }\n",
+    ")\n",
+    "db.create_table(\"observations\", observations, mode=\"overwrite\")\n",
+    "\n",
+    "calibration = pa.table(\n",
+    "    {\n",
+    "        \"object_id\": [\"cal_0\", \"cal_1\"],\n",
+    "        \"zeropoint\": [25.1, 25.3],\n",
+    "    }\n",
+    ")\n",
+    "db.create_table(\"calibration\", calibration, mode=\"overwrite\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af013baa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h = hyrax.Hyrax()\n",
+    "h.config[\"data_set\"][\"LanceDBDataset\"][\"table_name\"] = \"observations\"\n",
+    "h.config[\"data_request\"] = {\n",
+    "    \"infer\": {\n",
+    "        \"lance\": {\n",
+    "            \"dataset_class\": \"LanceDBDataset\",\n",
+    "            \"data_location\": str(db_path),\n",
+    "            \"primary_id_field\": \"object_id\",\n",
+    "            \"fields\": [\"object_id\", \"flux\", \"redshift\"],\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "prepared = h.prepare()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8e4da65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prepared[\"infer\"][0][\"lance\"]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/src/hyrax/datasets/__init__.py
+++ b/src/hyrax/datasets/__init__.py
@@ -72,6 +72,7 @@ from .dataset_registry import HyraxDataset
 from .hyrax_csv_dataset import HyraxCSVDataset
 from .mmu_dataset import MultimodalUniverseDataset
 from .nested_pandas_dataset import NestedPandasDataset
+from .lancedb_dataset import LanceDBDataset
 from .data_cache import DataCache
 
 __all__ = [
@@ -91,5 +92,6 @@ __all__ = [
     "HyraxCSVDataset",
     "MultimodalUniverseDataset",
     "NestedPandasDataset",
+    "LanceDBDataset",
     "DataCache",
 ]

--- a/src/hyrax/datasets/lancedb_dataset.py
+++ b/src/hyrax/datasets/lancedb_dataset.py
@@ -15,8 +15,7 @@ class LanceDBDataset(HyraxDataset):
             import lancedb
         except ImportError as err:
             raise ImportError(
-                "LanceDBDataset requires the `lancedb` package. "
-                "Install it with `pip install lancedb`."
+                "LanceDBDataset requires the `lancedb` package. Install it with `pip install lancedb`."
             ) from err
 
         settings = config["data_set"]["LanceDBDataset"]

--- a/src/hyrax/datasets/lancedb_dataset.py
+++ b/src/hyrax/datasets/lancedb_dataset.py
@@ -35,8 +35,8 @@ class LanceDBDataset(HyraxDataset):
     def _all_available_fields(self) -> list[str]:
         return list(self.table.schema.names)
 
-    def _resolve_table_name(self, configured_table_name: str | bool) -> str:
-        if configured_table_name is not False:
+    def _resolve_table_name(self, configured_table_name) -> str:
+        if isinstance(configured_table_name, str) and configured_table_name:
             return configured_table_name
 
         table_names = self.db.table_names()

--- a/src/hyrax/datasets/lancedb_dataset.py
+++ b/src/hyrax/datasets/lancedb_dataset.py
@@ -1,7 +1,10 @@
+from collections import OrderedDict
 from pathlib import Path
 from types import MethodType
 
 from hyrax.datasets.dataset_registry import HyraxDataset
+
+_ROW_CACHE_SIZE = 16
 
 
 class LanceDBDataset(HyraxDataset):
@@ -28,12 +31,28 @@ class LanceDBDataset(HyraxDataset):
         self.table_name = self._resolve_table_name(self.table_name)
         self.table = self.db.open_table(self.table_name, **self.open_table_kwargs)
         self.lance_dataset = self.table.to_lance()
+        self._row_cache: OrderedDict = OrderedDict()
 
         self._register_getters()
         super().__init__(config)
 
     def _all_available_fields(self) -> list[str]:
         return list(self.table.schema.names)
+
+    def _get_row(self, idx: int):
+        """Return the PyArrow record-batch for *idx*, using a small FIFO row cache.
+
+        Caching avoids redundant ``lance_dataset.take`` calls when multiple
+        ``get_<field>`` accessors are invoked for the same sample index, which is
+        the common pattern when DataProvider resolves all fields for a single item.
+        The cache holds at most ``_ROW_CACHE_SIZE`` rows; the oldest entry is
+        evicted once that limit is reached.
+        """
+        if idx not in self._row_cache:
+            if len(self._row_cache) >= _ROW_CACHE_SIZE:
+                self._row_cache.popitem(last=False)
+            self._row_cache[idx] = self.lance_dataset.take([idx])
+        return self._row_cache[idx]
 
     def _resolve_table_name(self, configured_table_name) -> str:
         if isinstance(configured_table_name, str) and configured_table_name:
@@ -54,7 +73,7 @@ class LanceDBDataset(HyraxDataset):
     def _register_getters(self) -> None:
         def _make_getter(field_name: str):
             def getter(self, idx, _field_name=field_name):
-                row = self.lance_dataset.take([int(idx)])
+                row = self._get_row(int(idx))
                 return row[_field_name][0].as_py()
 
             return getter

--- a/src/hyrax/datasets/lancedb_dataset.py
+++ b/src/hyrax/datasets/lancedb_dataset.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from types import MethodType
+
+from hyrax.datasets.dataset_registry import HyraxDataset
+
+
+class LanceDBDataset(HyraxDataset):
+    """A minimal Hyrax wrapper around a LanceDB table."""
+
+    def __init__(self, config: dict, data_location: Path | str | None = None):
+        if data_location is None:
+            raise ValueError("A `data_location` must be provided.")
+
+        try:
+            import lancedb
+        except ImportError as err:
+            raise ImportError(
+                "LanceDBDataset requires the `lancedb` package. "
+                "Install it with `pip install lancedb`."
+            ) from err
+
+        settings = config["data_set"]["LanceDBDataset"]
+        self.data_location = str(data_location)
+        self.table_name = settings["table_name"]
+        self.connect_kwargs = settings["connect_kwargs"]
+        self.open_table_kwargs = settings["open_table_kwargs"]
+
+        self.db = lancedb.connect(self.data_location, **self.connect_kwargs)
+        self.table_name = self._resolve_table_name(self.table_name)
+        self.table = self.db.open_table(self.table_name, **self.open_table_kwargs)
+        self.lance_dataset = self.table.to_lance()
+
+        self._register_getters()
+        super().__init__(config)
+
+    def _all_available_fields(self) -> list[str]:
+        return list(self.table.schema.names)
+
+    def _resolve_table_name(self, configured_table_name: str | bool) -> str:
+        if configured_table_name is not False:
+            return configured_table_name
+
+        table_names = self.db.table_names()
+        if len(table_names) == 1:
+            return table_names[0]
+
+        available_tables = ", ".join(table_names) if len(table_names) > 0 else "(none)"
+        raise RuntimeError(
+            "LanceDBDataset could not infer a table to open because `table_name` is unset "
+            "and the database does not have exactly one table. "
+            "Set `config['data_set']['LanceDBDataset']['table_name']` "
+            f"to one of: {available_tables}"
+        )
+
+    def _register_getters(self) -> None:
+        def _make_getter(field_name: str):
+            def getter(self, idx, _field_name=field_name):
+                row = self.lance_dataset.take([int(idx)])
+                return row[_field_name][0].as_py()
+
+            return getter
+
+        for field_name in self._all_available_fields():
+            method_name = f"get_{field_name}"
+            if not hasattr(self, method_name):
+                setattr(self, method_name, MethodType(_make_getter(field_name), self))
+
+    def __len__(self) -> int:
+        return self.table.count_rows()

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -369,6 +369,16 @@ invalid_value_type = "nan"
 # engine = "auto" # pandas default, but can be "pyarrow", "fastparquet"
 # See pandas.read_parquet API reference for all possible arguments.
 
+[data_set.LanceDBDataset]
+# Table name to open inside the LanceDB database.
+table_name = false
+
+# Extra keyword arguments passed directly to lancedb.connect.
+[data_set.LanceDBDataset.connect_kwargs]
+
+# Extra keyword arguments passed directly to db.open_table.
+[data_set.LanceDBDataset.open_table_kwargs]
+
 [data_set.MultimodalUniverseDataset]
 # Hugging Face split name to load (for example: "train", "validation", or "test").
 split = "train"

--- a/tests/hyrax/test_lancedb_dataset.py
+++ b/tests/hyrax/test_lancedb_dataset.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock
+
+import lancedb
+import pyarrow as pa
+import pytest
+
+from hyrax.datasets.lancedb_dataset import LanceDBDataset
+
+
+@pytest.fixture
+def lancedb_fixture(tmp_path):
+    db_path = tmp_path / "demo_lancedb"
+    db = lancedb.connect(str(db_path))
+
+    table_data = pa.table(
+        {
+            "object_id": ["obj_1", "obj_2", "obj_3"],
+            "flux": [10.5, 20.5, 30.5],
+            "label": [0, 1, 0],
+        }
+    )
+    db.create_table("observations", table_data)
+    return db_path
+
+
+def test_lancedb_dataset_reads_table_and_exposes_getters(lancedb_fixture):
+    dataset = LanceDBDataset(
+        config={
+            "data_set": {
+                "LanceDBDataset": {
+                    "table_name": False,
+                    "connect_kwargs": {},
+                    "open_table_kwargs": {},
+                }
+            }
+        },
+        data_location=lancedb_fixture,
+    )
+
+    assert len(dataset) == 3
+    assert dataset.get_object_id(0) == "obj_1"
+    assert dataset.get_flux(1) == 20.5
+    assert dataset.get_label(2) == 0
+
+
+def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(
+    lancedb_fixture, monkeypatch
+):
+    original_connect = lancedb.connect
+    mock_db = MagicMock()
+
+    def wrapped_connect(uri, **kwargs):
+        wrapped_connect.kwargs = kwargs
+        _ = original_connect(uri)
+        return mock_db
+
+    wrapped_connect.kwargs = None
+    mock_table = MagicMock()
+    mock_table.schema.names = ["object_id"]
+    mock_table.to_lance.return_value = MagicMock()
+    mock_table.count_rows.return_value = 0
+    mock_db.open_table.return_value = mock_table
+
+    monkeypatch.setattr(lancedb, "connect", wrapped_connect)
+
+    dataset = LanceDBDataset(
+        config={
+            "data_set": {
+                "LanceDBDataset": {
+                    "table_name": "observations",
+                    "connect_kwargs": {"api_key": "example-key"},
+                    "open_table_kwargs": {"storage_options": {"region": "us-west-2"}},
+                }
+            }
+        },
+        data_location=lancedb_fixture,
+    )
+
+    assert wrapped_connect.kwargs == {"api_key": "example-key"}
+    mock_db.open_table.assert_called_once_with(
+        "observations", storage_options={"region": "us-west-2"}
+    )
+    assert len(dataset) == 0
+
+
+def test_lancedb_dataset_requires_data_location():
+    with pytest.raises(ValueError):
+        LanceDBDataset(config={"data_set": {"LanceDBDataset": {}}})
+
+
+def test_lancedb_dataset_infers_only_table_name(monkeypatch, tmp_path):
+    mock_db = MagicMock()
+    mock_table = MagicMock()
+    mock_table.schema.names = ["object_id"]
+    mock_table.to_lance.return_value = MagicMock()
+    mock_table.count_rows.return_value = 0
+    mock_db.table_names.return_value = ["only_table"]
+    mock_db.open_table.return_value = mock_table
+    monkeypatch.setattr(lancedb, "connect", lambda *_args, **_kwargs: mock_db)
+
+    dataset = LanceDBDataset(
+        config={
+            "data_set": {
+                "LanceDBDataset": {
+                    "table_name": False,
+                    "connect_kwargs": {},
+                    "open_table_kwargs": {},
+                }
+            }
+        },
+        data_location=tmp_path / "db",
+    )
+
+    mock_db.open_table.assert_called_once_with("only_table")
+    assert len(dataset) == 0
+
+
+def test_lancedb_dataset_requires_table_name_when_multiple_tables(monkeypatch, tmp_path):
+    mock_db = MagicMock()
+    mock_db.table_names.return_value = ["table_a", "table_b"]
+    monkeypatch.setattr(lancedb, "connect", lambda *_args, **_kwargs: mock_db)
+
+    with pytest.raises(RuntimeError, match="table_a, table_b"):
+        LanceDBDataset(
+            config={
+                "data_set": {
+                    "LanceDBDataset": {
+                        "table_name": False,
+                        "connect_kwargs": {},
+                        "open_table_kwargs": {},
+                    }
+                }
+            },
+            data_location=tmp_path / "db",
+        )

--- a/tests/hyrax/test_lancedb_dataset.py
+++ b/tests/hyrax/test_lancedb_dataset.py
@@ -9,6 +9,12 @@ from hyrax.datasets.lancedb_dataset import LanceDBDataset
 
 @pytest.fixture
 def lancedb_fixture(tmp_path):
+    """Create a real LanceDB database on disk with a single 'observations' table
+    containing three rows across three columns (object_id, flux, label).
+
+    Used by tests that need to verify behaviour against an actual LanceDB file
+    rather than a mock.
+    """
     db_path = tmp_path / "demo_lancedb"
     db = lancedb.connect(str(db_path))
 
@@ -24,6 +30,12 @@ def lancedb_fixture(tmp_path):
 
 
 def test_lancedb_dataset_reads_table_and_exposes_getters(lancedb_fixture):
+    """Verify that LanceDBDataset opens a real LanceDB table and dynamically creates
+    ``get_<field>`` accessor methods for every column.
+
+    Checks that the dataset length matches the number of rows in the table and that
+    each accessor returns the correct scalar value for a given row index.
+    """
     dataset = LanceDBDataset(
         config={
             "data_set": {
@@ -44,6 +56,14 @@ def test_lancedb_dataset_reads_table_and_exposes_getters(lancedb_fixture):
 
 
 def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(lancedb_fixture, monkeypatch):
+    """Verify that ``connect_kwargs`` and ``open_table_kwargs`` from the config are
+    forwarded to ``lancedb.connect`` and ``db.open_table`` respectively.
+
+    Uses a wrapper around ``lancedb.connect`` to capture the keyword arguments it
+    received, and a mock table to inspect how ``open_table`` was called.  This
+    ensures remote/cloud LanceDB connections (which require auth or storage options)
+    work correctly when configured via Hyrax config.
+    """
     original_connect = lancedb.connect
     mock_db = MagicMock()
 
@@ -80,11 +100,25 @@ def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(lancedb_fi
 
 
 def test_lancedb_dataset_requires_data_location():
+    """Verify that constructing a LanceDBDataset without a ``data_location`` raises
+    a ``ValueError`` with a clear error message.
+
+    ``data_location`` points to the LanceDB database directory and has no
+    meaningful default, so its absence should be caught eagerly before any
+    connection attempt is made.
+    """
     with pytest.raises(ValueError):
         LanceDBDataset(config={"data_set": {"LanceDBDataset": {}}})
 
 
 def test_lancedb_dataset_infers_only_table_name(monkeypatch, tmp_path):
+    """Verify that when ``table_name`` is unset (``False``) and the database contains
+    exactly one table, that table is automatically selected without requiring explicit
+    configuration.
+
+    Uses a mocked LanceDB connection so the test does not require a real database
+    on disk, and asserts that ``open_table`` is called with the inferred table name.
+    """
     mock_db = MagicMock()
     mock_table = MagicMock()
     mock_table.schema.names = ["object_id"]
@@ -112,6 +146,13 @@ def test_lancedb_dataset_infers_only_table_name(monkeypatch, tmp_path):
 
 
 def test_lancedb_dataset_requires_table_name_when_multiple_tables(monkeypatch, tmp_path):
+    """Verify that when ``table_name`` is unset (``False``) and the database contains
+    multiple tables, a ``RuntimeError`` is raised listing the available table names.
+
+    Automatic table inference is only safe when there is exactly one table.  With
+    multiple tables the user must specify which one to open, and the error message
+    should include the names of the existing tables to help the user fix their config.
+    """
     mock_db = MagicMock()
     mock_db.table_names.return_value = ["table_a", "table_b"]
     monkeypatch.setattr(lancedb, "connect", lambda *_args, **_kwargs: mock_db)

--- a/tests/hyrax/test_lancedb_dataset.py
+++ b/tests/hyrax/test_lancedb_dataset.py
@@ -43,9 +43,7 @@ def test_lancedb_dataset_reads_table_and_exposes_getters(lancedb_fixture):
     assert dataset.get_label(2) == 0
 
 
-def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(
-    lancedb_fixture, monkeypatch
-):
+def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(lancedb_fixture, monkeypatch):
     original_connect = lancedb.connect
     mock_db = MagicMock()
 
@@ -77,9 +75,7 @@ def test_lancedb_dataset_passes_through_connect_and_open_table_kwargs(
     )
 
     assert wrapped_connect.kwargs == {"api_key": "example-key"}
-    mock_db.open_table.assert_called_once_with(
-        "observations", storage_options={"region": "us-west-2"}
-    )
+    mock_db.open_table.assert_called_once_with("observations", storage_options={"region": "us-west-2"})
     assert len(dataset) == 0
 
 

--- a/tests/hyrax/test_lancedb_dataset.py
+++ b/tests/hyrax/test_lancedb_dataset.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import lancedb
 import pyarrow as pa
@@ -170,3 +170,33 @@ def test_lancedb_dataset_requires_table_name_when_multiple_tables(monkeypatch, t
             },
             data_location=tmp_path / "db",
         )
+
+
+def test_lancedb_dataset_row_cache_avoids_redundant_reads(lancedb_fixture):
+    """Verify that accessing multiple fields for the same row index results in only
+    one underlying ``lance_dataset.take`` call.
+
+    ``LanceDBDataset`` maintains a small FIFO row cache keyed by index.  When
+    DataProvider resolves several fields for a single sample (e.g. ``get_flux`` and
+    ``get_label`` both for index 0) the row should be fetched from LanceDB exactly
+    once.  This test confirms the cache is working by patching ``lance_dataset.take``
+    and asserting it is called only once after two field accesses at the same index.
+    """
+    dataset = LanceDBDataset(
+        config={
+            "data_set": {
+                "LanceDBDataset": {
+                    "table_name": False,
+                    "connect_kwargs": {},
+                    "open_table_kwargs": {},
+                }
+            }
+        },
+        data_location=lancedb_fixture,
+    )
+
+    with patch.object(dataset.lance_dataset, "take", wraps=dataset.lance_dataset.take) as mock_take:
+        _ = dataset.get_flux(0)
+        _ = dataset.get_label(0)
+
+    mock_take.assert_called_once_with([0])


### PR DESCRIPTION
### Motivation

- Provide a Hyrax dataset wrapper for reading LanceDB tables so users can use LanceDB as a source for inference and dataset workflows.
- Make the dataset discoverable via the dataset registry and documented in the common workflows to guide users on usage.

### Description

- Add `src/hyrax/datasets/lancedb_dataset.py` implementing `LanceDBDataset` which connects to a LanceDB database, opens a table, exposes field getters via dynamic `get_<field>` methods, and implements `__len__`.
- Export `LanceDBDataset` from `src/hyrax/datasets/__init__.py` and add default configuration keys under `[data_set.LanceDBDataset]` in `src/hyrax/hyrax_default_config.toml` for `table_name`, `connect_kwargs`, and `open_table_kwargs`.
- Add a notebook `docs/notebooks/lancedb_with_hyrax.ipynb` and include it in the common workflows `docs/common_workflows.rst` to demonstrate creating and reading a LanceDB table.
- Add unit tests `tests/hyrax/test_lancedb_dataset.py` exercising table reading, getter generation, `connect_kwargs`/`open_table_kwargs` passthrough, missing `data_location` handling, and table-name inference/error behavior.

### Testing

- Ran the new unit tests in `tests/hyrax/test_lancedb_dataset.py` with `pytest` and they passed.
- Tests cover reading rows and dynamic getters, passthrough of `connect_kwargs` and `open_table_kwargs`, error on missing `data_location`, and error when multiple tables exist and `table_name` is unset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa4aaaf848331926986498c9e69b4)