### PR TITLE
Flag for distributed training

### DIFF
--- a/src/hyrax/hyrax_default_config.toml
+++ b/src/hyrax/hyrax_default_config.toml
@@ -13,9 +13,12 @@ log_level = "info"
 # Directory where data is stored.
 data_dir = "./data"
 
-#Top level directory for writing results.
+# Top level directory for writing results.
 results_dir = "./results"
 
+# Use multiple GPUs if available
+# Set to `false` by default for development purposes for now
+distributed = false
 
 [download]
 # Cut out width in arcseconds.

--- a/src/hyrax/verbs/train.py
+++ b/src/hyrax/verbs/train.py
@@ -94,7 +94,7 @@ class Train(Verb):
         #    Case separation here guarantees that we will only ever use
         #    idist.Parallel when there are multiple GPUs.
         nproc_per_node = torch.cuda.device_count()
-        if nproc_per_node > 1:
+        if config["general"]["distributed"] and nproc_per_node > 1:
             logger.info(f"Using {nproc_per_node} processes for distributed training.")
             with idist.Parallel(backend="nccl", nproc_per_node=nproc_per_node) as parallel:
                 parallel.run(Train._training, model, dataset, config, results_dir)


### PR DESCRIPTION
Adds flag for distributed training to default config. May remove or change to default `true` in the future; implemented currently for development purposes