### PR TITLE
make peek sample use consistent data

### DIFF
--- a/src/hyrax/datasets/kafka_stream_dataset.py
+++ b/src/hyrax/datasets/kafka_stream_dataset.py
@@ -203,8 +203,18 @@ class KafkaStreamDataset(HyraxDataset, torch.utils.data.IterableDataset):
             msg = consumer.poll(self.poll_timeout)
             if msg is not None and msg.error() is None:
                 sample = self._decode(msg)
-                self._buffered.append(sample)
-                return sample
+
+                # check if pre_filter is defined and apply it to the sample
+                if hasattr(self, "pre_filter"):
+                    sample = self.pre_filter([sample])
+                if sample:
+                    sample = sample[0] if isinstance(sample, list) else sample
+                    self._buffered.append(sample)
+                    # check if pre_process is defined and apply it to the sample
+                    if hasattr(self, "pre_process"):
+                        sample = self.pre_process([sample])
+                    return sample[0] if isinstance(sample, list) else sample
+
         raise RuntimeError("KafkaStreamDataset.peek_sample() stopped before a message arrived.")
 
     def __iter__(self):

--- a/tests/hyrax/test_kafka_stream_dataset.py
+++ b/tests/hyrax/test_kafka_stream_dataset.py
@@ -221,6 +221,8 @@ def test_peek_sample_buffers_and_replays(monkeypatch):
     messages = [_make_message("first", [[1.0]]), _make_message("second", [[2.0]])]
     _patch_consumer(monkeypatch, dataset, messages, stop_when_exhausted=True)
 
+    print(hasattr(dataset, "pre_filter"))
+
     peeked = dataset.peek_sample()
     assert peeked["object_id"] == "first"
 
@@ -229,6 +231,45 @@ def test_peek_sample_buffers_and_replays(monkeypatch):
     assert len(batches) == 1
     # The peeked message is replayed as the first sample of the first batch.
     assert [s["object_id"] for s in batches[0]] == ["first", "second"]
+
+
+def test_peek_sample_pre_filter(monkeypatch):
+    """peek_sample respects a pre_filter hook, skipping messages that return None."""
+    dataset = _build_dataset(batch_size=5, batch_flush_timeout=0.0)
+    messages = [_make_message("first", [[1.0]]), _make_message("second", [[2.0]])]
+    _patch_consumer(monkeypatch, dataset, messages, stop_when_exhausted=True)
+
+    def _test_pre_filter(self, batch):
+        # Only allow the second message to be processed
+        good_batch = []
+        for s in batch:
+            if s["object_id"] == "second":
+                good_batch.append(s)
+        return good_batch
+
+    dataset.pre_filter = lambda sample: _test_pre_filter(dataset, sample)
+
+    peeked = dataset.peek_sample()
+    assert peeked["object_id"] == "second"
+
+
+def test_peek_sample_pre_process(monkeypatch):
+    """peek_sample respects a pre_process hook, transforming messages before returning."""
+    dataset = _build_dataset(batch_size=5, batch_flush_timeout=0.0)
+    messages = [_make_message("first", [[1.0]])]
+    _patch_consumer(monkeypatch, dataset, messages, stop_when_exhausted=True)
+
+    def _test_pre_process(self, batch):
+        # Transform the message by adding a new field
+        for s in batch:
+            s["image"] = [[2.0]]
+        return batch
+
+    dataset.pre_process = lambda sample: _test_pre_process(dataset, sample)
+
+    peeked = dataset.peek_sample()
+    assert peeked["object_id"] == "first"
+    assert peeked["image"] == [[2.0]]
 
 
 def test_extra_credentials(tmp_path):


### PR DESCRIPTION
## Change Description
in `hyrax_alerts`, we define and allow the user to define `pre_filter` and `post_filter` functions that might affect the data, but `peek_sample` (used in `hyrax_alerts.process_alerts()` to do initial runtime setup) doesn't currently touch those functions, so we should check if those functions have been defined so that `peek_sample` can maintain data consistency.

## Solution Description
check for the functions and then apply if them if available.

Note: I added the sample to `_buffered` **before** the sample is pre processed since we should assume that when it gets read again through `process_alerts` as part of the main batch process that it'll be mixed in with data in the `__iter__` that hasn't been pre processed yet.

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
