### PR TITLE
Publish nightly benchmark fix

### DIFF
--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -7,6 +7,7 @@ on:
   workflow_run:
     workflows: ["Run benchmarks nightly job"]
     types: [completed]
+  workflow_dispatch:
 
 jobs:
   publish-benchmarks-nightly:

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
         run_id: ${{ github.event.workflow_run.id }}
         path: benchmarks
     - name: Deploy dashboard to GitHub Pages
-      if: ${{ hashFiles('benchmarks/_html/**') != '' }}
+      if: ${{ hashFiles('benchmarks/**') != '' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
@@ -37,7 +37,7 @@ jobs:
         run_id: ${{ github.event.workflow_run.id }}
         path: benchmarks
     - name: Submit new results to "benchmarks" branch
-      if: ${{ hashFiles('benchmarks/_results/**') != '' }}
+      if: ${{ hashFiles('benchmarks/**') != '' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: benchmarks


### PR DESCRIPTION
## Change Description
Put `workflow_dispatch` trigger to the publish workflow on the main branch for independent testing. Also try fixing the conditions that determine if publish steps runs.