### PR TITLE
Update cache key for asv nightly-results

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -47,16 +47,16 @@ jobs:
           # move results from self-hosted runner to current working dir
           mv ../gondor_results .
         fi
-    - name: Get nightly dates under comparison
-      id: nightly-dates
-      run: |
-        echo "yesterday=$(date -d yesterday +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-        echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
     - name: Use last nightly commit hash from cache
-      uses: actions/cache@v6
+      uses: actions/cache/restore@v6
       with:
         path: ${{env.WORKING_DIR}}
-        key: nightly-results-${{steps.nightly-dates.outputs.yesterday}}
+        # Exact match should always be a cache miss, there is no cache for current commit.
+        # Search for prefix partial matches, it will get the most recent one from cache.
+        key: nightly-results-${{ github.sha }}
+        # `restore-keys` provided for safety
+        restore-keys: |
+          nightly-results-
     - name: Run comparison of main against last nightly build
       id: benchmark-run
       run: |
@@ -84,10 +84,10 @@ jobs:
         echo $CURRENT_HASH > $HASH_FILE
         echo "regression=$REGRESSION" >> $GITHUB_OUTPUT
     - name: Update last nightly hash in cache
-      uses: actions/cache@v6
+      uses: actions/cache/save@v6
       with:
         path: ${{env.WORKING_DIR}}
-        key: nightly-results-${{steps.nightly-dates.outputs.today}}
+        key: nightly-results-${{github.sha}}
     - name: Generate dashboard HTML
       run: |
         asv publish

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -51,12 +51,9 @@ jobs:
       uses: actions/cache/restore@v6
       with:
         path: ${{env.WORKING_DIR}}
-        # Exact match should always be a cache miss, there is no cache for current commit.
+        # Exact match should be a cache miss.
         # Search for prefix partial matches, it will get the most recent one from cache.
-        key: nightly-results-${{ github.sha }}
-        # `restore-keys` provided for safety
-        restore-keys: |
-          nightly-results-
+        key: nightly-results-
     - name: Run comparison of main against last nightly build
       id: benchmark-run
       run: |


### PR DESCRIPTION
## Change Description
Update the cache key naming convention for the ASV nightly-results cache.

Previously, the cache key was named `nightly-results-<date>`, which allowed only one cache to be created per day. As a result, if a cache with that key already existed, subsequent runs on the same day would be cache hit and no new data would be saved.
This PR changes the cache key to `nightly-results-<commit>`, making each cache unique to a commit rather than the date. When restoring the cache, github actions does a prefix (`nightly-results-`) match for partial matching and restore the most recent matching cache. This preserves the previous behavior of reusing the latest results while allowing each benchmark run to create a new cache entry.