### PR TITLE
Remove slack notify from asv-nightly action

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -102,33 +102,3 @@ jobs:
       with:
         name: benchmark-results
         path: ${{env.WORKING_DIR}}/_results
-    - name: Notify Slack on success
-      if: success() && steps.benchmark-run.outputs.regression != 'true'
-      uses: slackapi/slack-github-action@v3
-      with:
-        webhook: ${{secrets.SLACK_WEBHOOK_URL}}
-        webhook-type: incoming-webhook
-        payload: |
-          {
-            "text": "✅ Hyrax nightly benchmarks succeeded on ${{steps.nightly-dates.outputs.today}}. View run: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-          }
-    - name: Notify Slack on benchmark regression
-      if: success() && steps.benchmark-run.outputs.regression == 'true'
-      uses: slackapi/slack-github-action@v3
-      with:
-        webhook: ${{secrets.SLACK_WEBHOOK_URL}}
-        webhook-type: incoming-webhook
-        payload: |
-          {
-            "text": "⚠️ Hyrax nightly benchmarks detected regressions on ${{steps.nightly-dates.outputs.today}}. View run: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-          }
-    - name: Notify Slack on failure
-      if: failure()
-      uses: slackapi/slack-github-action@v3
-      with:
-        webhook: ${{secrets.SLACK_WEBHOOK_URL}}
-        webhook-type: incoming-webhook
-        payload: |
-          {
-            "text": "❌ Hyrax nightly benchmarks failed on ${{steps.nightly-dates.outputs.today}}. View run: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-          }


### PR DESCRIPTION
## Change Description
The current asv-nightly workflow is failing because of a broken slack notification setup. I'm removing the slack notification section to see if that resolves the benchmark workflow failures.