### PR TITLE
Fix conda activate script compatibility in non-interactive shells

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -28,9 +28,13 @@ if [ ! -f "$SENTINEL" ]; then
   touch "$SENTINEL"
 fi
 
-# Activate the venv. CONDA_PREFIX may be unset; guard against set -u.
+# Activate the venv. PS1 and CONDA_PREFIX may be unset in non-interactive shells;
+# temporarily disable -u so the conda activate script doesn't abort on them.
 export CONDA_PREFIX="${CONDA_PREFIX:-}"
+export PS1="${PS1:-}"
+set +u
 source "$VENV_PATH/bin/activate"
+set -u
 
 # Ensure hyrax is editable-installed from the current checkout. Editable installs
 # are path-specific and must not be cached in the container image, so this runs


### PR DESCRIPTION
## Change Description

Fix the session-start hook to properly handle unset `PS1` variable in non-interactive shells when activating the conda environment.

## Solution Description

The conda activate script references the `PS1` variable, which may be unset in non-interactive shell contexts. When `set -u` (error on undefined variables) is enabled, this causes the activation to fail.

The fix:
1. Explicitly export `PS1` with a default empty value, similar to the existing `CONDA_PREFIX` handling
2. Temporarily disable `set -u` before sourcing the activate script
3. Re-enable `set -u` immediately after activation completes

This ensures the conda activation script can run successfully in both interactive and non-interactive shell environments while maintaining strict variable checking for the rest of the script.

## Code Quality
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

https://claude.ai/code/session_01287NGLb7wPQtqQahZaoPb1