### PR TITLE
codex setup: avoid redundant editable install and persist venv activation to ~/.profile

### DIFF
--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -34,4 +34,26 @@ conda-unpack
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
-python -m pip install -e '.[dev]'
+
+# Ensure hyrax is editable-installed from the current checkout path.
+EXPECTED_INIT="$REPO_ROOT/src/hyrax/__init__.py"
+INSTALLED_INIT="$(python -c "import hyrax; print(hyrax.__file__)" 2>/dev/null || true)"
+if [ "$INSTALLED_INIT" != "$EXPECTED_INIT" ]; then
+  python -m pip install -e '.[dev]'
+fi
+
+# Persist venv pathing for future non-interactive login shells in Codex.
+PROFILE_FILE="$HOME/.profile"
+BEGIN_MARKER="# >>> hyrax codex venv >>>"
+END_MARKER="# <<< hyrax codex venv <<<"
+if ! grep -Fq "$BEGIN_MARKER" "$PROFILE_FILE"; then
+  printf '\n' >> "$PROFILE_FILE"
+  cat >> "$PROFILE_FILE" <<EOF
+$BEGIN_MARKER
+if [ -f "$HOME/hyrax-venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  source "$HOME/hyrax-venv/bin/activate"
+fi
+$END_MARKER
+EOF
+fi


### PR DESCRIPTION
### Motivation

- Ensure the repository's current checkout is what provides the `hyrax` editable install so the script doesn't redundantly reinstall the package from elsewhere.
- Make the conda/venv activation persistent for future non-interactive login shells used by Codex by adding a safe sourcing snippet to `~/.profile`.

### Description

- Add a check that compares the installed `hyrax.__file__` path with the expected `src/hyrax/__init__.py` and run `python -m pip install -e '.[dev]'` only if they differ.
- Append a marked snippet to `~/.profile` that sources the `$HOME/hyrax-venv/bin/activate` script if present, and only add the block if the begin marker is not already present.
- Keep existing artifact download, extraction and `conda-unpack` behavior intact and only change the post-checkout installation and profile persistence logic.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0a6244ac8331be39216434663d03)