### PR TITLE
Dataset creation skill for coding agents

### DIFF
--- a/.agents/skills/hyrax-dataset-class
+++ b/.agents/skills/hyrax-dataset-class
@@ -1,0 +1,1 @@
+../../.claude/skills/hyrax-dataset-class

--- a/.claude/skills/hyrax-dataset-class/SKILL.md
+++ b/.claude/skills/hyrax-dataset-class/SKILL.md
@@ -19,6 +19,52 @@ Read [references/config-rules.md](references/config-rules.md) before reading or 
 
 Read [references/test-checklist.md](references/test-checklist.md) before writing or reviewing dataset tests.
 
+## Canonical Minimal Example
+
+Use this as the starting shape for any new dataset class. Adapt it to the user's data format.
+
+```python
+from hyrax.datasets import HyraxDataset
+
+
+class ExampleTabularDataset(HyraxDataset):
+    """Hyrax dataset wrapping a tabular data source."""
+
+    def __init__(self, config: dict, data_location=None):
+        if data_location is None:
+            raise ValueError("A `data_location` must be provided.")
+
+        self.data_location = str(data_location)
+        settings = config["data_set"]["ExampleTabularDataset"]
+        self.read_kwargs = settings["read_kwargs"]
+
+        self.table = self._load_table()
+        super().__init__(config)
+
+    def _load_table(self):
+        import some_library
+        return some_library.open(self.data_location, **self.read_kwargs)
+
+    def get_object_id(self, idx):
+        return str(self.table[idx]["object_id"])
+
+    def get_flux(self, idx):
+        return float(self.table[idx]["flux"])
+
+    def __len__(self):
+        return len(self.table)
+```
+
+Key points this example demonstrates:
+- Import from `hyrax.datasets`, not `hyrax.datasets.dataset_registry`.
+- Class name ends in `Dataset`.
+- One-line class docstring.
+- Config access with `[]`, never `.get()`.
+- Pass-through kwargs via a config sub-table.
+- `super().__init__(config)` called last.
+- Optional dependency imported inside the method that uses it.
+- Explicit getter methods for known fields.
+
 ## User Discovery
 
 Ask only material questions. Get enough information to define the golden path:
@@ -34,24 +80,27 @@ If the user is still exploring, stay at their level of generality: sketch the cl
 
 ## Implementation Workflow
 
-1. Choose a class name and module under `src/hyrax/datasets/`.
-2. Inherit from `hyrax.datasets.HyraxDataset` or the local import used by nearby dataset modules.
+1. Choose a class name ending in `Dataset` and a module under `src/hyrax/datasets/`.
+2. Import `HyraxDataset` from `hyrax.datasets` (the canonical import path).
 3. Implement `__init__(self, config: dict, data_location=None)`.
 4. Store `data_location` when relevant and do one-time setup there: locate files, load small catalogs, open handles, or store pass-through kwargs.
 5. Call `super().__init__(config)` after dataset-specific setup unless the surrounding local pattern requires otherwise.
 6. Implement `__len__(self)`.
 7. Implement `get_<field_name>(self, idx)` for every field Hyrax may request, including `get_<primary_id_field>`.
 8. Return stable, unique IDs from the primary ID getter. Prefer an existing unique object ID; otherwise use a stable index or deterministic hash from identifying values.
-9. Add focused tests under `tests/hyrax/` that create minimal sample data and assert length, primary IDs, requested fields, and config/pass-through behavior.
-10. Add a notebook or docs example when the request asks for a user-facing workflow or the dataset format needs demonstration.
+9. Add a one-line class docstring describing what the dataset wraps.
+10. Add focused tests under `tests/hyrax/` that create minimal sample data and assert length, primary IDs, requested fields, and config/pass-through behavior.
+11. Add a notebook or docs example when the request asks for a user-facing workflow or the dataset format needs demonstration.
 
 Keep heavy per-object work inside getters. Keep constructor work limited to setup that should happen once.
+
+Do not implement `__getitem__` or `collate` unless the user specifically asks for custom batching behavior. The base class and Hyrax machinery handle these.
 
 ## Code Style
 
 Optimize for readability of the normal path over exhaustive error correction. Validate only the inputs that would otherwise produce confusing failures or silent wrong results.
 
-Prefer explicit getters when the field set is small and known. Generate getters only when the data source exposes dynamic columns and the generated behavior is easier to read than repeating boilerplate.
+Default to explicit getters. Use dynamic getter registration (the `_register_getters` pattern) only when the columns come from the data source at runtime and are not known at development time (e.g. CSV columns, database schemas, Parquet fields). For most scientist-written datasets where the fields are known up front, explicit `get_<field>` methods are clearer and easier to debug.
 
 Keep optional dependency imports close to where they are needed when the dependency is dataset-specific.
 

--- a/.claude/skills/hyrax-dataset-class/SKILL.md
+++ b/.claude/skills/hyrax-dataset-class/SKILL.md
@@ -87,7 +87,7 @@ If the user is still exploring, stay at their level of generality: sketch the cl
 5. Call `super().__init__(config)` after dataset-specific setup unless the surrounding local pattern requires otherwise.
 6. Implement `__len__(self)`.
 7. Implement `get_<field_name>(self, idx)` for every field Hyrax may request, including `get_<primary_id_field>`.
-8. Return stable, unique IDs from the primary ID getter. Prefer an existing unique object ID; otherwise use a stable index or deterministic hash from identifying values.
+8. Return stable, unique IDs from the primary ID getter. Prefer an existing unique object ID; otherwise use a stable index or deterministic hash from identifying values. Unique IDs must be strings.
 9. Add a one-line class docstring describing what the dataset wraps.
 10. Add focused tests under `tests/hyrax/` that create minimal sample data and assert length, primary IDs, requested fields, and config/pass-through behavior.
 11. Always add a runnable notebook example except if directed otherwise specifically.
@@ -104,4 +104,4 @@ Default to explicit getters. Use dynamic getter registration (the `_register_get
 
 Keep optional dependency imports close to where they are needed when the dependency is dataset-specific.
 
-Preserve underlying library return types when they are already useful to Hyrax. Convert only when Hyrax or tests need a stable representation, such as `float`, `int`, `str`, NumPy arrays, or tensors.
+Preserve underlying library return types when they are already useful to Hyrax. Ensure types passed to hyrax are `float`, `int`, `str`, or NumPy arrays.

--- a/.claude/skills/hyrax-dataset-class/SKILL.md
+++ b/.claude/skills/hyrax-dataset-class/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Read `docs/dataset_class_reference.rst` before implementing. Treat it as the interface contract.
 
-Read `src/hyrax/hyrax_default_config.toml` before adding config keys. Match the existing TOML style and put dataset-specific defaults under `[data_set.<ClassName>]`.
+Read `src/hyrax/hyrax_default_config.toml` before adding config keys. Match the existing TOML style and put dataset-specific defaults under `[dataset.<ClassName>]`.
 
 Use existing dataset modules, tests, and notebook examples only as local patterns. Do not blindly copy an implementation; adapt the shape to the user's data format and requested fields.
 
@@ -35,7 +35,7 @@ class ExampleTabularDataset(HyraxDataset):
             raise ValueError("A `data_location` must be provided.")
 
         self.data_location = str(data_location)
-        settings = config["data_set"]["ExampleTabularDataset"]
+        settings = config["dataset"]["ExampleTabularDataset"]
         self.read_kwargs = settings["read_kwargs"]
 
         self.table = self._load_table()
@@ -61,7 +61,7 @@ Key points this example demonstrates:
 - One-line class docstring.
 - Config access with `[]`, never `.get()`.
 - Pass-through kwargs via a config sub-table.
-- `super().__init__(config)` called last.
+- `super().__init__(config)` should be called.
 - Optional dependency imported inside the method that uses it.
 - Explicit getter methods for known fields.
 

--- a/.claude/skills/hyrax-dataset-class/SKILL.md
+++ b/.claude/skills/hyrax-dataset-class/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: hyrax-dataset-class
+description: Create or update Hyrax dataset classes. Use when the user asks to "create a dataset class", "add a HyraxDataset", "load my data through Hyrax", "add dataset getter methods", "wire dataset defaults", "add dataset tests", or "make a notebook example" for a Hyrax dataset. Also use when a task involves data_request fields, primary_id_field, hyrax_default_config.toml defaults, or dataset code under src/hyrax/datasets.
+metadata:
+  version: "0.1.0"
+---
+
+# Hyrax Dataset Class
+
+## First Read
+
+Read `docs/dataset_class_reference.rst` before implementing. Treat it as the interface contract.
+
+Read `src/hyrax/hyrax_default_config.toml` before adding config keys. Match the existing TOML style and put dataset-specific defaults under `[data_set.<ClassName>]`.
+
+Use existing dataset modules, tests, and notebook examples only as local patterns. Do not blindly copy an implementation; adapt the shape to the user's data format and requested fields.
+
+Read [references/config-rules.md](references/config-rules.md) before reading or adding dataset config keys.
+
+Read [references/test-checklist.md](references/test-checklist.md) before writing or reviewing dataset tests.
+
+## User Discovery
+
+Ask only material questions. Get enough information to define the golden path:
+
+- Data location and storage format: file, directory, database, remote service, table name, split name, or other locator.
+- Object granularity: what one `idx` represents.
+- Dataset length source: catalog rows, files, table rows, remote records, or configured limit.
+- Requested Hyrax fields: `fields` values and the `primary_id_field` the data request will use.
+- Field shapes and types: scalar, array, image, time series, nested table, label, mask, metadata.
+- Required library pass-through kwargs and which options need Hyrax defaults.
+
+If the user is still exploring, stay at their level of generality: sketch the class skeleton, identify missing data details, and implement only what can be grounded in their example or specification.
+
+## Implementation Workflow
+
+1. Choose a class name and module under `src/hyrax/datasets/`.
+2. Inherit from `hyrax.datasets.HyraxDataset` or the local import used by nearby dataset modules.
+3. Implement `__init__(self, config: dict, data_location=None)`.
+4. Store `data_location` when relevant and do one-time setup there: locate files, load small catalogs, open handles, or store pass-through kwargs.
+5. Call `super().__init__(config)` after dataset-specific setup unless the surrounding local pattern requires otherwise.
+6. Implement `__len__(self)`.
+7. Implement `get_<field_name>(self, idx)` for every field Hyrax may request, including `get_<primary_id_field>`.
+8. Return stable, unique IDs from the primary ID getter. Prefer an existing unique object ID; otherwise use a stable index or deterministic hash from identifying values.
+9. Add focused tests under `tests/hyrax/` that create minimal sample data and assert length, primary IDs, requested fields, and config/pass-through behavior.
+10. Add a notebook or docs example when the request asks for a user-facing workflow or the dataset format needs demonstration.
+
+Keep heavy per-object work inside getters. Keep constructor work limited to setup that should happen once.
+
+## Code Style
+
+Optimize for readability of the normal path over exhaustive error correction. Validate only the inputs that would otherwise produce confusing failures or silent wrong results.
+
+Prefer explicit getters when the field set is small and known. Generate getters only when the data source exposes dynamic columns and the generated behavior is easier to read than repeating boilerplate.
+
+Keep optional dependency imports close to where they are needed when the dependency is dataset-specific.
+
+Preserve underlying library return types when they are already useful to Hyrax. Convert only when Hyrax or tests need a stable representation, such as `float`, `int`, `str`, NumPy arrays, or tensors.

--- a/.claude/skills/hyrax-dataset-class/SKILL.md
+++ b/.claude/skills/hyrax-dataset-class/SKILL.md
@@ -90,7 +90,7 @@ If the user is still exploring, stay at their level of generality: sketch the cl
 8. Return stable, unique IDs from the primary ID getter. Prefer an existing unique object ID; otherwise use a stable index or deterministic hash from identifying values.
 9. Add a one-line class docstring describing what the dataset wraps.
 10. Add focused tests under `tests/hyrax/` that create minimal sample data and assert length, primary IDs, requested fields, and config/pass-through behavior.
-11. Add a notebook or docs example when the request asks for a user-facing workflow or the dataset format needs demonstration.
+11. Always add a runnable notebook example except if directed otherwise specifically.
 
 Keep heavy per-object work inside getters. Keep constructor work limited to setup that should happen once.
 

--- a/.claude/skills/hyrax-dataset-class/agents/openai.yaml
+++ b/.claude/skills/hyrax-dataset-class/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Hyrax Dataset Class"
+  short_description: "Create Hyrax dataset classes"
+  default_prompt: "Use $hyrax-dataset-class to create a Hyrax dataset class for my data."

--- a/.claude/skills/hyrax-dataset-class/references/config-rules.md
+++ b/.claude/skills/hyrax-dataset-class/references/config-rules.md
@@ -28,3 +28,24 @@ resource = library.open(data_location, **open_kwargs)
 Avoid defensive branches around config keys that Hyrax owns. Use clear branches only for meaningful user choices, such as a `false` default meaning "disabled" or "infer automatically."
 
 Do not redefine optional keyword argument keys owned by an underlying library in Hyrax config. Keep those inside the pass-through dictionary unless Hyrax itself needs to interpret the option.
+
+## Complete TOML Example
+
+This is a real example from `hyrax_default_config.toml`. Use this as a template for new dataset defaults:
+
+```toml
+[data_set.LanceDBDataset]
+# Table name to open inside the LanceDB database.
+table_name = false
+
+# Extra keyword arguments passed directly to lancedb.connect.
+[data_set.LanceDBDataset.connect_kwargs]
+
+# Extra keyword arguments passed directly to db.open_table.
+[data_set.LanceDBDataset.open_table_kwargs]
+```
+
+Key formatting rules:
+- `false` is used as a sentinel meaning "not set" (TOML has no null).
+- Empty sub-tables (like `connect_kwargs` above) define pass-through dictionaries that start as `{}`.
+- Comments above keys explain the option. Commented-out key examples show valid values.

--- a/.claude/skills/hyrax-dataset-class/references/config-rules.md
+++ b/.claude/skills/hyrax-dataset-class/references/config-rules.md
@@ -3,7 +3,7 @@
 Access Hyrax-owned config keys with `[]`, not `.get()`.
 
 ```python
-settings = config["data_set"]["YourDatasetClass"]
+settings = config["dataset"]["YourDatasetClass"]
 value = settings["value_with_default"]
 ```
 
@@ -12,15 +12,15 @@ Add every Hyrax-owned key the dataset reads to `src/hyrax/hyrax_default_config.t
 Use pass-through dictionaries for optional keyword arguments owned by an underlying library. Add a default empty table for the pass-through dictionary, then forward it with `**kwargs`.
 
 ```toml
-[data_set.YourDatasetClass]
+[dataset.YourDatasetClass]
 required_option = false
 
-[data_set.YourDatasetClass.open_kwargs]
+[dataset.YourDatasetClass.open_kwargs]
 # library_option = "example"
 ```
 
 ```python
-settings = config["data_set"]["YourDatasetClass"]
+settings = config["dataset"]["YourDatasetClass"]
 open_kwargs = settings["open_kwargs"]
 resource = library.open(data_location, **open_kwargs)
 ```
@@ -34,15 +34,15 @@ Do not redefine optional keyword argument keys owned by an underlying library in
 This is a real example from `hyrax_default_config.toml`. Use this as a template for new dataset defaults:
 
 ```toml
-[data_set.LanceDBDataset]
+[dataset.LanceDBDataset]
 # Table name to open inside the LanceDB database.
 table_name = false
 
 # Extra keyword arguments passed directly to lancedb.connect.
-[data_set.LanceDBDataset.connect_kwargs]
+[dataset.LanceDBDataset.connect_kwargs]
 
 # Extra keyword arguments passed directly to db.open_table.
-[data_set.LanceDBDataset.open_table_kwargs]
+[dataset.LanceDBDataset.open_table_kwargs]
 ```
 
 Key formatting rules:

--- a/.claude/skills/hyrax-dataset-class/references/config-rules.md
+++ b/.claude/skills/hyrax-dataset-class/references/config-rules.md
@@ -1,0 +1,30 @@
+# Config Rules
+
+Access Hyrax-owned config keys with `[]`, not `.get()`.
+
+```python
+settings = config["data_set"]["YourDatasetClass"]
+value = settings["value_with_default"]
+```
+
+Add every Hyrax-owned key the dataset reads to `src/hyrax/hyrax_default_config.toml`. Missing defaults should fail loudly with `KeyError` during development.
+
+Use pass-through dictionaries for optional keyword arguments owned by an underlying library. Add a default empty table for the pass-through dictionary, then forward it with `**kwargs`.
+
+```toml
+[data_set.YourDatasetClass]
+required_option = false
+
+[data_set.YourDatasetClass.open_kwargs]
+# library_option = "example"
+```
+
+```python
+settings = config["data_set"]["YourDatasetClass"]
+open_kwargs = settings["open_kwargs"]
+resource = library.open(data_location, **open_kwargs)
+```
+
+Avoid defensive branches around config keys that Hyrax owns. Use clear branches only for meaningful user choices, such as a `false` default meaning "disabled" or "infer automatically."
+
+Do not redefine optional keyword argument keys owned by an underlying library in Hyrax config. Keep those inside the pass-through dictionary unless Hyrax itself needs to interpret the option.

--- a/.claude/skills/hyrax-dataset-class/references/test-checklist.md
+++ b/.claude/skills/hyrax-dataset-class/references/test-checklist.md
@@ -34,7 +34,7 @@ def sample_data(tmp_path):
 def test_dataset_length_and_getters(sample_data):
     dataset = YourDataset(
         config={
-            "data_set": {
+            "dataset": {
                 "YourDataset": {
                     # Mirror the keys from hyrax_default_config.toml
                     "some_option": "value",

--- a/.claude/skills/hyrax-dataset-class/references/test-checklist.md
+++ b/.claude/skills/hyrax-dataset-class/references/test-checklist.md
@@ -12,4 +12,44 @@ Cover the smallest representative sample:
 
 Prefer tests that create realistic tiny data in `tmp_path` over tests that depend on repository data fixtures. Keep the assertions tied to the public Hyrax behavior: constructor, `__len__`, and `get_<field>` methods.
 
+## Fixture Pattern
+
+Use this pattern to create sample data and a dataset instance for testing:
+
+```python
+import pytest
+
+from hyrax.datasets.your_dataset_module import YourDataset
+
+
+@pytest.fixture
+def sample_data(tmp_path):
+    """Create minimal realistic data on disk and return the path."""
+    data_path = tmp_path / "sample_data"
+    # Write a small representative dataset here (3-5 rows is enough)
+    # e.g. write a CSV, create a database, write parquet files
+    return data_path
+
+
+def test_dataset_length_and_getters(sample_data):
+    dataset = YourDataset(
+        config={
+            "data_set": {
+                "YourDataset": {
+                    # Mirror the keys from hyrax_default_config.toml
+                    "some_option": "value",
+                    "read_kwargs": {},
+                }
+            }
+        },
+        data_location=sample_data,
+    )
+
+    assert len(dataset) == 3
+    assert dataset.get_object_id(0) == "expected_id"
+    assert dataset.get_flux(1) == pytest.approx(20.5)
+```
+
+Key points: pass the config dict inline with the same structure as `hyrax_default_config.toml`. Use `pytest.approx` for floats. Test every getter the dataset exposes.
+
 Run the targeted dataset tests first. Run broader tests only when the change touches shared dataset loading, config parsing, data request handling, or collation behavior.

--- a/.claude/skills/hyrax-dataset-class/references/test-checklist.md
+++ b/.claude/skills/hyrax-dataset-class/references/test-checklist.md
@@ -1,0 +1,15 @@
+# Test Checklist
+
+Cover the smallest representative sample:
+
+- Constructor loads or connects using temporary sample data.
+- `len(dataset)` matches the number of objects.
+- `get_<primary_id_field>(idx)` returns stable unique IDs.
+- Each requested getter returns the expected value, shape, and type.
+- Dataset-specific config defaults are read with bracket access.
+- Pass-through kwargs reach the underlying library when supported.
+- Missing `data_location` raises only when the dataset cannot sensibly operate without it.
+
+Prefer tests that create realistic tiny data in `tmp_path` over tests that depend on repository data fixtures. Keep the assertions tied to the public Hyrax behavior: constructor, `__len__`, and `get_<field>` methods.
+
+Run the targeted dataset tests first. Run broader tests only when the change touches shared dataset loading, config parsing, data request handling, or collation behavior.


### PR DESCRIPTION
Skill to write dataset classes in hyrax.

There's several one-shot implementations of nested pandas dataset created by the various AIs in branches. All were on "medium" effort:
Codex GPT 5.5: [mtauraso/test-dataset-skill-codex-gpt-5-5](https://github.com/lincc-frameworks/hyrax/compare/mtauraso/test-dataset-skill...mtauraso/test-dataset-skill-codex-gpt-5-5) [Reasonable]
Codex GPT 5.4: [mtauraso/test-dataset-skill-codex-gpt-5-4](https://github.com/lincc-frameworks/hyrax/compare/mtauraso/test-dataset-skill...mtauraso/test-dataset-skill-codex-gpt-5-4) [Reasonable]
Codex GPT 5.4-mini: [mtauraso/test-dataset-skill-codex-gpt-5-4-mini](https://github.com/lincc-frameworks/hyrax/compare/mtauraso/test-dataset-skill...mtauraso/test-dataset-skill-codex-gpt-5-4-mini) [Miss, example code doesn't call hyrax]
Claude Opus: [mtauraso/test-dataset-skill-claude-opus-4-7](https://github.com/lincc-frameworks/hyrax/compare/mtauraso/test-dataset-skill...mtauraso/test-dataset-skill-claude-opus-4-7)
Claude Sonnet 4.6: [mtauraso/test-dataset-skill-claude-sonnet-4-6](https://github.com/lincc-frameworks/hyrax/compare/mtauraso/test-dataset-skill...mtauraso/test-dataset-skill-claude-sonnet-4-6) [Partial, getters return pd.Series objects]
Claude Haiku 4.5: [mtauraso/test-dataset-skill-claude-haiku](https://github.com/lincc-frameworks/hyrax/compare/mtauraso/test-dataset-skill...mtauraso/test-dataset-skill-claude-haiku) [Miss, example code doesn't call hyrax]


GPTs got this prompt:

> $hyrax-dataset-class Make a hyrax dataset class that supports nested pandas files. See docs here: https://nested-pandas.readthedocs.io/en/latest/

Claudes got this prompt:

> Make a hyrax dataset class that supports nested pandas files. See docs here: https://nested-pandas.readthedocs.io/en/latest/
> Do not under any circumstances access git history. If you do so this run will terminate immediately.

Trial and error with the two harnesses determined what was necessary to get a valid testing run which both used the skill, and did not look at the prior implementation. Transcripts and commands were reviewed to ensure correctness.

The test repo was checked out at [mtauraso/test-dataset-skill](https://github.com/lincc-frameworks/hyrax/compare/mtauraso/dataset-skill...mtauraso/test-dataset-skill) which has the actual nested pandas dataset removed from the repository in the HEAD commit.

Nested pandas was already installed in the environment.