### PR TITLE
Bind validate_batch to DDP and update autoencoderv2 to use self.forward()

### DIFF
--- a/src/hyrax/models/hyrax_autoencoderv2.py
+++ b/src/hyrax/models/hyrax_autoencoderv2.py
@@ -151,7 +151,7 @@ class HyraxAutoencoderV2(nn.Module):
             Dictionary containing the loss value for the current batch.
         """
         x = batch
-        z = self._eval_encoder(x)
+        z = self.forward(x)
         x_hat = self._eval_decoder(z)
 
         # The loss averaging strategy here is different from v1 which averages
@@ -199,7 +199,7 @@ class HyraxAutoencoderV2(nn.Module):
             Dictionary containing the loss value for the current batch.
         """
         x = batch
-        z = self._eval_encoder(x)
+        z = self.forward(x)
         x_hat = self._eval_decoder(z)
 
         if self.band_reduction == "sum":
@@ -233,7 +233,7 @@ class HyraxAutoencoderV2(nn.Module):
             Dictionary containing the loss value for the current batch.
         """
         x = batch
-        z = self._eval_encoder(x)
+        z = self.forward(x)
         x_hat = self._eval_decoder(z)
 
         if self.band_reduction == "sum":

--- a/src/hyrax/pytorch_ignite.py
+++ b/src/hyrax/pytorch_ignite.py
@@ -429,7 +429,7 @@ def extract_model_method(model, method_name):
         The method extracted from the model
     """
 
-    wrapped = type(model) is DistributedDataParallel or type(model) is DataParallel
+    wrapped = type(model) is DistributedDataParallel
 
     if not hasattr(model.module if wrapped else model, method_name):
         raise RuntimeError(f"Model does not have required method: {method_name}")
@@ -517,9 +517,15 @@ def create_validator(
 
     device = idist.device()
     wrapped_model = _auto_model(model)
-    tensorboardx_logger = get_tensorboard_logger()
+
+    wrapped = type(wrapped_model) is DistributedDataParallel
+
+    if wrapped:
+        # bind the validate_batch function to the DDP model
+        wrapped_model.validate_batch = model.validate_batch.__get__(wrapped_model)
 
     validator = create_engine("validate_batch", device, wrapped_model, config)
+    tensorboardx_logger = get_tensorboard_logger()
     fixup_engine(validator)
 
     @validator.on(Events.STARTED)
@@ -712,9 +718,7 @@ def create_trainer(model: torch.nn.Module, config: dict, results_directory: Path
     model.train()
     wrapped_model = _auto_model(model)
 
-    # in the future, write our own auto_model function which will not use DataParallel.
-    # remove all instances of DataParallel from code at that point.
-    wrapped = type(wrapped_model) is DistributedDataParallel or type(wrapped_model) is DataParallel
+    wrapped = type(wrapped_model) is DistributedDataParallel
 
     if wrapped:
         # bind the train_batch function to the DDP model


### PR DESCRIPTION
Fixes distributed desyncing issue on unsupervised training notebooks (use autoencoverv2 model) by

1) Updating hyrax_autoencoderv2 to use `self.forward()` rather than `self._eval_encode` so that DDP can actually have an effect
2) Binding `validate_batch` to DDP in `pytorch_ignite.py` so that validation is done correctly through DDP
