### PR TITLE
ASV plot for custom benchmark results

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -45,6 +45,15 @@ jobs:
             --no-commit
           mv ../_results ../gondor_results .
         fi
+    - name: DEBUG - Check if gondor_results exists
+      run: |
+        if [ -d "$GITHUB_WORKSPACE/benchmarks/gondor_results" ]; then
+          echo "gondor_results exists"
+          ls -la "$GITHUB_WORKSPACE/benchmarks/gondor_results"
+        else
+          echo "gondor_results not found"
+          exit 1
+        fi
     - name: Get nightly dates under comparison
       id: nightly-dates
       run: |

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -49,7 +49,9 @@ jobs:
       run: |
         if [ -d "$GITHUB_WORKSPACE/benchmarks/gondor_results" ]; then
           echo "gondor_results exists"
+          pwd
           ls -la "$GITHUB_WORKSPACE/benchmarks/gondor_results"
+          cat "$GITHUB_WORKSPACE/benchmarks/benchmarks/track_pipeline_benchmarks.py"
         else
           echo "gondor_results not found"
           exit 1

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -56,6 +56,9 @@ jobs:
           echo "gondor_results not found"
           exit 1
         fi
+    - name: DEBUG - Run track function
+      run: |
+        python track_pipeline_benchmarks.py
     - name: Get nightly dates under comparison
       id: nightly-dates
       run: |

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -45,20 +45,6 @@ jobs:
             --no-commit
           mv ../_results ../gondor_results .
         fi
-    - name: DEBUG - Check if gondor_results exists
-      run: |
-        if [ -d "$GITHUB_WORKSPACE/benchmarks/gondor_results" ]; then
-          echo "gondor_results exists"
-          pwd
-          ls -la "$GITHUB_WORKSPACE/benchmarks/gondor_results"
-          cat "$GITHUB_WORKSPACE/benchmarks/track_pipeline_benchmarks.py"
-        else
-          echo "gondor_results not found"
-          exit 1
-        fi
-    - name: DEBUG - Run track function
-      run: |
-        python track_pipeline_benchmarks.py
     - name: Get nightly dates under comparison
       id: nightly-dates
       run: |

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -51,7 +51,7 @@ jobs:
           echo "gondor_results exists"
           pwd
           ls -la "$GITHUB_WORKSPACE/benchmarks/gondor_results"
-          cat "$GITHUB_WORKSPACE/benchmarks/benchmarks/track_pipeline_benchmarks.py"
+          cat "$GITHUB_WORKSPACE/benchmarks/track_pipeline_benchmarks.py"
         else
           echo "gondor_results not found"
           exit 1

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -43,7 +43,9 @@ jobs:
           git merge origin/benchmarks \
             --allow-unrelated-histories \
             --no-commit
-          mv ../_results ../gondor_results .
+          mv ../_results .
+          # move results from self-hosted runner to current working dir
+          mv ../gondor_results .
         fi
     - name: Get nightly dates under comparison
       id: nightly-dates
@@ -64,8 +66,7 @@ jobs:
         if [ -f $HASH_FILE ]; then
           PREV_HASH=$(cat $HASH_FILE)
           set +e
-          # currently only run the benchmarks tha has `track` in their name, to avoid running time_ functions
-          asv continuous $PREV_HASH $CURRENT_HASH --verbose --bench track
+          asv continuous $PREV_HASH $CURRENT_HASH --verbose
           asv_continuous_exit_code=$?
           set -e
           case $asv_continuous_exit_code in

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -43,7 +43,7 @@ jobs:
           git merge origin/benchmarks \
             --allow-unrelated-histories \
             --no-commit
-          mv ../_results .
+          mv ../_results ../gondor_results .
         fi
     - name: Get nightly dates under comparison
       id: nightly-dates
@@ -64,7 +64,8 @@ jobs:
         if [ -f $HASH_FILE ]; then
           PREV_HASH=$(cat $HASH_FILE)
           set +e
-          asv continuous $PREV_HASH $CURRENT_HASH --verbose
+          # currently only run the benchmarks tha has `track` in their name, to avoid running time_ functions
+          asv continuous $PREV_HASH $CURRENT_HASH --verbose --bench track
           asv_continuous_exit_code=$?
           set -e
           case $asv_continuous_exit_code in

--- a/benchmarks/track_pipeline_benchmarks.py
+++ b/benchmarks/track_pipeline_benchmarks.py
@@ -2,21 +2,19 @@ import json
 import os
 from pathlib import Path
 
-"""This module is used to track the performance of the full pipeline with asv."""
-
-
 class PipelineBenchmarkTracker:
-    """Loads benchmark results once and exposes metrics for ASV."""
+    """Loads benchmark results once and return metrics for ASV."""
 
-    def __init__(self):
+    def setup_cache(self):
+        """
+        Setup for loading self-hosted benchmark results. Opens the json file and save it as payload.
+        """
+        # TODO: "gondor_results" is the directory to store results from self-hosted runner on gondor
         base_dir = Path(__file__).resolve().parent / "gondor_results"
+        # TODO: currently hard coded to tesy file loading only
         self.json_path = base_dir / "2026-07-24T22:08:39.409085+00:00.json"
 
         self.payload = None
-        self._load_results()
-
-    def _load_results(self):
-        """Load the benchmark JSON once."""
         if not self.json_path.exists():
             print(f"Benchmark results not found: {self.json_path}")
             self.payload = {}
@@ -39,11 +37,13 @@ class PipelineBenchmarkTracker:
 
 def track_test():
     """
+    Trial function, kept for testing.
     Load benchmark results from a JSON file under the ASV results directory and
     return the requested slowdown metric.
+    Should behave the same as `track_train_slowdown` above.
     """
+    # Hard-coded path
     base_dir = Path(__file__).resolve().parent / "gondor_results"
-
     json_path = base_dir / "2026-07-24T22:08:39.409085+00:00.json"
     if not json_path.exists():
         return 11111111111111
@@ -51,13 +51,11 @@ def track_test():
     with json_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
 
-    print(f"Loaded benchmark results from {json_path}: {payload}")
-    print(f"Train slowdown: {payload.get('train_slowdown')}")
     return payload.get("train_slowdown")
 
 if __name__ == "__main__":
     result = track_test()
-    print(f"Returned: {result}")
+    print(f"Returned from track_test: {result}")
 
     tracker = PipelineBenchmarkTracker()
     print(tracker.track_train_slowdown())

--- a/benchmarks/track_pipeline_benchmarks.py
+++ b/benchmarks/track_pipeline_benchmarks.py
@@ -5,6 +5,38 @@ from pathlib import Path
 """This module is used to track the performance of the full pipeline with asv."""
 
 
+class PipelineBenchmarkTracker:
+    """Loads benchmark results once and exposes metrics for ASV."""
+
+    def __init__(self):
+        base_dir = Path(__file__).resolve().parent / "gondor_results"
+        self.json_path = base_dir / "2026-07-24T22:08:39.409085+00:00.json"
+
+        self.payload = None
+        self._load_results()
+
+    def _load_results(self):
+        """Load the benchmark JSON once."""
+        if not self.json_path.exists():
+            print(f"Benchmark results not found: {self.json_path}")
+            self.payload = {}
+            return
+
+        with self.json_path.open("r", encoding="utf-8") as handle:
+            self.payload = json.load(handle)
+
+        print(f"Loaded benchmark results from {self.json_path}")
+        print(self.payload)
+
+    def track_train_slowdown(self):
+        return self.payload.get("train_slowdown")
+
+    def track_infer_slowdown(self):
+        return self.payload.get("infer_slowdown")
+
+    def track_total_slowdown(self):
+        return self.payload.get("total_slowdown")
+
 def track_test():
     """
     Load benchmark results from a JSON file under the ASV results directory and
@@ -26,3 +58,8 @@ def track_test():
 if __name__ == "__main__":
     result = track_test()
     print(f"Returned: {result}")
+
+    tracker = PipelineBenchmarkTracker()
+    print(tracker.track_train_slowdown())
+    print(tracker.track_infer_slowdown())
+    print(tracker.track_total_slowdown())

--- a/benchmarks/track_pipeline_benchmarks.py
+++ b/benchmarks/track_pipeline_benchmarks.py
@@ -19,4 +19,6 @@ def track_test():
     with json_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
 
+    print(f"Loaded benchmark results from {json_path}: {payload}")
+    print(f"Train slowdown: {payload.get('train_slowdown')}")
     return payload.get("train_slowdown")

--- a/benchmarks/track_pipeline_benchmarks.py
+++ b/benchmarks/track_pipeline_benchmarks.py
@@ -1,6 +1,22 @@
+import json
+import os
+from pathlib import Path
+
 """This module is used to track the performance of the full pipeline with asv."""
 
 
 def track_test():
-    """This test function should be able to detect by asv and run along for saving results"""
-    return 55555555555555
+    """
+    Load benchmark results from a JSON file under the ASV results directory and
+    return the requested slowdown metric.
+    """
+    base_dir = Path(__file__).resolve().parent / "gondor_results"
+
+    json_path = base_dir / "2026-07-24T22:08:39.409085+00:00.json"
+    if not json_path.exists():
+        return 11111111111111
+
+    with json_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    return payload.get("train_slowdown")

--- a/benchmarks/track_pipeline_benchmarks.py
+++ b/benchmarks/track_pipeline_benchmarks.py
@@ -22,3 +22,7 @@ def track_test():
     print(f"Loaded benchmark results from {json_path}: {payload}")
     print(f"Train slowdown: {payload.get('train_slowdown')}")
     return payload.get("train_slowdown")
+
+if __name__ == "__main__":
+    result = track_test()
+    print(f"Returned: {result}")

--- a/benchmarks/track_pipeline_benchmarks.py
+++ b/benchmarks/track_pipeline_benchmarks.py
@@ -1,6 +1,6 @@
 import json
-import os
 from pathlib import Path
+
 
 class PipelineBenchmarkTracker:
     """Loads benchmark results once and return metrics for ASV."""
@@ -27,13 +27,24 @@ class PipelineBenchmarkTracker:
         print(self.payload)
 
     def track_train_slowdown(self):
+        """
+        Track and return the train slowdown factor between Hyrax and PyTorch.
+        """
         return self.payload.get("train_slowdown")
 
     def track_infer_slowdown(self):
+        """
+        Track and return the infer performance slowdown factor between Hyrax and PyTorch.
+        """
         return self.payload.get("infer_slowdown")
 
     def track_total_slowdown(self):
+        """
+        Track and return the overall performance slowdown factor between Hyrax and PyTorch.
+        The metric combines training and inference time for both frameworks.
+        """
         return self.payload.get("total_slowdown")
+
 
 def track_test():
     """
@@ -52,6 +63,7 @@ def track_test():
         payload = json.load(handle)
 
     return payload.get("train_slowdown")
+
 
 # if __name__ == "__main__":
 #     result = track_test()

--- a/benchmarks/track_pipeline_benchmarks.py
+++ b/benchmarks/track_pipeline_benchmarks.py
@@ -53,11 +53,11 @@ def track_test():
 
     return payload.get("train_slowdown")
 
-if __name__ == "__main__":
-    result = track_test()
-    print(f"Returned from track_test: {result}")
+# if __name__ == "__main__":
+#     result = track_test()
+#     print(f"Returned from track_test: {result}")
 
-    tracker = PipelineBenchmarkTracker()
-    print(tracker.track_train_slowdown())
-    print(tracker.track_infer_slowdown())
-    print(tracker.track_total_slowdown())
+#     tracker = PipelineBenchmarkTracker()
+#     print(tracker.track_train_slowdown())
+#     print(tracker.track_infer_slowdown())
+#     print(tracker.track_total_slowdown())

--- a/benchmarks_self_hosted/run_timebench.py
+++ b/benchmarks_self_hosted/run_timebench.py
@@ -86,11 +86,13 @@ def main():
     )
 
     # save the result to json file
-    output_dir = Path(os.environ.get("RESULT_PATH", "benchmarks/results"))
+    output_dir = Path(os.environ.get("RESULT_PATH", "benchmarks_self_hosted/results"))
     # make sure the directory exist
     output_dir.mkdir(parents=True, exist_ok=True)
-
-    result_file = output_dir / f"{result['commit']}.json"
+    timestamp = datetime.datetime.fromisoformat(result["timestamp"])
+    # filename format: <short_commit>_<YYYYMMDD_HHMMSS>.json
+    filename = f"{result['commit'][:8]}_{timestamp.strftime('%Y%m%d_%H%M%S')}.json"
+    result_file = output_dir / filename
 
     with open(result_file, "w") as f:
         json.dump(


### PR DESCRIPTION
## Change Description

- Update the asv-nightly workflow to also fetch benchmark results generated from the self-hosted runner. Results generated on the self-hosted runner are currently stored under `gondor_results`.
- Update the existing `track_test` function to read data from a specific benchmark results file. The function is kept for testing.
- Add a benchmark tracking class that loads the results file once and reuses it across all `track_*` functions, avoiding repeated file reads.
- Improve the naming convention for self-hosted benchmark result files to make them more informative. Results are now named using the format `<short_commit>_<YYYYMMDD_HHMMSS>.json`.
