### PR TITLE
Clean up copilot env setup.

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -96,6 +96,3 @@ jobs:
         run: |
           python --version
           python -c "import hyrax; print('hyrax imported from:', hyrax.__file__)"
-
-      - name: Run tests
-        run: python -m pytest -m "not slow"


### PR DESCRIPTION
This last line takes a long time and copilot doesn't cache the container between requests, so it just slows it down.