### PR TITLE
Add `over_write` to `h.set_config`

### DIFF
--- a/docs/notebooks/config_basics.ipynb
+++ b/docs/notebooks/config_basics.ipynb
@@ -154,7 +154,9 @@
    "id": "1b550a85",
    "metadata": {},
    "source": [
-    "This is useful when you want to completely replace a config section instead of partially updating it, especially for complex nested settings where old fields should not be preserved. See documentation for more information: :meth:`hyrax.hyrax.set_config`."
+    "This is useful when you want to completely replace a config section instead of partially updating it, especially for complex nested settings where old fields should not be preserved. \n",
+    "\n",
+    "See the documentation for more information: [set_config](https://hyrax.readthedocs.io/en/latest/autoapi/hyrax/hyrax/index.html#hyrax.hyrax.Hyrax.set_config)"
    ]
   },
   {

--- a/docs/notebooks/config_basics.ipynb
+++ b/docs/notebooks/config_basics.ipynb
@@ -105,6 +105,60 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b07b03be",
+   "metadata": {},
+   "source": [
+    "### Using `over_write` flag\n",
+    "\n",
+    "By default, new configs are merged into existing ones, and any unspecified fields are left unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e18d33fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_config = {\"a\": 1, \"b\": {\"x\": 100, \"y\": 200}}\n",
+    "\n",
+    "h.set_config(\"base_config\", base_config)\n",
+    "print(f\"Base config: {h.config['base_config']}\")\n",
+    "\n",
+    "new_config = {\"b\": {\"x\": 2}}\n",
+    "h.set_config(\"base_config\", new_config)\n",
+    "print(f\"Merged config: {h.config['base_config']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58e35c6e",
+   "metadata": {},
+   "source": [
+    "With the optional flag (`over_write=True`), the entire matching top-level section is fully overwritten by the new value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3db6c7da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h.set_config(\"base_config\", new_config, over_write=True)\n",
+    "print(f\"Overwritten config: {h.config['base_config']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b550a85",
+   "metadata": {},
+   "source": [
+    "This is useful when you want to completely replace a config section instead of partially updating it, especially for complex nested settings where old fields should not be preserved. See documentation for more information: :meth:`hyrax.hyrax.set_config`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c382d1f7",
    "metadata": {},
    "source": [
@@ -186,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -231,6 +231,7 @@ class ConfigManager:
     def _render_config(
         user_specific_config: TOMLDocument = None,
         hyrax_default_config: TOMLDocument = None,
+        over_write: bool = False,
     ):
         user_specific_config = user_specific_config if user_specific_config is not None else TOMLDocument()
         hyrax_default_config = hyrax_default_config if hyrax_default_config is not None else TOMLDocument()
@@ -249,7 +250,9 @@ class ConfigManager:
         )
 
         # 3) merge the user config on top of the overall defaults
-        config = ConfigManager.merge_configs(overall_default_config, user_specific_config)
+        config = ConfigManager.merge_configs(
+            overall_default_config, user_specific_config, over_write=over_write
+        )
 
         ConfigManager._resolve_config_paths(config)
         if not config["general"]["dev_mode"]:
@@ -257,7 +260,7 @@ class ConfigManager:
 
         return config
 
-    def set_config(self, key: str, value: Any):
+    def set_config(self, key: str, value: Any, over_write: bool = False):
         """Set a config value at runtime. This modifies the in-memory config object.
         Once the configuration is updated, the entire config is re-rendered to
         ensure that any requested external library default configs are incorporated.
@@ -271,6 +274,12 @@ class ConfigManager:
 
         value : Any
             The value to set the key to.
+
+        over_write : bool, optional
+            Whether to allow overwriting existing keys in the config.
+            If True, this method will overwrite the highest level existing values in the config.
+            If False, this method will merge the new setting into the existing ones.
+            By default False.
         """
         keys = parse_dotted_key(key)
 
@@ -303,7 +312,7 @@ class ConfigManager:
             d = d[k]
         d[keys[-1]] = value
 
-        self.config = self._render_config(self.config, self.original_config)
+        self.config = self._render_config(self.config, self.original_config, over_write=over_write)
         self.original_config = copy.deepcopy(self.config)
 
     @staticmethod
@@ -455,7 +464,7 @@ class ConfigManager:
         return ConfigManager.merge_configs(hyrax_defaults, external_defaults)
 
     @staticmethod
-    def merge_configs(base_config: dict, overriding_config: dict) -> dict:
+    def merge_configs(base_config: dict, overriding_config: dict, over_write: bool = False) -> dict:
         """Merge two config dictionaries with the overriding_config values overriding
         the base_config values.
 
@@ -467,6 +476,11 @@ class ConfigManager:
         overriding_config : dict
             The new configuration values that will override the values in base_config.
 
+        over_write : bool, optional
+            If True, the overriding_config values will overwrite the base_config values.
+            If False, the overriding_config values will be merged with the base_config values.
+            By default False.
+
         Returns
         -------
         dict
@@ -475,7 +489,12 @@ class ConfigManager:
 
         final_config = base_config.copy()
         for k, v in overriding_config.items():
-            if k in final_config and isinstance(final_config[k], dict) and isinstance(v, dict):
+            if (
+                not over_write
+                and k in final_config
+                and isinstance(final_config[k], dict)
+                and isinstance(v, dict)
+            ):
                 final_config[k] = ConfigManager.merge_configs(base_config[k], v)
             else:
                 final_config[k] = v

--- a/src/hyrax/config_utils.py
+++ b/src/hyrax/config_utils.py
@@ -260,7 +260,7 @@ class ConfigManager:
 
         return config
 
-    def set_config(self, key: str, value: Any, over_write: bool = False):
+    def _set_config(self, key: str, value: Any, over_write: bool = False):
         """Set a config value at runtime. This modifies the in-memory config object.
         Once the configuration is updated, the entire config is re-rendered to
         ensure that any requested external library default configs are incorporated.

--- a/src/hyrax/hyrax.py
+++ b/src/hyrax/hyrax.py
@@ -97,7 +97,7 @@ class Hyrax:
 
         self.logger.debug(f"Runtime Config read from: {ConfigManager.resolve_runtime_config(config_file)}")
 
-    def set_config(self, key: str, value):
+    def set_config(self, key: str, value, over_write: bool = False):
         """
         Set a config value at runtime. This modifies the in-memory config object.
         Once the configuration is updated, the entire config is re-rendered to
@@ -114,8 +114,14 @@ class Hyrax:
 
         value : Any
             The value to set the key to.
+
+        over_write : bool, optional
+            Whether to allow overwriting existing keys in the config.
+            If True, this method overwrites the entire matching top-level config section with the new value.
+            If False, this method will merge the new setting into the existing ones.
+            By default False.
         """
-        self.config_manager.set_config(key, value)  # type: ignore[arg-type]
+        self.config_manager.set_config(key, value, over_write=over_write)  # type: ignore[arg-type]
         self.config = self.config_manager.config
 
     def _initialize_log_handlers(self):

--- a/src/hyrax/hyrax.py
+++ b/src/hyrax/hyrax.py
@@ -119,6 +119,7 @@ class Hyrax:
             Whether to allow overwriting existing keys in the config.
             If True, this method overwrites the entire matching top-level config section with the new value.
             If False, this method will merge the new setting into the existing ones.
+            Cannot be used with a value of True if the key does not already exist in the config.
             By default False.
         """
         self.config_manager._set_config(key, value, over_write=over_write)  # type: ignore[arg-type]

--- a/src/hyrax/hyrax.py
+++ b/src/hyrax/hyrax.py
@@ -121,7 +121,7 @@ class Hyrax:
             If False, this method will merge the new setting into the existing ones.
             By default False.
         """
-        self.config_manager.set_config(key, value, over_write=over_write)  # type: ignore[arg-type]
+        self.config_manager._set_config(key, value, over_write=over_write)  # type: ignore[arg-type]
         self.config = self.config_manager.config
 
     def _initialize_log_handlers(self):

--- a/tests/hyrax/test_config_migrations.py
+++ b/tests/hyrax/test_config_migrations.py
@@ -265,7 +265,7 @@ def test_set_config_deprecated_key_warns(tmp_path):
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        cm.set_config("model_inputs", {"train": {"data": "test"}})
+        cm._set_config("model_inputs", {"train": {"data": "test"}})
 
     assert any(
         issubclass(w.category, DeprecationWarning)
@@ -292,6 +292,6 @@ def test_set_config_current_key_no_warn(tmp_path):
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        cm.set_config("data_request", {"train": {"data": "test"}})
+        cm._set_config("data_request", {"train": {"data": "test"}})
 
     assert not any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/tests/hyrax/test_config_utils.py
+++ b/tests/hyrax/test_config_utils.py
@@ -418,11 +418,11 @@ def test_set_config_simple():
     )
 
     # Test setting a simple value
-    config_manager.set_config("general.dev_mode", False)
+    config_manager._set_config("general.dev_mode", False)
     assert config_manager.config["general"]["dev_mode"] is False
 
     # Test setting a nested value
-    config_manager.set_config("train.model.layers", 5)
+    config_manager._set_config("train.model.layers", 5)
     assert config_manager.config["train"]["model"]["layers"] == 5
 
 
@@ -443,16 +443,16 @@ def test_set_config_quoted_key():
     assert config_manager.config["my.custom.optimizer.Adam"]["lr"] == 0.01
 
     # Test setting a value in a quoted table using single quotes
-    config_manager.set_config("'my.custom.optimizer.Adam'.lr", 0.001)
+    config_manager._set_config("'my.custom.optimizer.Adam'.lr", 0.001)
     assert config_manager.config["my.custom.optimizer.Adam"]["lr"] == 0.001
 
     # Test setting a value in a quoted table using double quotes
     assert config_manager.config["my.custom.optimizer.SGD"]["momentum"] == 0.9
-    config_manager.set_config('"my.custom.optimizer.SGD".momentum', 0.95)
+    config_manager._set_config('"my.custom.optimizer.SGD".momentum', 0.95)
     assert config_manager.config["my.custom.optimizer.SGD"]["momentum"] == 0.95
 
     # Test setting a new key in a quoted table
-    config_manager.set_config("'my.custom.optimizer.Adam'.beta2", 0.999)
+    config_manager._set_config("'my.custom.optimizer.Adam'.beta2", 0.999)
     assert config_manager.config["my.custom.optimizer.Adam"]["beta2"] == 0.999
 
 
@@ -469,9 +469,9 @@ def test_set_config_overwrite():
     )
 
     data_request = {"train": {"data": "some_data"}}
-    config_manager.set_config("general.data_request", data_request)
+    config_manager._set_config("general.data_request", data_request)
     assert config_manager.config["general"]["data_request"] == data_request
 
     new_data_request = {"test": {"data": "new_data"}}
-    config_manager.set_config("general.data_request", new_data_request, over_write=True)
+    config_manager._set_config("general.data_request", new_data_request, over_write=True)
     assert config_manager.config["general"]["data_request"] == new_data_request

--- a/tests/hyrax/test_config_utils.py
+++ b/tests/hyrax/test_config_utils.py
@@ -454,3 +454,24 @@ def test_set_config_quoted_key():
     # Test setting a new key in a quoted table
     config_manager.set_config("'my.custom.optimizer.Adam'.beta2", 0.999)
     assert config_manager.config["my.custom.optimizer.Adam"]["beta2"] == 0.999
+
+
+def test_set_config_overwrite():
+    """Test that set_config works with the over_write parameter."""
+    this_file_dir = os.path.dirname(os.path.abspath(__file__))
+    config_manager = ConfigManager(
+        runtime_config_filepath=os.path.abspath(
+            os.path.join(this_file_dir, "./test_data/test_user_config.toml")
+        ),
+        default_config_filepath=os.path.abspath(
+            os.path.join(this_file_dir, "./test_data/test_default_config.toml")
+        ),
+    )
+
+    data_request = {"train": {"data": "some_data"}}
+    config_manager.set_config("general.data_request", data_request)
+    assert config_manager.config["general"]["data_request"] == data_request
+
+    new_data_request = {"test": {"data": "new_data"}}
+    config_manager.set_config("general.data_request", new_data_request, over_write=True)
+    assert config_manager.config["general"]["data_request"] == new_data_request

--- a/tests/hyrax/test_config_validation_warnings.py
+++ b/tests/hyrax/test_config_validation_warnings.py
@@ -27,7 +27,7 @@ def test_set_config_warns_on_invalid_data_request(caplog):
     }
 
     with caplog.at_level(logging.WARNING):
-        cm.set_config("data_request", invalid_dict)
+        cm._set_config("data_request", invalid_dict)
 
     # Should log a warning
     assert "Configuration for 'data_request' failed Pydantic validation" in caplog.text
@@ -56,7 +56,7 @@ def test_set_config_no_warning_on_valid_data_request(caplog):
     }
 
     with caplog.at_level(logging.WARNING):
-        cm.set_config("data_request", valid_dict)
+        cm._set_config("data_request", valid_dict)
 
     # Should not log a warning about validation failure
     assert "failed Pydantic validation" not in caplog.text
@@ -200,7 +200,7 @@ def test_completely_invalid_structure_still_warns(caplog):
     invalid_data = {"random_key": "random_value", "nested": {"deeply": {"invalid": 123}}}
 
     with caplog.at_level(logging.WARNING):
-        cm.set_config("data_request", invalid_data)
+        cm._set_config("data_request", invalid_data)
 
     # Should log a warning
     assert "Configuration for 'data_request' failed Pydantic validation" in caplog.text

--- a/tests/hyrax/test_data_request_config.py
+++ b/tests/hyrax/test_data_request_config.py
@@ -159,7 +159,7 @@ def test_config_manager_set_config_accepts_data_request_definition():
         }
     )
 
-    cm.set_config("data_request", definition)
+    cm._set_config("data_request", definition)
 
     rendered = cm.config["data_request"]
     assert rendered["train"]["data"]["dataset_class"] == "HyraxRandomDataset"
@@ -183,7 +183,7 @@ def test_config_manager_set_config_with_valid_dict():
         }
     }
 
-    cm.set_config("data_request", valid_dict)
+    cm._set_config("data_request", valid_dict)
 
     rendered = cm.config["data_request"]
     assert rendered["train"]["data"]["dataset_class"] == "HyraxRandomDataset"
@@ -206,7 +206,7 @@ def test_config_manager_set_config_with_invalid_data_accepts_as_is():
     }
 
     # Should not raise - validation error is logged as warning but data is accepted
-    cm.set_config("data_request", invalid_dict)
+    cm._set_config("data_request", invalid_dict)
 
     # Invalid data is stored as-is without validation/coercion
     rendered = cm.config["data_request"]
@@ -230,7 +230,7 @@ def test_config_manager_set_config_coerces_typed_dataset_config():
         }
     }
 
-    cm.set_config("data_request", valid_dict)
+    cm._set_config("data_request", valid_dict)
 
     rendered = cm.config["data_request"]
     assert rendered["train"]["data"]["dataset_class"] == "HyraxCifarDataset"
@@ -255,7 +255,7 @@ def test_config_manager_set_config_with_partial_validity():
     }
 
     # Should not raise - validation error is logged as warning but data is accepted
-    cm.set_config("data_request", partially_valid)
+    cm._set_config("data_request", partially_valid)
 
     # Since validation fails, data is stored as-is
     rendered = cm.config["data_request"]
@@ -998,7 +998,7 @@ def test_issue_817_single_named_source_no_extra_data_nesting():
             }
         }
     }
-    cm.set_config("data_request", data_request)
+    cm._set_config("data_request", data_request)
 
     train_cfg = cm.config["data_request"]["train"]
 

--- a/tests/hyrax/test_verb_data_request_validation.py
+++ b/tests/hyrax/test_verb_data_request_validation.py
@@ -19,7 +19,7 @@ from hyrax.verbs.verb_registry import Verb
 def _make_config(data_request: dict) -> dict:
     """Return a minimal config dict with the given data_request."""
     cm = ConfigManager()
-    cm.set_config("data_request", data_request)
+    cm._set_config("data_request", data_request)
     return cm.config
 
 
@@ -243,7 +243,7 @@ def test_data_request_missing_required_group_raises():
     """Missing required group in data_request also raises RuntimeError."""
     cm = ConfigManager()
     cm.config.pop("data_request", None)
-    cm.set_config(
+    cm._set_config(
         "data_request",
         {
             "infer": {


### PR DESCRIPTION
## Change Description
Closes #821 

## Solution Description
Adding `over_write=False` to `set_config()` to support overwriting the highest level existing values provided. Already update the docstring to address the change. I will add some tests to test the new parameter.

Currently I kept the workflow logic the same as before but added this new parameter to all the function gets called along the path. `merge_configs` will skip recursive calls when it was set to True, so directly setting the value to what is given.


## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
