### PR TITLE
Introduce Hyrax's own auto_model function to remove DataParallel

### DIFF
--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -409,9 +409,8 @@ def create_engine(funcname: str, device: torch.device, model: torch.nn.Module, c
 
 
 def extract_model_method(model, method_name):
-    """Extract a method from a model, which may be wrapped in a DistributedDataParallel
-    or DataParallel object. For instance, method_name could be `train_batch` or
-    `infer_batch`.
+    """Extract a method from a model, which may be wrapped in DistributedDataParallel.
+    For instance, method_name could be `train_batch` or `infer_batch`.
 
     Parameters
     ----------

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -409,13 +409,13 @@ def create_engine(funcname: str, device: torch.device, model: torch.nn.Module, c
 
 
 def extract_model_method(model, method_name):
-    """Extract a method from a model, which may be wrapped in a DistributedDataParallel
-    or DataParallel object. For instance, method_name could be `train_batch` or
+    """Extract a method from a model, which may be wrapped in DistributedDataParallel.
+     For instance, method_name could be `train_batch` or
     `infer_batch`.
 
     Parameters
     ----------
-    model : nn.Module, DistributedDataParallel, or DataParallel
+    model : nn.Module
         The model to extract the method from
     method_name : str
         Name of the method to extract
@@ -426,7 +426,7 @@ def extract_model_method(model, method_name):
         The method extracted from the model
     """
 
-    wrapped = type(model) is DistributedDataParallel or type(model) is DataParallel
+    wrapped = type(model) is DistributedDataParallel
 
     if not hasattr(model.module if wrapped else model, method_name):
         raise RuntimeError(f"Model does not have required method: {method_name}")
@@ -459,7 +459,7 @@ def create_evaluator(
     """
     device = idist.device()
     model.eval()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     evaluator = create_engine("infer_batch", device, wrapped_model, config)
 
     @evaluator.on(Events.STARTED)
@@ -513,7 +513,7 @@ def create_validator(
     """
 
     device = idist.device()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     validator = create_engine("validate_batch", device, wrapped_model, config)
@@ -568,7 +568,7 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
     """
 
     device = idist.device()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     tester = create_engine("test_batch", device, wrapped_model, config)
@@ -646,7 +646,7 @@ def attach_best_checkpoint(
     results_directory : Path
         Directory where checkpoint files are written.
     """
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
 
     to_save = {
         "model": wrapped_model,
@@ -707,11 +707,9 @@ def create_trainer(model: torch.nn.Module, config: dict, results_directory: Path
 
     device = idist.device()
     model.train()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
 
-    # in the future, write our own auto_model function which will not use DataParallel.
-    # remove all instances of DataParallel from code at that point.
-    wrapped = type(wrapped_model) is DistributedDataParallel or type(wrapped_model) is DataParallel
+    wrapped = type(wrapped_model) is DistributedDataParallel
 
     if wrapped:
         # bind the train_batch function to the DDP model

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -409,13 +409,13 @@ def create_engine(funcname: str, device: torch.device, model: torch.nn.Module, c
 
 
 def extract_model_method(model, method_name):
-    """Extract a method from a model, which may be wrapped in DistributedDataParallel.
-     For instance, method_name could be `train_batch` or
+    """Extract a method from a model, which may be wrapped in a DistributedDataParallel
+    or DataParallel object. For instance, method_name could be `train_batch` or
     `infer_batch`.
 
     Parameters
     ----------
-    model : nn.Module
+    model : nn.Module, DistributedDataParallel, or DataParallel
         The model to extract the method from
     method_name : str
         Name of the method to extract
@@ -426,7 +426,7 @@ def extract_model_method(model, method_name):
         The method extracted from the model
     """
 
-    wrapped = type(model) is DistributedDataParallel
+    wrapped = type(model) is DistributedDataParallel or type(model) is DataParallel
 
     if not hasattr(model.module if wrapped else model, method_name):
         raise RuntimeError(f"Model does not have required method: {method_name}")
@@ -459,7 +459,7 @@ def create_evaluator(
     """
     device = idist.device()
     model.eval()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
     evaluator = create_engine("infer_batch", device, wrapped_model, config)
 
     @evaluator.on(Events.STARTED)
@@ -513,7 +513,7 @@ def create_validator(
     """
 
     device = idist.device()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     validator = create_engine("validate_batch", device, wrapped_model, config)
@@ -568,7 +568,7 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
     """
 
     device = idist.device()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     tester = create_engine("test_batch", device, wrapped_model, config)
@@ -646,7 +646,7 @@ def attach_best_checkpoint(
     results_directory : Path
         Directory where checkpoint files are written.
     """
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
 
     to_save = {
         "model": wrapped_model,
@@ -707,9 +707,11 @@ def create_trainer(model: torch.nn.Module, config: dict, results_directory: Path
 
     device = idist.device()
     model.train()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
 
-    wrapped = type(wrapped_model) is DistributedDataParallel
+    # in the future, write our own auto_model function which will not use DataParallel.
+    # remove all instances of DataParallel from code at that point.
+    wrapped = type(wrapped_model) is DistributedDataParallel or type(wrapped_model) is DataParallel
 
     if wrapped:
         # bind the train_batch function to the DDP model

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -63,8 +63,8 @@ def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) ->
         sync_bn: if True, applies `torch convert_sync_batchnorm`_ to the model for native torch
             distributed only. Default, False. Note, if using Nvidia/Apex, batchnorm conversion should be
             applied before calling ``amp.initialize``.
-        kwargs: kwargs to model's wrapping class: `torch DistributedDataParallel`_ or `torch DataParallel`_
-            if applicable. Please, make sure to use acceptable kwargs for given backend.
+        kwargs: kwargs to model's wrapping class (`torch DistributedDataParallel`_ )if applicable.
+            Please, make sure to use acceptable kwargs for given backend.
 
     Returns:
         torch.nn.Module

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -60,10 +60,10 @@ def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) ->
 
     Args:
         model: model to adapt.
-        sync_bn: if True, applies `torch convert_sync_batchnorm`_ to the model for native torch
+        sync_bn: if True, applies `torch.nn.SyncBatchNorm.convert_sync_batchnorm`_ to the model for native torch
             distributed only. Default, False. Note, if using Nvidia/Apex, batchnorm conversion should be
             applied before calling ``amp.initialize``.
-        kwargs: kwargs to model's wrapping class (`torch DistributedDataParallel`_ )if applicable.
+        kwargs: kwargs to model's wrapping class (`torch.nn.DistributedDataParallel`_ )if applicable.
             Please, make sure to use acceptable kwargs for given backend.
 
     Returns:

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -53,6 +53,20 @@ def _new__getattr__(self, name: str):
 DistributedDataParallel.__getattr__ = _new__getattr__
 
 
+# Helper method to wrap a model in DistributedDataParallel if needed.
+# Uses idist.auto_model to do the wrapping, then ignore the result if it is a DataParallel instance.
+# For more info, see https://docs.pytorch.org/ignite/generated/ignite.distributed.auto.auto_model.html.
+# Arguments are identical to idist.auto_model.
+def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) -> torch.nn.Module:
+    wrapped_model = idist.auto_model(model, sync_bn=sync_bn, **kwargs)
+    if type(wrapped_model) is DataParallel:
+        logger.info(
+            'Ignore previous message "Apply torch DataParallel on model". Hyrax does not use DataParallel'
+        )
+        return model
+    return wrapped_model
+
+
 class SubsetSequentialSampler(Sampler[int]):
     r"""Samples elements sequentially from a given list of indices, without replacement.
 

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -53,6 +53,31 @@ def _new__getattr__(self, name: str):
 DistributedDataParallel.__getattr__ = _new__getattr__
 
 
+def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) -> torch.nn.Module:
+    """Helper method to wrap a model in DistributedDataParallel if needed.
+    Uses idist.auto_model to do the wrapping, then ignore the result if it is a DataParallel instance.
+    For more info, see https://docs.pytorch.org/ignite/generated/ignite.distributed.auto.auto_model.html
+
+    Args:
+        model: model to adapt.
+        sync_bn: if True, applies `torch convert_sync_batchnorm`_ to the model for native torch
+            distributed only. Default, False. Note, if using Nvidia/Apex, batchnorm conversion should be
+            applied before calling ``amp.initialize``.
+        kwargs: kwargs to model's wrapping class: `torch DistributedDataParallel`_ or `torch DataParallel`_
+            if applicable. Please, make sure to use acceptable kwargs for given backend.
+
+    Returns:
+        torch.nn.Module
+    """
+    wrapped_model = idist.auto_model(model, sync_bn=sync_bn, **kwargs)
+    if type(wrapped_model) is DataParallel:
+        logger.info(
+            'Ignore previous message "Apply torch DataParallel on model". Hyrax does not use DataParallel'
+        )
+        return model
+    return wrapped_model
+
+
 class SubsetSequentialSampler(Sampler[int]):
     r"""Samples elements sequentially from a given list of indices, without replacement.
 
@@ -395,13 +420,13 @@ def create_engine(funcname: str, device: torch.device, model: torch.nn.Module, c
 
 
 def extract_model_method(model, method_name):
-    """Extract a method from a model, which may be wrapped in a DistributedDataParallel
-    or DataParallel object. For instance, method_name could be `train_batch` or
+    """Extract a method from a model, which may be wrapped in DistributedDataParallel.
+     For instance, method_name could be `train_batch` or
     `infer_batch`.
 
     Parameters
     ----------
-    model : nn.Module, DistributedDataParallel, or DataParallel
+    model : nn.Module
         The model to extract the method from
     method_name : str
         Name of the method to extract
@@ -412,7 +437,7 @@ def extract_model_method(model, method_name):
         The method extracted from the model
     """
 
-    wrapped = type(model) is DistributedDataParallel or type(model) is DataParallel
+    wrapped = type(model) is DistributedDataParallel
 
     if not hasattr(model.module if wrapped else model, method_name):
         raise RuntimeError(f"Model does not have required method: {method_name}")
@@ -445,7 +470,7 @@ def create_evaluator(
     """
     device = idist.device()
     model.eval()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     evaluator = create_engine("infer_batch", device, wrapped_model, config)
 
     @evaluator.on(Events.STARTED)
@@ -499,7 +524,7 @@ def create_validator(
     """
 
     device = idist.device()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     validator = create_engine("validate_batch", device, wrapped_model, config)
@@ -554,7 +579,7 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
     """
 
     device = idist.device()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     tester = create_engine("test_batch", device, wrapped_model, config)
@@ -632,7 +657,7 @@ def attach_best_checkpoint(
     results_directory : Path
         Directory where checkpoint files are written.
     """
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
 
     to_save = {
         "model": wrapped_model,
@@ -693,11 +718,9 @@ def create_trainer(model: torch.nn.Module, config: dict, results_directory: Path
 
     device = idist.device()
     model.train()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
 
-    # in the future, write our own auto_model function which will not use DataParallel.
-    # remove all instances of DataParallel from code at that point.
-    wrapped = type(wrapped_model) is DistributedDataParallel or type(wrapped_model) is DataParallel
+    wrapped = type(wrapped_model) is DistributedDataParallel
 
     if wrapped:
         # bind the train_batch function to the DDP model

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -53,22 +53,11 @@ def _new__getattr__(self, name: str):
 DistributedDataParallel.__getattr__ = _new__getattr__
 
 
+# Helper method to wrap a model in DistributedDataParallel if needed.
+# Uses idist.auto_model to do the wrapping, then ignore the result if it is a DataParallel instance.
+# For more info, see https://docs.pytorch.org/ignite/generated/ignite.distributed.auto.auto_model.html.
+# Arguments are identical to idist.auto_model.
 def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) -> torch.nn.Module:
-    """Helper method to wrap a model in DistributedDataParallel if needed.
-    Uses idist.auto_model to do the wrapping, then ignore the result if it is a DataParallel instance.
-    For more info, see https://docs.pytorch.org/ignite/generated/ignite.distributed.auto.auto_model.html
-
-    Args:
-        model: model to adapt.
-        sync_bn: if True, applies `convert_sync_batchnorm` to the model for native torch distributed only.
-            Default, False. Note, if using Nvidia/Apex, batchnorm conversion should be
-            applied before calling ``amp.initialize``.
-        kwargs: kwargs to model's wrapping class (`DistributedDataParallel`)if applicable.
-            Please, make sure to use acceptable kwargs for given backend.
-
-    Returns:
-        torch.nn.Module
-    """
     wrapped_model = idist.auto_model(model, sync_bn=sync_bn, **kwargs)
     if type(wrapped_model) is DataParallel:
         logger.info(

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -60,8 +60,9 @@ def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) ->
 
     Args:
         model: model to adapt.
-        sync_bn: if True, applies `torch.nn.SyncBatchNorm.convert_sync_batchnorm`_ to the model for native torch
-            distributed only. Default, False. Note, if using Nvidia/Apex, batchnorm conversion should be
+        sync_bn: if True, applies `torch.nn.SyncBatchNorm.convert_sync_batchnorm`_
+            to the model for native torch distributed only.
+            Default, False. Note, if using Nvidia/Apex, batchnorm conversion should be
             applied before calling ``amp.initialize``.
         kwargs: kwargs to model's wrapping class (`torch.nn.DistributedDataParallel`_ )if applicable.
             Please, make sure to use acceptable kwargs for given backend.

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -53,20 +53,6 @@ def _new__getattr__(self, name: str):
 DistributedDataParallel.__getattr__ = _new__getattr__
 
 
-# Helper method to wrap a model in DistributedDataParallel if needed.
-# Uses idist.auto_model to do the wrapping, then ignore the result if it is a DataParallel instance.
-# For more info, see https://docs.pytorch.org/ignite/generated/ignite.distributed.auto.auto_model.html.
-# Arguments are identical to idist.auto_model.
-def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) -> torch.nn.Module:
-    wrapped_model = idist.auto_model(model, sync_bn=sync_bn, **kwargs)
-    if type(wrapped_model) is DataParallel:
-        logger.info(
-            'Ignore previous message "Apply torch DataParallel on model". Hyrax does not use DataParallel'
-        )
-        return model
-    return wrapped_model
-
-
 class SubsetSequentialSampler(Sampler[int]):
     r"""Samples elements sequentially from a given list of indices, without replacement.
 
@@ -409,13 +395,13 @@ def create_engine(funcname: str, device: torch.device, model: torch.nn.Module, c
 
 
 def extract_model_method(model, method_name):
-    """Extract a method from a model, which may be wrapped in DistributedDataParallel.
-     For instance, method_name could be `train_batch` or
+    """Extract a method from a model, which may be wrapped in a DistributedDataParallel
+    or DataParallel object. For instance, method_name could be `train_batch` or
     `infer_batch`.
 
     Parameters
     ----------
-    model : nn.Module
+    model : nn.Module, DistributedDataParallel, or DataParallel
         The model to extract the method from
     method_name : str
         Name of the method to extract
@@ -426,7 +412,7 @@ def extract_model_method(model, method_name):
         The method extracted from the model
     """
 
-    wrapped = type(model) is DistributedDataParallel
+    wrapped = type(model) is DistributedDataParallel or type(model) is DataParallel
 
     if not hasattr(model.module if wrapped else model, method_name):
         raise RuntimeError(f"Model does not have required method: {method_name}")
@@ -459,7 +445,7 @@ def create_evaluator(
     """
     device = idist.device()
     model.eval()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
     evaluator = create_engine("infer_batch", device, wrapped_model, config)
 
     @evaluator.on(Events.STARTED)
@@ -513,7 +499,7 @@ def create_validator(
     """
 
     device = idist.device()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     validator = create_engine("validate_batch", device, wrapped_model, config)
@@ -568,7 +554,7 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
     """
 
     device = idist.device()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     tester = create_engine("test_batch", device, wrapped_model, config)
@@ -646,7 +632,7 @@ def attach_best_checkpoint(
     results_directory : Path
         Directory where checkpoint files are written.
     """
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
 
     to_save = {
         "model": wrapped_model,
@@ -707,9 +693,11 @@ def create_trainer(model: torch.nn.Module, config: dict, results_directory: Path
 
     device = idist.device()
     model.train()
-    wrapped_model = _auto_model(model)
+    wrapped_model = idist.auto_model(model)
 
-    wrapped = type(wrapped_model) is DistributedDataParallel
+    # in the future, write our own auto_model function which will not use DataParallel.
+    # remove all instances of DataParallel from code at that point.
+    wrapped = type(wrapped_model) is DistributedDataParallel or type(wrapped_model) is DataParallel
 
     if wrapped:
         # bind the train_batch function to the DDP model

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -415,7 +415,7 @@ def extract_model_method(model, method_name):
 
     Parameters
     ----------
-    model : nn.Module, DistributedDataParallel, or DataParallel
+    model : nn.Module
         The model to extract the method from
     method_name : str
         Name of the method to extract

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -60,11 +60,10 @@ def _auto_model(model: torch.nn.Module, sync_bn: bool = False, **kwargs: Any) ->
 
     Args:
         model: model to adapt.
-        sync_bn: if True, applies `torch.nn.SyncBatchNorm.convert_sync_batchnorm`_
-            to the model for native torch distributed only.
+        sync_bn: if True, applies `convert_sync_batchnorm` to the model for native torch distributed only.
             Default, False. Note, if using Nvidia/Apex, batchnorm conversion should be
             applied before calling ``amp.initialize``.
-        kwargs: kwargs to model's wrapping class (`torch.nn.DistributedDataParallel`_ )if applicable.
+        kwargs: kwargs to model's wrapping class (`DistributedDataParallel`)if applicable.
             Please, make sure to use acceptable kwargs for given backend.
 
     Returns:

--- a/tests/hyrax/test_train.py
+++ b/tests/hyrax/test_train.py
@@ -389,12 +389,14 @@ def test_constant_scheduler_checkpointing(loopback_hyrax, tmp_path):
 
 def test_training_info_returned_on_model(loopback_hyrax):
     """
-    Test that scheduler works correctly when model is wrapped in DataParallel.
+    Test that scheduler works correctly when model is wrapped in DistributedDataParallel.
     This test validates the fix for PR #652 AttributeError bug.
+    This test was updated as part of PR #996. It validates the overwriting
+    of __getattr__ for DistributedDataParallel which was done in PR #974.
     """
     from unittest.mock import patch
 
-    from torch.nn.parallel import DataParallel
+    from torch.nn.parallel import DistributedDataParallel
 
     h, _ = loopback_hyrax
     gamma = 0.5
@@ -403,17 +405,18 @@ def test_training_info_returned_on_model(loopback_hyrax):
     h.config["train"]["epochs"] = 2
     initial_lr = 64
     h.config[h.config["optimizer"]["name"]]["lr"] = initial_lr
+    h.config["general"]["distributed"] = True
 
-    # Mock idist.auto_model to wrap the model in DataParallel
+    # Mock idist.auto_model to wrap the model in DistributedDataParallel
     # This simulates what happens in distributed training environments
 
     def mock_auto_model(model):
-        # Wrap the model in DataParallel to test the fix
-        return DataParallel(model)
+        # Wrap the model in DistributedDataParallel to test the fix
+        return DistributedDataParallel(model)
 
-    # Patch idist.auto_model in the pytorch_ignite module
-    with patch("hyrax.pytorch_ignite.idist.auto_model", side_effect=mock_auto_model):
-        # This should not raise AttributeError: 'DataParallel' object has no attribute 'scheduler'
+    # Patch _auto_model in the pytorch_ignite module
+    with patch("hyrax.pytorch_ignite._auto_model", side_effect=mock_auto_model):
+        # This should not raise AttributeError: 'DistributedDataParallel' object has no attribute 'scheduler'
         model = h.train()
 
     # Verify the scheduler worked correctly

--- a/tests/hyrax/test_train.py
+++ b/tests/hyrax/test_train.py
@@ -389,14 +389,12 @@ def test_constant_scheduler_checkpointing(loopback_hyrax, tmp_path):
 
 def test_training_info_returned_on_model(loopback_hyrax):
     """
-    Test that scheduler works correctly when model is wrapped in DistributedDataParallel.
+    Test that scheduler works correctly when model is wrapped in DataParallel.
     This test validates the fix for PR #652 AttributeError bug.
-    This test was updated as part of PR #996. It validates the overwriting
-    of __getattr__ for DistributedDataParallel which was done in PR #974.
     """
     from unittest.mock import patch
 
-    from torch.nn.parallel import DistributedDataParallel
+    from torch.nn.parallel import DataParallel
 
     h, _ = loopback_hyrax
     gamma = 0.5
@@ -405,18 +403,17 @@ def test_training_info_returned_on_model(loopback_hyrax):
     h.config["train"]["epochs"] = 2
     initial_lr = 64
     h.config[h.config["optimizer"]["name"]]["lr"] = initial_lr
-    h.config["general"]["distributed"] = True
 
-    # Mock idist.auto_model to wrap the model in DistributedDataParallel
+    # Mock idist.auto_model to wrap the model in DataParallel
     # This simulates what happens in distributed training environments
 
     def mock_auto_model(model):
-        # Wrap the model in DistributedDataParallel to test the fix
-        return DistributedDataParallel(model)
+        # Wrap the model in DataParallel to test the fix
+        return DataParallel(model)
 
-    # Patch _auto_model in the pytorch_ignite module
-    with patch("hyrax.pytorch_ignite._auto_model", side_effect=mock_auto_model):
-        # This should not raise AttributeError: 'DistributedDataParallel' object has no attribute 'scheduler'
+    # Patch idist.auto_model in the pytorch_ignite module
+    with patch("hyrax.pytorch_ignite.idist.auto_model", side_effect=mock_auto_model):
+        # This should not raise AttributeError: 'DataParallel' object has no attribute 'scheduler'
         model = h.train()
 
     # Verify the scheduler worked correctly


### PR DESCRIPTION
Introduce a helper function `_auto_model` to `pytorch_ignite.py` to replace `idist.auto_model` and remove `DataParallel`. In other words, models will never be wrapped in `DataParallel` anymore; they will either be unwrapped or wrapped in `DistributedDataParallel`.
