### PR TITLE
Cache and pre-resolve LSST deep_coadd refs; extend mock butler with query support

### DIFF
--- a/src/hyrax/datasets/lsst_dataset.py
+++ b/src/hyrax/datasets/lsst_dataset.py
@@ -75,6 +75,9 @@ class LSSTDataset(HyraxDataset, HyraxImageDataset, Dataset):
 
         self.set_function_transform()
         self.set_crop_transform()
+        self._deep_coadd_refs = {}
+        if self._butler_config is not None:
+            self._build_deep_coadd_ref_cache()
 
     def _butler_available(self):
         try:
@@ -288,9 +291,36 @@ class LSSTDataset(HyraxDataset, HyraxImageDataset, Dataset):
         This function only returns the single principle tract and patch in the case of overlap.
         """
         radec = self._parse_sphere_point(row)
-        skymap = self._get_butler_thread_safe().get("skyMap", {"skymap": self._butler_config["skymap"]})
+        skymap = self._get_skymap(self._butler_config["skymap"])
         tract_info = skymap.findTract(radec)
         return (tract_info, tract_info.findPatch(radec))
+
+    @functools.lru_cache(maxsize=4)  # noqa: B019
+    def _get_skymap(self, skymap_name):
+        """Fetch and cache the immutable skymap object by name."""
+        return self._get_butler_thread_safe().get("skyMap", {"skymap": skymap_name})
+
+    def _build_deep_coadd_ref_cache(self):
+        """Bulk-resolve deep_coadd refs for catalog tracts/patches and configured bands."""
+        butler = self._get_butler_thread_safe()
+        needed_tract_patches = set()
+        for row in self.catalog:
+            tract_info, patch_info = self._get_tract_patch(row)
+            needed_tract_patches.add((tract_info.getId(), patch_info.sequential_index))
+
+        for band in LSSTDataset.BANDS:
+            data_id = {"skymap": self.config["data_set"]["skymap"], "band": band}
+            refs = list(
+                butler.query_datasets(
+                    "deep_coadd",
+                    data_id=data_id,
+                    collections=self._butler_config["collections"],
+                )
+            )
+            for ref in refs:
+                key = (ref.dataId["tract"], ref.dataId["patch"], ref.dataId["band"])
+                if (key[0], key[1]) in needed_tract_patches:
+                    self._deep_coadd_refs[key] = ref
 
     # super basic patch caching
     @functools.lru_cache(maxsize=128)  # noqa: B019
@@ -303,20 +333,11 @@ class LSSTDataset(HyraxDataset, HyraxImageDataset, Dataset):
         Uses functools.lru_cache for basic in-memory caching.
         """
         data = []
-
-        # Get the patch images we need
         for band in LSSTDataset.BANDS:
-            # Set up the data dict
-            butler_dict = {
-                "tract": tract_index,
-                "patch": patch_index,
-                "skymap": self.config["data_set"]["skymap"],
-                "band": band,
-            }
-
-            # pull from butler
-            image = self._get_butler_thread_safe().get("deep_coadd", butler_dict)
+            ref = self._deep_coadd_refs[(tract_index, patch_index, band)]
+            image = self._get_butler_thread_safe().get(ref)
             data.append(image.getImage())
+
         return data
 
     def _fetch_single_cutout(self, row):

--- a/tests/hyrax/mocks/lsst_butler_mocks.py
+++ b/tests/hyrax/mocks/lsst_butler_mocks.py
@@ -505,6 +505,34 @@ class MockButler:
         else:
             self.band_request_count[band] += 1
 
+    def query_datasets(self, dataset_type, data_id=None, collections=None, find_first=True):
+        """Return mock resolved refs matching query_datasets signature."""
+        if dataset_type != "deep_coadd":
+            return []
+        data_id = {} if data_id is None else dict(data_id)
+        tract = data_id.get("tract")
+        patch = data_id.get("patch")
+        band = data_id.get("band", "g")
+        skymap = data_id.get("skymap", "mock")
+
+        if tract is not None and patch is not None:
+            return [MockDatasetRef(dataset_type, data_id)]
+
+        refs = []
+        for tract_patch in MockSkyMap.ids:
+            refs.append(
+                MockDatasetRef(
+                    dataset_type,
+                    {
+                        "tract": tract_patch["tract_id"],
+                        "patch": 42,
+                        "band": band,
+                        "skymap": skymap,
+                    },
+                )
+            )
+        return refs
+
     def get(self, dataset_type, data_id=None):
         """Retrieve mock data product.
 
@@ -515,6 +543,9 @@ class MockButler:
         Returns:
             Mock object depending on dataset_type
         """
+        if isinstance(dataset_type, MockDatasetRef):
+            data_id = dataset_type.dataId
+            dataset_type = dataset_type.datasetType
         data_id = {} if data_id is None else data_id
 
         if dataset_type == "skyMap":
@@ -543,6 +574,14 @@ class MockButler:
 
         else:
             raise ValueError(f"Unsupported dataset_type: {dataset_type}")
+
+
+class MockDatasetRef:
+    """Minimal mock DatasetRef with dataset type and data ID."""
+
+    def __init__(self, dataset_type, data_id):
+        self.datasetType = dataset_type
+        self.dataId = dict(data_id)
 
 
 # Mock geometry module that contains the classes


### PR DESCRIPTION
### Motivation

- Reduce repeated Butler lookups and improve multithreaded behavior by pre-resolving and caching deep_coadd references and skymap objects for catalog tracts/patches and configured bands.

### Description

- Initialize an internal cache `self._deep_coadd_refs` and call `_build_deep_coadd_ref_cache()` when a Butler configuration is present in `LSSTDataset`.
- Add `_build_deep_coadd_ref_cache()` to bulk-query the butler for `deep_coadd` dataset references per band and store them keyed by `(tract, patch, band)` for later retrieval.
- Replace ad-hoc skymap retrieval in `_get_tract_patch()` with a cached `_get_skymap()` helper decorated with `functools.lru_cache` to avoid repeated lookups.
- Update `_request_patch()` to use the pre-resolved `MockDatasetRef`/butler refs via `self._deep_coadd_refs[(tract_index, patch_index, band)]` and call the butler with the ref instead of constructing dict-based IDs.
- Extend test mocks in `tests/hyrax/mocks/lsst_butler_mocks.py` by adding `MockButler.query_datasets()`, a minimal `MockDatasetRef` class, and making `MockButler.get()` accept `MockDatasetRef` instances so the tests can simulate `query_datasets` + `get(ref)` behavior.

### Testing

- Ran unit tests under `tests/hyrax` with `pytest` to exercise the LSST dataset and mock butler paths, and the test suite passed.
- Executed the modified mock interactions by invoking `MockButler.query_datasets()` and `MockButler.get()` in tests to verify resolving and fetching `deep_coadd` exposures, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15dcb5bb188331a37bbf81d1c9c4a9)