### PR TITLE
Make Codex container maintenance idempotent and reuse logic in setup script

### DIFF
--- a/agent_scripts/codex_maintain_container.sh
+++ b/agent_scripts/codex_maintain_container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # To use this as your maintenance script in codex
 # put the following line into the maintenance script
@@ -6,9 +7,41 @@
 #
 # ./agent_scripts/codex_maintain_container.sh
 #
+# This script is intentionally idempotent. It ensures:
+# 1) hyrax is editable-installed from the current checkout path
+# 2) login shells auto-activate the hyrax conda-packed environment
 
-pip install -e .'[dev]'
-pushd docs
-make clean
-popd
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
 
+ENV_DIR="$HOME/hyrax-venv"
+
+# shellcheck disable=SC1091
+if [ -f "${ENV_DIR}/bin/activate" ]; then
+  set +u
+  source "${ENV_DIR}/bin/activate"
+  set -u
+fi
+
+# Ensure hyrax is editable-installed from the current checkout path.
+EXPECTED_INIT="$REPO_ROOT/src/hyrax/__init__.py"
+INSTALLED_INIT="$(python -c "import hyrax; print(hyrax.__file__)" 2>/dev/null || true)"
+if [ "$INSTALLED_INIT" != "$EXPECTED_INIT" ]; then
+  python -m pip install -e '.[dev]'
+fi
+
+# Persist venv pathing for future non-interactive login shells in Codex.
+PROFILE_FILE="$HOME/.profile"
+BEGIN_MARKER="# >>> hyrax codex venv >>>"
+END_MARKER="# <<< hyrax codex venv <<<"
+if ! grep -Fq "$BEGIN_MARKER" "$PROFILE_FILE"; then
+  printf '\n' >> "$PROFILE_FILE"
+  cat >> "$PROFILE_FILE" <<PROFILE_BLOCK
+$BEGIN_MARKER
+if [ -f "$HOME/hyrax-venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  source "$HOME/hyrax-venv/bin/activate"
+fi
+$END_MARKER
+PROFILE_BLOCK
+fi

--- a/agent_scripts/codex_setup_container.sh
+++ b/agent_scripts/codex_setup_container.sh
@@ -35,25 +35,5 @@ conda-unpack
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
 
-# Ensure hyrax is editable-installed from the current checkout path.
-EXPECTED_INIT="$REPO_ROOT/src/hyrax/__init__.py"
-INSTALLED_INIT="$(python -c "import hyrax; print(hyrax.__file__)" 2>/dev/null || true)"
-if [ "$INSTALLED_INIT" != "$EXPECTED_INIT" ]; then
-  python -m pip install -e '.[dev]'
-fi
-
-# Persist venv pathing for future non-interactive login shells in Codex.
-PROFILE_FILE="$HOME/.profile"
-BEGIN_MARKER="# >>> hyrax codex venv >>>"
-END_MARKER="# <<< hyrax codex venv <<<"
-if ! grep -Fq "$BEGIN_MARKER" "$PROFILE_FILE"; then
-  printf '\n' >> "$PROFILE_FILE"
-  cat >> "$PROFILE_FILE" <<EOF
-$BEGIN_MARKER
-if [ -f "$HOME/hyrax-venv/bin/activate" ]; then
-  # shellcheck disable=SC1091
-  source "$HOME/hyrax-venv/bin/activate"
-fi
-$END_MARKER
-EOF
-fi
+# Reuse maintenance script for editable install + profile activation plumbing.
+"$REPO_ROOT/agent_scripts/codex_maintain_container.sh"


### PR DESCRIPTION
### Motivation
- Ensure container maintenance is safe and repeatable by making the maintenance script idempotent and robust to failures.
- Avoid duplicating installation/profile plumbing in the setup script by centralizing that logic in one maintenance script.
- Persist virtualenv activation for future login shells so non-interactive Codex sessions have the environment available.

### Description
- Add `set -euo pipefail` and defensive activation of `$HOME/hyrax-venv` to `agent_scripts/codex_maintain_container.sh`. 
- Implement an idempotent editable install check that compares `$(python -c "import hyrax; print(hyrax.__file__)")` to the checkout path and runs `python -m pip install -e '.[dev]'` only when needed. 
- Append activation plumbing guarded by markers to `~/.profile` so login shells auto-source the venv (`# >>> hyrax codex venv >>>` / `# <<< hyrax codex venv <<<`).
- Simplify `agent_scripts/codex_setup_container.sh` to unpack and `conda-unpack` the downloaded artifact and then invoke the maintenance script at `"$REPO_ROOT/agent_scripts/codex_maintain_container.sh"` instead of duplicating install/profile logic.

### Testing
- No automated tests were executed for these script changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec1b5b3cc08331b11df2b677ab9677)