### PR TITLE
Fix test_torch_load_with_map_location on macs.

### DIFF
--- a/src/hyrax/models/model_registry.py
+++ b/src/hyrax/models/model_registry.py
@@ -62,7 +62,7 @@ def _torch_load(self: nn.Module, load_path: Path):
     device = idist.device()
     state = torch.load(load_path, weights_only=True, map_location=device)
 
-    self.load_state_dict(state)
+    self.load_state_dict(state, assign=True)
 
     # Try loading prepare_inputs first (new name), fall back to to_tensor for backward compatibility
     prepare_inputs_fn = load_prepare_inputs(load_path.parent)


### PR DESCRIPTION
Issue was that nn.Module `load_state_dict` uses the properties of the model rather than the properties of the incoming state dict to determine device affinity by default.

With `assign=True` `load_state_dict` uses the properties of the incoming dict, which is what we want, since the state dict has already been deserialized into device memory by `torch.load` using `map_location`
