### PR TITLE
Remove metadata interface

### DIFF
--- a/GETITEM_REFACTOR_PLAN.md
+++ b/GETITEM_REFACTOR_PLAN.md
@@ -1,0 +1,389 @@
+# Plan: HyraxDataset __getitem__ Refactor
+
+## Context
+
+The current dataset interface has DataProvider reaching into datasets via `get_*` method discovery, managing augmentation RNG, and calling individual getters per field. This creates a tangled relationship where DataProvider does too much and datasets are passive method bags.
+
+This refactor:
+1. Gives `HyraxDataset` a default `__getitem__` that calls `get_*` methods internally
+2. Makes DataProvider delegate to `dataset[idx]` for all data fetching (golden path)
+3. Moves augmentation RNG into the dataset (torch-based, epoch-varying)
+4. Removes the deprecated metadata/metadata_table system entirely
+5. Rewrites the visualize verb to use normal field access
+
+**Simplicity bar**: Someone implementing just `__getitem__` + `__len__` on a HyraxDataset subclass should have it "just work" with no other requirements.
+
+**Key constraints**:
+- Join secondaries MUST have a `get_<join_field>` method (pure __getitem__ datasets cannot be join secondaries)
+- Custom `__getitem__` + `augment` config → RuntimeError (augmentation only works with default __getitem__)
+- DataCache is refactored to per-dataset (not replaced), living on HyraxDataset instance
+
+---
+
+## Step 1: Remove Metadata System — DONE
+
+Remove with no backwards compatibility.
+
+### `src/hyrax/datasets/dataset_registry.py`
+- Remove `metadata_table` parameter from `HyraxDataset.__init__`
+- Remove `self._metadata_table` storage
+- Remove the auto-generated `get_*` methods from metadata table columns (lines 92-103)
+- Remove `metadata_fields()` method
+- Remove `metadata()` method
+- Remove `numpy.ma` import inside metadata()
+
+### `src/hyrax/datasets/data_provider.py`
+- Remove `self.all_metadata_fields` from `__init__`
+- Remove metadata field collection in `prepare_datasets()` (lines 797-803)
+- Remove `metadata()` method (lines 1200-1272)
+- Remove `metadata_fields()` method (lines 1274-1312)
+- Remove `_translate_metadata_indices()` method (lines 1314-1339)
+
+### `src/hyrax/datasets/random/hyrax_random_dataset.py`
+- Remove metadata table construction in `HyraxRandomDatasetBase.__init__` (the `Table(meta)` creation and the `metadata_fields` config usage)
+- Change `super().__init__(config, metadata_table, "object_id")` → `super().__init__(config)`
+- Remove `from astropy.table import Table` import
+
+### `src/hyrax/datasets/inference_dataset.py`
+- Remove `metadata_fields()` override (lines 227-236)
+- Remove `metadata()` override (lines 238-274)
+
+### `src/hyrax/datasets/kafka_stream_dataset.py`
+- Change `super().__init__(config, metadata_table=None)` → `super().__init__(config)`
+
+### `src/hyrax/datasets/lsst_dataset.py`
+- Change `super().__init__(config, self.catalog, self.oid_column_name)` → `super().__init__(config)`
+- Add explicit `get_object_id(self, idx)` — previously auto-generated from metadata table
+
+### `src/hyrax/datasets/fits_image_dataset.py`
+- Remove `_prepare_metadata()` call from `__init__`, change super to `super().__init__(config)`
+- Note: catalog metadata fields (ira, idec, SNR) are no longer auto-exposed as `get_*` methods
+
+### `src/hyrax/datasets/hsc_dataset.py`
+- Change `super().__init__(config, data_location)` → `super().__init__(config, data_location=data_location)` (was passing data_location positionally where metadata_table used to be)
+
+### Config / tests
+- Remove `metadata_fields` key from `[data_set.HyraxRandomDataset]` in `hyrax_default_config.toml`
+- Update/remove tests that exercise metadata methods
+
+---
+
+## Step 2: Add Default `__getitem__` to HyraxDataset
+
+### `src/hyrax/datasets/dataset_registry.py` — HyraxDataset.__init__
+
+After storing `self._config`, discover and cache methods:
+
+```python
+self._field_getters: dict[str, Callable] = {}
+self._augment_getters: dict[str, Callable] = {}
+
+for name in dir(self):
+    if name.startswith("get_") and callable(getattr(self, name, None)):
+        self._field_getters[name[4:]] = getattr(self, name)
+    elif name.startswith("augment_") and name != "augment_cache_key" and callable(getattr(self, name, None)):
+        self._augment_getters[name[8:]] = getattr(self, name)
+
+self.requested_fields: tuple[str, ...] = ()
+self._epoch: int = 0
+self._augment_enabled: bool = False  # Set by DataProvider
+```
+
+### `src/hyrax/datasets/dataset_registry.py` — HyraxDataset.__getitem__
+
+```python
+def __getitem__(self, idx: int) -> dict[str, Any]:
+    fields = self.requested_fields or tuple(self._field_getters.keys())
+
+    # Check base cache
+    cached = self._data_cache.try_fetch_base(idx)
+    if cached is not None and not self._augment_enabled:
+        return cached
+
+    # Fetch base data (from cache or getters)
+    if cached is not None:
+        base_data = cached
+    else:
+        base_data = {field: self._field_getters[field](idx) for field in fields}
+        self._data_cache.insert_base(idx, base_data)
+
+    if not self._augment_enabled:
+        return base_data
+
+    # Generate per-call RNG seed: same for all fields, varies by epoch
+    import torch
+    rng_seed = np.int64(hash((torch.initial_seed(), self._epoch, idx)) % (2**63 - 1))
+
+    # Check augment cache
+    aug_key = self.augment_cache_key(idx, rng_seed)
+    if aug_key is not None:
+        aug_cached = self._data_cache.try_fetch_augmented(aug_key)
+        if aug_cached is not None:
+            return aug_cached
+
+    # Apply augmentation
+    result = {}
+    for field, value in base_data.items():
+        augment_fn = self._augment_getters.get(field)
+        if augment_fn is not None:
+            if isinstance(value, np.ndarray):
+                value = value.copy()
+                value.flags.writeable = False
+            result[field] = augment_fn(value, idx, rng_seed)
+        else:
+            result[field] = value
+
+    if aug_key is not None:
+        self._data_cache.insert_augmented(aug_key, result)
+
+    return result
+```
+
+### `src/hyrax/datasets/dataset_registry.py` — on_epoch_start update
+
+```python
+def on_epoch_start(self, verb: str):
+    self._epoch += 1
+```
+
+### Data cache integration
+
+Each dataset instance owns its own `DataCache` (see Step 7 for the refactor of `data_cache.py`). Created in `HyraxDataset.__init__`:
+
+```python
+from hyrax.datasets.data_cache import DataCache
+self._data_cache = DataCache(use_cache=config["data_set"]["use_cache"])
+```
+
+---
+
+## Step 3: Simplify DataProvider
+
+### Key files to read first
+- `src/hyrax/datasets/data_provider.py` — the whole file, focus on `prepare_datasets()`, `resolve_data()`, `__init__`
+- `src/hyrax/trace.py` — understand `instrument_dataprovider` and `instrument_dataset_getter`
+
+### `prepare_datasets()` changes
+
+After instantiating each dataset:
+
+1. **Field discovery**: If no `fields` in config:
+   - If dataset has `_field_getters` (getter-mode): use those keys
+   - Else (custom `__getitem__`): call `dataset[0]` and use the returned dict's keys
+
+2. **Set `dataset.requested_fields`**: Set it to the tuple of resolved field names.
+
+3. **Augmentation setup**: If `augment` config is truthy:
+   - If dataset has overridden `__getitem__` (custom mode): raise RuntimeError
+   - Otherwise: set `dataset._augment_enabled = True`, validate augment methods exist
+
+4. **Collation discovery**: Unchanged — `collate_<field>` and `collate` methods still discovered
+
+5. **Remove `self.dataset_getters`** — no longer needed for the data path
+
+6. **Keep join_field validation**: If `join_field` configured, verify `get_<join_field>` exists on dataset. Raise RuntimeError if not.
+
+### `_build_join_indices()` changes
+
+Access getters via `dataset._field_getters[join_field]` instead of `self.dataset_getters`.
+
+### `resolve_data()` simplification
+
+```python
+def resolve_data(self, idx: int) -> dict:
+    result = {}
+
+    # Pre-fetch primary object ID for joins
+    if self._join_maps:
+        primary = self.prepped_datasets[self.primary_dataset]
+        object_id_str = str(primary._field_getters[self.primary_dataset_id_field_name](idx))
+    else:
+        object_id_str = None
+
+    for friendly_name, fields in self.requested_fields.items():
+        dataset = self.prepped_datasets[friendly_name]
+
+        # Join mapping
+        if friendly_name in self._join_maps:
+            real_idx = self._join_maps[friendly_name].get(object_id_str)
+            if real_idx is None:
+                result[friendly_name] = None
+                continue
+        else:
+            real_idx = idx
+
+        # Delegate to dataset — cache + augmentation handled there
+        raw = dataset[real_idx]
+        result[friendly_name] = {field: raw[field] for field in fields}
+
+    # Extract object_id
+    if self.primary_dataset:
+        primary_data = result.get(self.primary_dataset, {})
+        if primary_data and self.primary_dataset_id_field_name in primary_data:
+            object_id = primary_data[self.primary_dataset_id_field_name]
+        elif object_id_str is not None:
+            object_id = object_id_str
+        else:
+            primary = self.prepped_datasets[self.primary_dataset]
+            object_id = str(primary[idx][self.primary_dataset_id_field_name])
+        result["object_id"] = str(object_id)
+
+    return result
+```
+
+### `get_object_id()` and `ids()` changes
+
+```python
+def get_object_id(self, idx: int) -> str:
+    primary = self.prepped_datasets[self.primary_dataset]
+    getter = primary._field_getters.get(self.primary_dataset_id_field_name)
+    if getter:
+        return str(getter(idx))
+    return str(primary[idx][self.primary_dataset_id_field_name])
+```
+
+### `fields()` method update
+
+Return from `self.requested_fields` dict plus any additional discovered fields from `dataset._field_getters`.
+
+### `_setup_trace()` changes
+
+Skip per-field getter instrumentation. Instrument `dataset.__getitem__` as a single trace point per dataset. Collation tracing unchanged.
+
+### Remove from DataProvider
+- `self.dataset_getters`
+- `self.all_metadata_fields`
+- `self.augment_getters`, `self.augment_enabled`
+- `self._augment_rng`, `self._epoch_rng`, `self._current_epoch`
+- `_augment_rng_seed()`, `_apply_augmentation()`
+- `metadata()`, `metadata_fields()`, `_translate_metadata_indices()`
+- `self.data_cache` — DataCache now lives per-dataset on the HyraxDataset instance
+
+### `on_epoch_start()` simplification
+
+```python
+def on_epoch_start(self, verb: str):
+    for dataset in self.prepped_datasets.values():
+        dataset.on_epoch_start(verb)
+```
+
+---
+
+## Step 4: Clean Up Existing Datasets
+
+### Key files to read
+- `src/hyrax/datasets/random/hyrax_random_dataset.py`
+- `src/hyrax/datasets/hyrax_csv_dataset.py`
+- `src/hyrax/datasets/inference_dataset.py`
+- `src/hyrax/datasets/fits_image_dataset.py`
+- `src/hyrax/datasets/lsst_dataset.py`
+
+### Changes
+- `HyraxRandomDataset`: Remove `__getitem__`, remove `Dataset` from bases
+- `HyraxCSVDataset`: Remove dummy `__getitem__`
+- `InferenceDataset`: Remove `Dataset` from bases, update `__getitem__` to return field dict
+- `FitsImageDataset` / `LsstDataset`: Check for `__getitem__`/`Dataset` base, remove if present
+
+---
+
+## Step 5: Rewrite Visualize Verb — DONE
+
+### Key files to read
+- `src/hyrax/verbs/visualize.py` — full file
+- How `setup_dataset()` in `src/hyrax/pytorch_ignite.py` creates DataProviders
+
+### Pattern replacement
+
+`metadata_fields()` → `data_provider.fields()` (returns available field names per dataset)
+
+`metadata(indices, fields)` → iterate indices, call `data_provider[idx]`, extract fields:
+```python
+def _batch_fetch_fields(self, indices, fields):
+    import numpy as np
+    result = {field: [] for field in fields}
+    for idx in indices:
+        sample = self.metadata_provider[idx]
+        primary_name = self.metadata_provider.primary_dataset
+        data = sample.get(primary_name, {})
+        for field in fields:
+            result[field].append(data.get(field))
+    return {field: np.array(values) for field, values in result.items()}
+```
+
+### Specific changes
+- Replace `self.metadata_provider.metadata_fields()` with DataProvider field discovery
+- Replace `self.metadata_provider.metadata(indices, fields)` with batch fetch pattern
+- data_request config for visualize must include needed fields in `fields` list
+
+---
+
+## Step 6: Mode Detection and Error Handling
+
+In `DataProvider.prepare_datasets()`, detect custom __getitem__:
+
+```python
+has_custom_getitem = type(dataset_instance).__getitem__ is not HyraxDataset.__getitem__
+```
+
+Conditions to check:
+- Custom `__getitem__` + `augment` config → RuntimeError
+- Join secondary without `get_<join_field>` → RuntimeError
+- Custom `__getitem__` with no `fields` in config and no `get_*` methods → call `dataset[0]` for field discovery
+
+---
+
+## Step 7: Refactor `DataCache` to Per-Dataset
+
+### Key file: `src/hyrax/datasets/data_cache.py`
+
+Currently `DataCache.__init__` takes `(config, datasets: dict[str, HyraxDataset], augment_active: dict[str, bool])` — manages caches for multiple datasets keyed by friendly name.
+
+### Changes
+- Constructor becomes `DataCache(use_cache: bool)` — one instance per dataset
+- Remove `datasets` and `augment_active` constructor args
+- Remove friendly-name keying from `_base_cache` and `_augment_cache` — each is now just `dict[int, dict]` and `dict[Any, dict]`
+- Split `try_fetch` into `try_fetch_base(idx)` and `try_fetch_augmented(key)`
+- `insert_base(idx, data)` and `insert_augmented(key, data)` — no friendly_name param
+- Keep size tracking and logging
+
+---
+
+## Step 8: Tests
+
+### Update existing tests
+- Remove all metadata-related test assertions
+- Update DataProvider tests to verify new `dataset[idx]` → dict flow
+- Update HyraxRandomDataset tests (no `__getitem__`, no metadata table)
+
+### New tests
+- Pure `__getitem__` dataset works with DataProvider
+- Getter-mode dataset works through default `__getitem__`
+- Augmentation through default `__getitem__` (seed consistency, epoch variation)
+- Custom `__getitem__` + `augment` config raises RuntimeError
+- Join secondary without getter raises RuntimeError
+- Field discovery from `dataset[0]`
+- Cache hit/miss through default `__getitem__`
+- `requested_fields` set correctly
+
+---
+
+## Open Considerations
+
+1. **`pull_up_primary_dataset_methods`**: Already excludes `_`-prefixed methods, so `_field_getters`, `_data_cache` etc. are safe.
+
+2. **InferenceDataset `__getitem__`**: Currently returns torch tensors. Must change to dict. Breaks direct `InferenceDataset[idx]` usage outside DataProvider.
+
+3. **Streaming data provider**: `StreamingDataProvider` has its own flow. Not affected.
+
+4. **Trace system**: Per-field getter instrumentation goes away. Single `__getitem__` trace point per dataset, or accept reduced granularity.
+
+---
+
+## Verification
+
+1. `ruff check src/ tests/ && ruff format src/ tests/`
+2. `python -m pytest -m "not slow"` — full fast test suite
+3. `pre-commit run --all-files`
+4. Manual: pure `__getitem__` dataset works with DataProvider
+5. Manual: `HyraxRandomDataset` works through default `__getitem__`
+6. Verify augmentation seed consistency across fields, variation across epochs

--- a/src/hyrax/datasets/data_provider.py
+++ b/src/hyrax/datasets/data_provider.py
@@ -520,7 +520,6 @@ class DataProvider(CollationMixin):
 
         self.prepped_datasets = {}  # will be friendly name -> dataset instance
         self.dataset_getters = {}  # will be friendly name -> dict(field_name->getter func) all fields
-        self.all_metadata_fields = {}
         self.requested_fields = {}  # will be friendly name -> tuple(field_names) but only requested fields
 
         # This dictionary maintains a mapping of friendly name to callable collate
@@ -792,15 +791,6 @@ class DataProvider(CollationMixin):
                     f"No `get_*` methods were found in the class: {dataset_class}. "
                     "This is likely an error in the dataset class definition."
                 )
-
-            # Get all the dataset's metadata fields and store them in
-            # `self.all_metadata_fields` dictionary. Modify the name to be
-            # <metadata_field_name>_<friendly_name>, i.e. "RA_cifar" or "photoz_hsc".
-            if dataset_instance._metadata_table:
-                columns = [f"{col}_{friendly_name}" for col in dataset_instance._metadata_table.colnames]
-                self.all_metadata_fields[friendly_name] = columns
-            else:
-                self.all_metadata_fields[friendly_name] = []
 
             # If this dataset is marked as the primary dataset, store that
             # information for later use.
@@ -1190,153 +1180,6 @@ class DataProvider(CollationMixin):
             tensorboardx_logger.log_duration_ts(f"{prefix}/cache_hit_s", start_time)
 
         return result
-
-    # ^ If we move toward supporting get_<metadata_column_name> methods in datasets,
-    # ^ we should be able to remove most or all of this method and the metadata_fields method.
-    # ^ This is really here to support the visualization code, and if we convert that
-    # ^ to using get_<metadata_column_name> methods, we can remove this.
-    # ^ See: https://github.com/lincc-frameworks/hyrax/issues/418
-
-    def metadata(self, idxs=None, fields=None) -> np.ndarray:
-        """Fetch the requested metadata fields for the given indices.
-
-        Example:
-
-        .. code-block:: python
-
-            # Fetch the metadata_1 and metadata_2 fields from the dataset with the
-            # friendly name "random_1".
-
-            metadata = data_provider.metadata(
-                idxs=[0, 1, 2],
-                fields=["metadata_1_random_1", "metadata_2_random_1"]
-            )
-
-        Parameters
-        ----------
-        idxs : list of int, optional
-            A list of indices for which to fetch metadata. If None, no metadata
-            will be returned.
-        fields : list of str, optional
-            A list of metadata fields to fetch. If None, no metadata will be
-            returned.
-
-        Returns
-        -------
-        np.ndarray
-            A structured NumPy array containing the requested metadata fields.
-            The dtype names of the array will be the metadata field names, modified
-            to include the friendly name of the dataset they come from. For example,
-            if the "RA" field comes from a dataset with the friendly name "cifar",
-            the returned field name will be "RA_cifar".
-        """
-
-        if idxs is None:
-            idxs = []
-
-        if fields is None:
-            fields = []
-
-        # Create an empty structured array to hold the merged metadata
-        returned_metadata = np.empty(0, dtype=[])
-
-        # For each dataset:
-        # 1) Find the requested metadata fields that come from it
-        # 2) Strip the friendly name from the metadata field name
-        # 3) Call the dataset's `metadata` method with indices and metadata fields.
-        for friendly_name, dataset in self.prepped_datasets.items():
-            metadata_fields_to_fetch = [
-                field[: -len(f"_{friendly_name}")] for field in fields if field.endswith(f"_{friendly_name}")
-            ]
-
-            if metadata_fields_to_fetch:
-                # Translate indices for joined datasets; unmatched items are
-                # omitted from the secondary's metadata result.
-                effective_idxs, _mask = self._translate_metadata_indices(idxs, friendly_name)
-                if not effective_idxs and idxs:
-                    # All requested indices were unmatched in this joined
-                    # secondary — skip it entirely.
-                    continue
-                this_metadata = dataset.metadata(effective_idxs, metadata_fields_to_fetch)
-                # Append the friendly name to the columns
-                this_metadata.dtype.names = [f"{name}_{friendly_name}" for name in this_metadata.dtype.names]
-
-                # merge this_metadata into the returned_metadata structured array
-                if returned_metadata.size == 0:
-                    returned_metadata = this_metadata
-                else:
-                    returned_metadata = np.lib.recfunctions.merge_arrays(
-                        (returned_metadata, this_metadata), flatten=True
-                    )
-
-        return returned_metadata
-
-    def metadata_fields(self, friendly_name=None) -> list[str]:
-        """Returns a list of metadata fields that are available across all prepared
-        datasets.
-
-        The field names will be modified to include the friendly name of the
-        dataset they come from. For example, if the "RA" field comes from a dataset
-        with the friendly name "cifar", the returned field name will be "RA_cifar".
-
-        NOTE: If a specific dataset friendly_name is provided, only the metadata
-        fields for that dataset will be returned, and the field names will not
-        include the friendly name suffix.
-
-        Parameters
-        ----------
-        friendly_name : str, optional
-            If provided, only the metadata fields for the specified friendly name
-            will be returned. If not provided, metadata fields from all datasets
-            will be returned.
-
-        Returns
-        -------
-        list[str]
-            The column names of the metadata table passed. Empty list if no metadata
-            was provided during construction of the DataProvider.
-        """
-        all_fields = []
-        if friendly_name:
-            return [
-                field.replace(f"_{friendly_name}", "")
-                for field in self.all_metadata_fields.get(friendly_name, [])
-            ]
-
-        for _, v in self.all_metadata_fields.items():
-            all_fields.extend(v)
-
-        # Always include the `object_id` field
-        all_fields.append("object_id")
-
-        return all_fields
-
-    def _translate_metadata_indices(self, idxs, friendly_name):
-        """Translate primary indices to real dataset indices for metadata.
-
-        For joined secondaries, looks up the matching secondary index via the
-        join map.  Indices with no match in the secondary are omitted (the
-        caller receives fewer rows than requested for that secondary).
-
-        Returns a tuple ``(translated_idxs, mask)`` where *mask* is a boolean
-        list of the same length as *idxs* indicating which positions had a
-        valid match.  Non-joined datasets always return a full-True mask.
-        """
-        if friendly_name not in self._join_maps:
-            return idxs, [True] * len(idxs)
-
-        translated = []
-        mask = []
-        primary_id_getter = self.dataset_getters[self.primary_dataset][self.primary_dataset_id_field_name]
-        for pi in idxs:
-            key = str(primary_id_getter(pi))
-            secondary_idx = self._join_maps[friendly_name].get(key)
-            if secondary_idx is not None:
-                translated.append(secondary_idx)
-                mask.append(True)
-            else:
-                mask.append(False)
-        return translated, mask
 
     def _primary_or_first_dataset(self):
         """Returns the primary dataset instance if it exists, otherwise returns

--- a/src/hyrax/datasets/dataset_registry.py
+++ b/src/hyrax/datasets/dataset_registry.py
@@ -1,11 +1,9 @@
 # ruff: noqa: D102, B027
 import logging
 from collections.abc import Callable
-from types import MethodType
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 
 from hyrax.plugin_utils import get_or_load_class, update_registry
 
@@ -29,18 +27,11 @@ class HyraxDataset:
                 # Your len function goes here
                 pass
 
-    Optional interfaces:
-
-    ``metadata`` -> Subclasses may pass an astropy table of metadata to ``__init__`` in the
-    superclass. This table of metadata will be available through the ``metadata_fields`` and
-    ``metadata`` functions.  If desired, a subclass may override these functions directly
-    rather than using the astropy Table interface.
-
     Further documentation is in the :doc:`/pre_executed/external_dataset_class` example notebook.
 
     """
 
-    def __init__(self, config: dict, metadata_table=None, object_id_column_name=None):
+    def __init__(self, config: dict):
         """
         .. py:method:: __init__
 
@@ -57,50 +48,13 @@ class HyraxDataset:
                     <your code>
                     super().__init__(config)
 
-        If per tensor metadata is available, it is recommended that dataset authors create an
-        astropy Table of that data, in the same order as their data and pass that `metadata_table`
-        as shown below:
-
-        .. code-block:: python
-
-            from hyrax.datasets import HyraxDataset
-            from astropy.table import Table
-
-            class MyDataset(HyraxDataset):
-                def __init__(config):
-                    <your code>
-                    metadata_table = Table(<Your catalog data goes here>)
-                    super().__init__(config, metadata_table)
-
         Parameters
         ----------
-        config : dict, Optional
+        config : dict
             The runtime configuration for hyrax
-        metadata_table : Optional[Table], optional
-            An Astropy Table with
-            1. the metadata columns desired for visualization AND
-            2. in the order your data will be enumerated.
-        object_id_column_name : Optional[str], optional
-            The name of the column containing object IDs. If None, uses the default
-            from config or creates one from the ids() method.
         """
 
         self._config = config
-        self._metadata_table = metadata_table
-
-        # Pull up all metadata fields as HyraxQL getters.
-        if self._metadata_table is not None:
-
-            def _make_getter(column):
-                def getter(self, idx, _col=column):
-                    return self._metadata_table[_col][idx]
-
-                return getter
-
-            for col in self._metadata_table.colnames:
-                method_name = f"get_{col}"
-                if not hasattr(self, method_name):
-                    setattr(self, method_name, MethodType(_make_getter(col), self))
 
     @property
     def config(self):
@@ -120,17 +74,6 @@ class HyraxDataset:
 
         # Ensure the class is in the registry so the config system can find it
         update_registry(DATASET_REGISTRY, cls.__name__, cls)
-
-    def metadata_fields(self) -> list[str]:
-        """Returns a list of metadata fields supported by this object
-
-        Returns
-        -------
-        list[str]
-            The column names of the metadata table passed. Empty string if no metadata was provided at
-            during construction of the HyraxDataset (or derived class).
-        """
-        return [] if self._metadata_table is None else list(self._metadata_table.colnames)
 
     def augment_cache_key(self, idx: int, rng_seed: np.int64) -> np.int64 | None:
         """Return a cache key for augmented data, or None to skip caching.
@@ -170,54 +113,6 @@ class HyraxDataset:
             ``"test"``, or ``"engine"``.
         """
         pass
-
-    def metadata(self, idxs: npt.ArrayLike, fields: list[str]) -> npt.ArrayLike:
-        """Returns a table representing the metadata given an array of indexes and a list of fields.
-
-        Parameters
-        ----------
-        idxs : npt.ArrayLike
-            The indexes of the relevant tensor objects
-        fields : list[str]
-            The names of the fields you would like returned. All values must be among those returned by
-            metadata_fields()
-
-        Returns
-        -------
-        npt.ArrayLike
-            A numpy record array of your metadata, with only the columns specified.
-            Roughly equivalent to: `metadata_table[idxs][fields].as_array()` where metadata_table is the
-            astropy table that the HyraxDataset (or derived class) was constructed with.
-
-        Raises
-        ------
-        RuntimeError
-            When none of the provided fields are
-        """
-        metadata_fields = self.metadata_fields()
-        for field in fields:
-            if field not in metadata_fields:
-                msg = f"Field {field} is not available for {self.__class__.__name__}."
-                logger.error(msg)
-
-        columns = [field for field in fields if field in metadata_fields]
-
-        if len(columns) == 0:
-            msg = (
-                f"None of the metadata fields passed [{fields}] are available for {self.__class__.__name__}."
-            )
-            raise RuntimeError(msg)
-
-        result = self._metadata_table[idxs][columns].as_array()
-
-        # Convert masked arrays to regular arrays with NaN for masked values
-        import numpy as np
-        import numpy.ma as ma
-
-        if ma.isMaskedArray(result):
-            result = ma.filled(result, np.nan)
-
-        return result
 
 
 def fetch_dataset_class(class_name: str) -> type[HyraxDataset]:

--- a/src/hyrax/datasets/dataset_registry.py
+++ b/src/hyrax/datasets/dataset_registry.py
@@ -1,6 +1,7 @@
 # ruff: noqa: D102, B027
 import logging
 from collections.abc import Callable
+from types import MethodType
 from typing import Any
 
 import numpy as np
@@ -31,7 +32,7 @@ class HyraxDataset:
 
     """
 
-    def __init__(self, config: dict):
+    def __init__(self, config: dict, metadata_table=None):
         """
         .. py:method:: __init__
 
@@ -52,9 +53,25 @@ class HyraxDataset:
         ----------
         config : dict
             The runtime configuration for hyrax
+        metadata_table : optional
+            An Astropy Table whose columns are auto-registered as
+            ``get_<column>`` getter methods on the instance.
         """
 
         self._config = config
+
+        if metadata_table is not None:
+
+            def _make_getter(column):
+                def getter(self, idx, _col=column):
+                    return metadata_table[_col][idx]
+
+                return getter
+
+            for col in metadata_table.colnames:
+                method_name = f"get_{col}"
+                if not hasattr(self, method_name):
+                    setattr(self, method_name, MethodType(_make_getter(col), self))
 
     @property
     def config(self):

--- a/src/hyrax/datasets/fits_image_dataset.py
+++ b/src/hyrax/datasets/fits_image_dataset.py
@@ -126,9 +126,7 @@ class FitsImageDataset(HyraxDataset, HyraxImageDataset, Dataset):
 
         # Relies on self.filters_ref and self.filter_catalog_table which are both determined
         # inside _init_from_path()
-        logger.debug("Preparing Metadata")
-        metadata = self._prepare_metadata()
-        super().__init__(config, metadata)
+        super().__init__(config)
 
         self._post_init_hook()
 

--- a/src/hyrax/datasets/fits_image_dataset.py
+++ b/src/hyrax/datasets/fits_image_dataset.py
@@ -126,7 +126,9 @@ class FitsImageDataset(HyraxDataset, HyraxImageDataset, Dataset):
 
         # Relies on self.filters_ref and self.filter_catalog_table which are both determined
         # inside _init_from_path()
-        super().__init__(config)
+        logger.debug("Preparing Metadata")
+        metadata = self._prepare_metadata()
+        super().__init__(config, metadata_table=metadata)
 
         self._post_init_hook()
 

--- a/src/hyrax/datasets/hsc_dataset.py
+++ b/src/hyrax/datasets/hsc_dataset.py
@@ -45,7 +45,7 @@ class HSCDataset(FitsImageDataset):
 
         self.filters_config = config["data_set"]["filters"] if config["data_set"]["filters"] else None
 
-        super().__init__(config, data_location)
+        super().__init__(config, data_location=data_location)
 
     def _read_filter_catalog(self, filter_catalog_path: Path | None):
         from astropy.table import Table

--- a/src/hyrax/datasets/inference_dataset.py
+++ b/src/hyrax/datasets/inference_dataset.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
-import numpy.typing as npt
 from torch.utils.data import Dataset
 
 from .dataset_registry import HyraxDataset
@@ -223,55 +222,6 @@ class InferenceDataset(HyraxDataset, Dataset):
             as input for whatever inference process created this dataset.
         """
         return self._original_dataset_config
-
-    def metadata_fields(self) -> list[str]:
-        """Get the metadata fields associted with the original dataset used to generate this one
-
-        Returns
-        -------
-        list[str]
-            List of valid field names for metadata queries
-        """
-        # We must override this and pass to the original dataset.
-        return self.original_dataset.metadata_fields()  # type: ignore[no-any-return,attr-defined]
-
-    def metadata(self, idxs: npt.ArrayLike, fields: list[str]) -> npt.ArrayLike:
-        """Get metadata associated with the data in the InferenceDataset. This metadata comes from
-        the original dataset, but is indexed according to the InferenceDataset.
-
-        Parameters
-        ----------
-        idxs : npt.ArrayLike
-            Indexes in the InferenceDataset for which metadata is desired
-        fields : list[str]
-            Metadata fields requested
-
-        Returns
-        -------
-        npt.ArrayLike
-            An array where the rows correspond to the passed list of indexes and the columns
-            correspond to the fields passed. Order is preserved- metadata[i] corresponds to idxs[i].
-        """
-
-        idxs = np.asarray(idxs)
-
-        # Get the requested IDs in the order they were requested
-        ids_requested = np.array([self.get_object_id(idx) for idx in idxs])  # type: ignore[index]
-
-        # Get all original dataset IDs
-        original_ids = np.array(list(self.original_dataset.ids()))  # type: ignore[attr-defined]
-
-        # Create mapping from original ID to original index
-        id_to_original_idx = {str(oid): i for i, oid in enumerate(original_ids)}
-
-        # Map requested IDs to original indices, preserving order
-        original_idxs = [id_to_original_idx[str(req_id)] for req_id in ids_requested]
-
-        # Get metadata from original dataset
-        original_metadata = self.original_dataset.metadata(original_idxs, fields)  # type: ignore[attr-defined,no-any-return]
-
-        # Return metadata in the same order as requested
-        return original_metadata
 
     def _load_from_batch_file(self, batch_num: int, ids=Union[int, np.ndarray]) -> np.ndarray:
         """Hands back an array of tensors given a set of IDs in a particular batch and the given

--- a/src/hyrax/datasets/kafka_stream_dataset.py
+++ b/src/hyrax/datasets/kafka_stream_dataset.py
@@ -114,7 +114,7 @@ class KafkaStreamDataset(HyraxDataset, torch.utils.data.IterableDataset):
         self._consumer = None
         self._buffered: list[dict] = []
 
-        super().__init__(config, metadata_table=None)
+        super().__init__(config)
 
     def stop(self):
         """Signal :meth:`__iter__` to flush any pending batch and stop iterating."""

--- a/src/hyrax/datasets/lsst_dataset.py
+++ b/src/hyrax/datasets/lsst_dataset.py
@@ -70,7 +70,7 @@ class LSSTDataset(HyraxDataset, HyraxImageDataset, Dataset):
             else self._detect_object_id_column_name()
         )
 
-        super().__init__(config)
+        super().__init__(config, metadata_table=self.catalog)
 
         self.set_function_transform()
         self.set_crop_transform()

--- a/src/hyrax/datasets/lsst_dataset.py
+++ b/src/hyrax/datasets/lsst_dataset.py
@@ -70,8 +70,7 @@ class LSSTDataset(HyraxDataset, HyraxImageDataset, Dataset):
             else self._detect_object_id_column_name()
         )
 
-        # TODO: Metadata from the catalog
-        super().__init__(config, self.catalog, self.oid_column_name)
+        super().__init__(config)
 
         self.set_function_transform()
         self.set_crop_transform()
@@ -185,6 +184,10 @@ class LSSTDataset(HyraxDataset, HyraxImageDataset, Dataset):
 
     def __len__(self):
         return len(self.catalog)
+
+    def get_object_id(self, idx):
+        """Get the object ID at the given index."""
+        return str(self.catalog[self.oid_column_name][idx])
 
     def get_image(self, idxs):
         """Get image cutouts for the given indices.

--- a/src/hyrax/datasets/random/hyrax_random_dataset.py
+++ b/src/hyrax/datasets/random/hyrax_random_dataset.py
@@ -1,5 +1,4 @@
 import numpy as np
-from astropy.table import Table
 from torch.utils.data import Dataset
 
 from hyrax.datasets.dataset_registry import HyraxDataset
@@ -121,17 +120,7 @@ class HyraxRandomDatasetBase:
         if self.provided_labels:
             self.labels = rng.choice(self.provided_labels, size=data_size)
 
-        meta_fields = config["data_set"]["HyraxRandomDataset"]["metadata_fields"]
-
-        meta = {"object_id": [str(id) for id in self.id_list]}
-
-        for i, field in enumerate(meta_fields):
-            meta[field] = np.array(list(range(data_size, 0, -1))) / (i + 2)
-
-        # Create a metadata_table that is used when visualizing data
-        metadata_table = Table(meta)
-
-        super().__init__(config, metadata_table, "object_id")
+        super().__init__(config)
 
         self.data_location = data_location
 

--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -321,9 +321,6 @@ seed = 42
 # If set to false, no labels will be included with the data.
 provided_labels = [0, 1, 2]
 
-# List of metadata field names. These will be populated with dummy data.
-metadata_fields = ["meta_field_1", "meta_field_2"]
-
 # Set this to a positive integer to randomly replace some values with an "invalid" value.
 number_invalid_values = 0
 

--- a/src/hyrax/verbs/visualize.py
+++ b/src/hyrax/verbs/visualize.py
@@ -131,9 +131,9 @@ class Visualize(Verb):
         # NOTE: this presently depends on only a single required
         # split, but here is here the data provider logic would be
         # extended if needed.
-        self.metadata_provider = datasets[Visualize.REQUIRED_DATA_GROUPS[0]]
+        self.data_provider = datasets[Visualize.REQUIRED_DATA_GROUPS[0]]
 
-        available_fields = self.metadata_provider.metadata_fields()
+        available_fields = self._available_fields()
         for field in fields.copy():
             if field not in available_fields:
                 logger.warning(f"Field {field} is unavailable for this dataset")
@@ -165,8 +165,7 @@ class Visualize(Verb):
 
         if self.color_column:
             try:
-                # Check if column exists
-                available_fields = self.metadata_provider.metadata_fields()
+                available_fields = self._available_fields()
                 if self.color_column not in available_fields:
                     logger.warning(
                         f"Column '{self.color_column}' not found in dataset."
@@ -174,14 +173,10 @@ class Visualize(Verb):
                     )
                     self.color_column = False
                 else:
-                    # Get all indices for the dataset
                     all_indices = list(range(len(self.umap_results)))
-
-                    # Extract metadata for the specified column
-                    metadata = self.metadata_provider.metadata(all_indices, [self.color_column])
-                    self.color_values = metadata[self.color_column]
+                    fetched = self._fetch_fields(all_indices, [self.color_column])
+                    self.color_values = fetched[self.color_column]
                     logger.info(f"Successfully loaded color values from column '{self.color_column}'")
-                    import numpy as np
 
                     logger.debug(
                         f"Color values range: {np.nanmin(self.color_values)} "
@@ -550,15 +545,14 @@ class Visualize(Verb):
         # these are the object_id, x, and y columns
         columns = [self.points_id, self.points.T[0], self.points.T[1]]  # type: ignore[list-item]
 
-        # These are the rest of the columns, pulled from metadata
         try:
-            metadata = self.metadata_provider.metadata(self.points_idx, self.data_fields)
+            fetched = self._fetch_fields(self.points_idx, self.data_fields)
         except Exception as e:
-            # Leave in this try/catch beause some notebook implementations dont
+            # Leave in this try/catch because some notebook implementations dont
             # allow us to return an exception to the console.
             return Table(([str(e)]), ["message"])
 
-        columns += [metadata[field] for field in self.data_fields]  # type: ignore[call-overload,misc,index]
+        columns += [fetched[field] for field in self.data_fields]
         return Table(tuple(columns), key_dims, value_dims)
 
     @staticmethod
@@ -595,6 +589,40 @@ class Visualize(Verb):
 
         return (xmin, xmax, ymin, ymax)
 
+    def _available_fields(self) -> set[str]:
+        """Return the set of all field names available across all datasets in the data provider."""
+        all_fields = set()
+        for field_list in self.data_provider.fields().values():
+            all_fields.update(field_list)
+        all_fields.add("object_id")
+        return all_fields
+
+    def _fetch_fields(self, indices, fields) -> dict[str, list]:
+        """Fetch specific fields for a list of indices from the data provider.
+
+        Parameters
+        ----------
+        indices : list of int
+            Indices to fetch data for.
+        fields : list of str
+            Field names to extract.
+
+        Returns
+        -------
+        dict[str, np.ndarray]
+            Mapping of field name to array of values across all indices.
+        """
+        import numpy as np
+
+        result = {field: [] for field in fields}
+        primary_name = self.data_provider.primary_dataset
+        for idx in indices:
+            sample = self.data_provider[idx]
+            data = sample.get(primary_name, {})
+            for field in fields:
+                result[field].append(data.get(field))
+        return {field: np.array(values) for field, values in result.items()}
+
     def get_selected_df(self):
         r"""
         Retrieve a pandas DataFrame containing the currently selected points and their associated metadata.
@@ -612,8 +640,8 @@ class Visualize(Verb):
 
         df = pd.DataFrame(self.points, columns=["x", "y"])
         df[self.object_id_column_name] = self.points_id
-        meta = self.metadata_provider.metadata(self.points_idx, self.data_fields)
-        meta_df = pd.DataFrame(meta, columns=self.data_fields)
+        fetched = self._fetch_fields(self.points_idx, self.data_fields)
+        meta_df = pd.DataFrame(fetched)
 
         cols = [self.object_id_column_name, "x", "y"] + self.data_fields
         result = pd.concat([df.reset_index(drop=True), meta_df.reset_index(drop=True)], axis=1)
@@ -682,16 +710,10 @@ class Visualize(Verb):
             # Get sampled ids correspoinding to the idxs
             sampled_ids = [id_map[idx] for idx in chosen_idx]
 
-            # Get metadata - this is in the same order as chosen_idx
-            meta = self.metadata_provider.metadata(
-                chosen_idx, [self.object_id_column_name, self.filename_column_name]
-            )
+            fetched = self._fetch_fields(chosen_idx, [self.filename_column_name])
+            raw_filenames = fetched[self.filename_column_name]
 
-            # Extract metadata directly
-            # DEBUG: object_ids = meta[self.object_id_column_name]
-            raw_filenames = meta[self.filename_column_name]
-
-            filenames = [f.decode("utf-8") for f in raw_filenames]
+            filenames = [str(f) for f in raw_filenames]
 
         else:
             sampled_ids = []

--- a/tests/hyrax/test_data_provider.py
+++ b/tests/hyrax/test_data_provider.py
@@ -54,19 +54,13 @@ def test_data_provider(data_provider):
 
     # There should be 2 dataset_getters dicts with subdicts of different sizes
     assert len(dp.dataset_getters) == 2
-    assert len(dp.dataset_getters["random_0"]) == 5
-    assert len(dp.dataset_getters["random_1"]) == 5
+    assert len(dp.dataset_getters["random_0"]) == 3
+    assert len(dp.dataset_getters["random_1"]) == 3
 
     data_request = dp.data_request
     for friendly_name in data_request:
         for field in data_request[friendly_name]["fields"]:
             assert field in dp.dataset_getters[friendly_name]
-
-    data_request = dp.data_request
-    for friendly_name in data_request:
-        assert len(dp.all_metadata_fields[friendly_name]) == 3
-        for metadata_field in dp.all_metadata_fields[friendly_name]:
-            assert friendly_name in metadata_field
 
 
 def test_validate_request_no_dataset_class(multimodal_config, caplog):
@@ -338,49 +332,6 @@ def test_primary_dataset(multimodal_config):
     assert primary_dataset.data_location == "./in_memory_1"
 
 
-def test_metadata_fields(data_provider):
-    """Test that the calling metadata_fields returns the expected
-    fields with the expected structure."""
-
-    dp = data_provider
-    dp.prepare_datasets()
-
-    all_metadata_fields = dp.all_metadata_fields
-
-    assert "random_0" in all_metadata_fields
-    assert "random_1" in all_metadata_fields
-
-    assert len(all_metadata_fields["random_0"]) == 3
-    assert len(all_metadata_fields["random_1"]) == 3
-
-    all_fields = dp.metadata_fields()
-
-    assert isinstance(all_fields, list)
-    assert "object_id" in all_fields
-
-    expected_metadata_fields = ["object_id", "meta_field_1", "meta_field_2"]
-    for field in expected_metadata_fields:
-        assert field + "_random_0" in all_fields
-        assert field + "_random_1" in all_fields
-
-
-def test_metadata_fields_with_friendly_name(data_provider):
-    """Test that the calling metadata_fields returns the expected
-    fields with the expected structure."""
-
-    dp = data_provider
-    dp.prepare_datasets()
-
-    all_fields = dp.metadata_fields("random_0")
-
-    assert isinstance(all_fields, list)
-    assert "object_id" in all_fields
-
-    expected_metadata_fields = ["object_id", "meta_field_1", "meta_field_2"]
-    for field in expected_metadata_fields:
-        assert field in all_fields
-
-
 def test_sample_data():
     """Test that sample_data returns a dictionary with the expected
     structure.
@@ -533,48 +484,6 @@ def test_data_provider_ids(data_provider):
     assert len(ids) == len(random_0_ids)
     assert all(i == j for i, j in zip(ids, random_0_ids))
     assert all(i != j for i, j in zip(ids, random_1_ids))
-
-
-def test_data_provider_returns_metadata(data_provider):
-    """Basic test to ensure that metadata() returns the expected value.
-    The metadata returned from DataProvider are the metadata of the primary
-    dataset or, if no primary dataset is specified, the first dataset.
-
-    We have specified random_0 to be the primary dataset in conftest.
-    """
-
-    dp = data_provider
-    dp.prepare_datasets()
-
-    metadata = dp.metadata()
-    assert len(metadata) == 0
-
-    metadata = dp.metadata(idxs=None, fields=[])
-    assert len(metadata) == 0
-
-    metadata = dp.metadata(idxs=[], fields=[])
-    assert len(metadata) == 0
-
-    metadata = dp.metadata(idxs=[], fields=["meta_field_1_random_0"])
-    assert len(metadata) == 0
-    assert len(metadata.dtype.names) == 1
-    assert "meta_field_1_random_0" in metadata.dtype.names[0]
-
-    metadata = dp.metadata(idxs=[5], fields=["meta_field_1_random_0"])
-    assert len(metadata) == 1
-    assert len(metadata.dtype.names) == 1
-    assert "meta_field_1_random_0" in metadata.dtype.names[0]
-
-    metadata = dp.metadata(idxs=[5, 97], fields=["meta_field_1_random_0"])
-    assert len(metadata) == 2
-    assert len(metadata.dtype.names) == 1
-    assert "meta_field_1_random_0" in metadata.dtype.names
-
-    metadata = dp.metadata(idxs=[5, 97], fields=["meta_field_1_random_0", "meta_field_2_random_1"])
-    assert len(metadata) == 2
-    assert len(metadata.dtype.names) == 2
-    assert "meta_field_1_random_0" in metadata.dtype.names
-    assert "meta_field_2_random_1" in metadata.dtype.names
 
 
 def test_primary_id_field_fetched_when_not_in_fields():

--- a/tests/hyrax/test_downloaded_lsst_dataset.py
+++ b/tests/hyrax/test_downloaded_lsst_dataset.py
@@ -81,8 +81,8 @@ def test_init(mock_lsst_environment, lsst_config, tmp_path):  # noqa: F811
         # Verify it has the right number of bands (channels)
         assert cutout.shape[0] == 3  # g, r, i bands
 
-        # Verify it is the first thing in the sample catalog
-        assert dataset.metadata([0], ["object_id"])[0][0] == 1001
+        # Verify the first object has the expected ID
+        assert dataset.get_object_id(0) == "1001"
 
 
 def test_download(mock_lsst_environment, lsst_config, tmp_path):  # noqa: F811
@@ -487,7 +487,7 @@ def test_catalog_ordering(mock_lsst_environment, lsst_config, tmp_path, sample_c
 
     # Get data for the first object
     first_object_id = catalog_data["object_id"][0]
-    assert first_object_id == dataset.metadata([0], ["object_id"])[0][0]
+    assert str(first_object_id) == dataset.get_object_id(0)
 
     # Truncate the sample catalog
     catalog_truncation_index = int(mocks.SAMPLE_CATALOG_LENGTH / 2.0)
@@ -526,7 +526,4 @@ def test_catalog_ordering(mock_lsst_environment, lsst_config, tmp_path, sample_c
         # index indexes the filtered dataset
         # value is the index in the original dataset
         assert (filtered_dataset[index]["data"]["image"] == dataset[value]["data"]["image"]).all()
-        assert (
-            filtered_dataset.metadata([index], ["object_id"])[0][0]
-            == dataset.metadata([value], ["object_id"])[0][0]
-        )
+        assert filtered_dataset.get_object_id(index) == dataset.get_object_id(value)

--- a/tests/hyrax/test_fits_image_dataset.py
+++ b/tests/hyrax/test_fits_image_dataset.py
@@ -59,10 +59,10 @@ def test_prepare(test_hyrax_small_dataset_hscstars):
         for d in a:
             assert d["data"]["image"].shape == Size([1, 20, 20])
 
-        # Selected columns in the original catalog exist
-        assert "ira" in a.metadata_fields("data")
-        assert "idec" in a.metadata_fields("data")
-        assert "SNR" in a.metadata_fields("data")
+        # Core fields are available
+        available_fields = a.fields()["data"]
+        assert "image" in available_fields
+        assert "object_id" in available_fields
 
         # IDs are correct and in the correct order
         assert a.ids() == [

--- a/tests/hyrax/test_fits_image_dataset.py
+++ b/tests/hyrax/test_fits_image_dataset.py
@@ -59,10 +59,11 @@ def test_prepare(test_hyrax_small_dataset_hscstars):
         for d in a:
             assert d["data"]["image"].shape == Size([1, 20, 20])
 
-        # Core fields are available
+        # Catalog columns are available as fields via auto-generated getters
         available_fields = a.fields()["data"]
-        assert "image" in available_fields
-        assert "object_id" in available_fields
+        assert "ira" in available_fields
+        assert "idec" in available_fields
+        assert "SNR" in available_fields
 
         # IDs are correct and in the correct order
         assert a.ids() == [

--- a/tests/hyrax/test_inference_dataset.py
+++ b/tests/hyrax/test_inference_dataset.py
@@ -79,73 +79,28 @@ def get_data_by_dataset_type(dataset, idxs):
 
 
 def test_order(inference_dataset):
-    """Test ID and metadata ordering consistency between original and inference datasets.
+    """Test ID ordering consistency between original and inference datasets.
 
     Test cases:
     1) ids() should not be in the same order between original and result
     2) ids() should contain all the IDs in the original dataset
-    3) the ids() from ids, and the ids delivered via metadata from the inference dataset should match exactly
-    4) The value from inference_dataset[idx] should match a value from data_set
-    4a) The matching values should have the same ID in both inference_dataset and data_set according to .ids()
-    4b) The matching values should have the same ID in both inference_dataset and data_set according to
-        respective metadata
-    5) metadata() must preserve the exact order of requested indices (critical for visualization correctness)
+    3) The value from inference_dataset[idx] should match a value from data_set
+    3a) The matching values should have the same ID in both inference_dataset and data_set according to .ids()
     """
     orig, result = inference_dataset
 
     orig_ids = orig.ids()
     result_ids = result.ids()
 
-    all_idx = list(range(20))
-    orig_meta_ids = list(orig.metadata(all_idx, ["object_id_data"])["object_id_data"])
-    result_meta_ids = list(result.metadata(all_idx, ["object_id_data"])["object_id_data"])
-
     # Check no IDs are dropped
     for id in orig_ids:
         assert id in result_ids
-        assert id in orig_meta_ids
-        assert id in result_meta_ids
 
     # Check all data is the correct data for that ID
     for result_i in range(20):
         for orig_i in range(20):
             if np.all(orig[orig_i]["data"]["image"] == result[result_i].numpy()):
-                try:
-                    assert orig_ids[orig_i] == result_ids[result_i]
-                    assert orig_meta_ids[orig_i] == result_meta_ids[result_i]
-                    assert orig_ids[orig_i] == result_meta_ids[result_i]
-                    assert orig_meta_ids[orig_i] == result_ids[result_i]
-                except Exception as e:
-                    print(f"Original ID: {orig_ids[orig_i]} (Correct b/c data matches)")
-                    print(f"Original metaID: {orig_meta_ids[orig_i]}")
-                    print(f"Result ID: {result_ids[result_i]}")
-                    print(f"Result metaID: {result_meta_ids[result_i]}")
-                    raise e
+                assert orig_ids[orig_i] == result_ids[result_i]
                 break
         else:
             assert False, "Could not find matching value for ID."  # noqa: B011
-
-    # Test explicit metadata ordering preservation with non-sequential patterns
-    test_patterns = [
-        [3, 1, 4, 0, 2],
-        [19, 5, 10, 15, 2],
-        [0, 19, 1, 18],
-    ]
-
-    for idx_pattern in test_patterns:
-        # Skip patterns that exceed dataset size
-        if max(idx_pattern) >= len(result):
-            continue
-
-        metadata_result = result.metadata(idx_pattern, ["object_id_data"])
-
-        # Get expected IDs in the exact order requested
-        expected_ids = [result.get_object_id(i) for i in idx_pattern]
-        actual_ids = [str(id) for id in metadata_result["object_id_data"]]
-
-        assert actual_ids == expected_ids, (
-            f"CRITICAL: Metadata ordering broken! For indices {idx_pattern}:\n"
-            f"Expected IDs: {expected_ids}\n"
-            f"Actual IDs:   {actual_ids}\n"
-            f"This will cause visualization labels and data to be scrambled."
-        )


### PR DESCRIPTION
Removes the Metadata interface from datasets, Includes a quick fix to the only remaining consumer (visualizev1) so it uses the `get_` interface for everything.