### PR TITLE
update calls to idist.auto_model to be _auto_model instead

### DIFF
--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -41,6 +41,10 @@ _LEGACY_SPLIT_KEYS = ("train_size", "validate_size", "test_size")
 _old__getattr__ = Module.__getattr__
 
 
+# There is an identical version of this function used in
+# test_train.py::test_training_info_returned_on_model.
+# If this method is ever updated, make sure to update the version
+# there too.
 def _new__getattr__(self, name: str):
     try:
         return _old__getattr__(self, name)

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -458,7 +458,7 @@ def create_evaluator(
     """
     device = idist.device()
     model.eval()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     evaluator = create_engine("infer_batch", device, wrapped_model, config)
 
     @evaluator.on(Events.STARTED)
@@ -512,7 +512,7 @@ def create_validator(
     """
 
     device = idist.device()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     validator = create_engine("validate_batch", device, wrapped_model, config)
@@ -567,7 +567,7 @@ def create_tester(model: torch.nn.Module, config: dict) -> Engine:
     """
 
     device = idist.device()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
     tensorboardx_logger = get_tensorboard_logger()
 
     tester = create_engine("test_batch", device, wrapped_model, config)
@@ -645,7 +645,7 @@ def attach_best_checkpoint(
     results_directory : Path
         Directory where checkpoint files are written.
     """
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
 
     to_save = {
         "model": wrapped_model,
@@ -706,7 +706,7 @@ def create_trainer(model: torch.nn.Module, config: dict, results_directory: Path
 
     device = idist.device()
     model.train()
-    wrapped_model = idist.auto_model(model)
+    wrapped_model = _auto_model(model)
 
     # in the future, write our own auto_model function which will not use DataParallel.
     # remove all instances of DataParallel from code at that point.

--- a/tests/hyrax/test_train.py
+++ b/tests/hyrax/test_train.py
@@ -396,7 +396,7 @@ def test_training_info_returned_on_model(loopback_hyrax):
     """
     from unittest.mock import patch
 
-    from torch.nn.parallel import DistributedDataParallel
+    from torch import nn
 
     h, _ = loopback_hyrax
     gamma = 0.5
@@ -405,14 +405,33 @@ def test_training_info_returned_on_model(loopback_hyrax):
     h.config["train"]["epochs"] = 2
     initial_lr = 64
     h.config[h.config["optimizer"]["name"]]["lr"] = initial_lr
-    h.config["general"]["distributed"] = True
+
+    _old__getattr__ = nn.Module.__getattr__
+
+    class FakeDDP(nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
+
+        # This is an identical version of the _new__getattr__ function
+        # in pytorch_ignite. It should always match that version.
+        def __getattr__(self, name):
+            try:
+                return _old__getattr__(self, name)
+            except AttributeError:
+                if hasattr(self.module, name):
+                    return getattr(self.module, name)
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     # Mock idist.auto_model to wrap the model in DistributedDataParallel
     # This simulates what happens in distributed training environments
+    # Using the real DDP class leads to issues with running the test on
+    # non-CUDA environments and ForkingPickling errors with HyraxLoopback
+    # even on CUDA environments
 
     def mock_auto_model(model):
         # Wrap the model in DistributedDataParallel to test the fix
-        return DistributedDataParallel(model)
+        return FakeDDP(model)
 
     # Patch _auto_model in the pytorch_ignite module
     with patch("hyrax.pytorch_ignite._auto_model", side_effect=mock_auto_model):


### PR DESCRIPTION
Forgot to update calls to `idist.auto_model` to use `_auto_model` instead in #996. Quick PR to fix that.