### PR TITLE
Update models for DDP compatibility

### DIFF
--- a/src/hyrax/models/hsc_dcae.py
+++ b/src/hyrax/models/hsc_dcae.py
@@ -95,7 +95,7 @@ class HSCDCAE(nn.Module):
         x1 = self.activation(self.encoder1(data))
         x2 = self.activation(self.encoder2(self.pool(x1)))
         x3 = self.activation(self.encoder3(self.pool(x2)))
-        x4 = self.activation(self.encoder4(self.pool(x3)))
+        x4 = self.forward(data)
 
         # Decoder with skip connections
         x = self.activation(self.decoder4(x4) + x3)
@@ -133,7 +133,7 @@ class HSCDCAE(nn.Module):
         x1 = self.activation(self.encoder1(data))
         x2 = self.activation(self.encoder2(self.pool(x1)))
         x3 = self.activation(self.encoder3(self.pool(x2)))
-        x4 = self.activation(self.encoder4(self.pool(x3)))
+        x4 = self.forward(data)
 
         # Decoder with skip connections
         x = self.activation(self.decoder4(x4) + x3)
@@ -169,7 +169,7 @@ class HSCDCAE(nn.Module):
         x1 = self.activation(self.encoder1(data))
         x2 = self.activation(self.encoder2(self.pool(x1)))
         x3 = self.activation(self.encoder3(self.pool(x2)))
-        x4 = self.activation(self.encoder4(self.pool(x3)))
+        x4 = self.forward(data)
 
         # Decoder with skip connections
         x = self.activation(self.decoder4(x4) + x3)

--- a/src/hyrax/models/hyrax_autoencoder.py
+++ b/src/hyrax/models/hyrax_autoencoder.py
@@ -109,7 +109,7 @@ class HyraxAutoencoder(nn.Module):
         return x
 
     def forward(self, batch):
-        return self._eval_encoder(batch)
+        return self.forward(batch)
 
     def train_batch(self, batch):
         """This function contains the logic for a single training step. i.e. the
@@ -126,7 +126,7 @@ class HyraxAutoencoder(nn.Module):
         Current loss value : dict
             Dictionary containing the loss value for the current batch.
         """
-        z = self._eval_encoder(batch)
+        z = self.forward(batch)
         x_hat = self._eval_decoder(z)
         loss = F.mse_loss(batch, x_hat, reduction="none")
         loss = loss.sum(dim=[1, 2, 3]).mean(dim=[0])
@@ -155,7 +155,7 @@ class HyraxAutoencoder(nn.Module):
         Current loss value : dict
             Dictionary containing the loss value for the current batch.
         """
-        z = self._eval_encoder(batch)
+        z = self.forward(batch)
         x_hat = self._eval_decoder(z)
         loss = F.mse_loss(batch, x_hat, reduction="none")
         loss = loss.sum(dim=[1, 2, 3]).mean(dim=[0])
@@ -178,7 +178,7 @@ class HyraxAutoencoder(nn.Module):
         Current loss value : dict
             Dictionary containing the loss value for the current batch.
         """
-        z = self._eval_encoder(batch)
+        z = self.forward(batch)
         x_hat = self._eval_decoder(z)
         loss = F.mse_loss(batch, x_hat, reduction="none")
         loss = loss.sum(dim=[1, 2, 3]).mean(dim=[0])

--- a/src/hyrax/models/hyrax_autoencoder.py
+++ b/src/hyrax/models/hyrax_autoencoder.py
@@ -109,7 +109,7 @@ class HyraxAutoencoder(nn.Module):
         return x
 
     def forward(self, batch):
-        return self.forward(batch)
+        return self._eval_encoder(batch)
 
     def train_batch(self, batch):
         """This function contains the logic for a single training step. i.e. the

--- a/src/hyrax/models/hyrax_loopback.py
+++ b/src/hyrax/models/hyrax_loopback.py
@@ -36,19 +36,23 @@ class HyraxLoopback(nn.Module):
             x, _ = x
         return x
 
+    # dummy self.forward() called for DDP compatibility
     def train_batch(self, batch):
         """Training is a noop"""
         logger.debug(f"Batch length: {len(batch)}")
+        self.forward(batch)
         return {"loss": 0.0}
 
     def validate_batch(self, batch):
-        """Validation is just a forward pass"""
+        """Validation is a noop"""
         logger.debug(f"Batch length: {len(batch)}")
+        self.forward(batch)
         return {"loss": 0.0}
 
     def test_batch(self, batch):
-        """Testing is just a forward pass"""
+        """Testing is a noop"""
         logger.debug(f"Batch length: {len(batch)}")
+        self.forward(batch)
         return {"loss": 0.0}
 
     def infer_batch(self, batch):

--- a/src/hyrax/models/image_dcae.py
+++ b/src/hyrax/models/image_dcae.py
@@ -207,6 +207,7 @@ class ImageDCAE(nn.Module):
 
         # Encode to latent space
         latent, skip_connections, encoded_shape = self.encode(data)
+        latent = self.forward(data)  # forward call required for DDP compatbility
 
         # Decode back to image
         decoded = self.decode(latent, skip_connections, encoded_shape)
@@ -240,6 +241,7 @@ class ImageDCAE(nn.Module):
 
         # Encode to latent space
         latent, skip_connections, encoded_shape = self.encode(data)
+        latent = self.forward(data)  # forward call required for DDP compatbility
 
         # Decode back to image
         decoded = self.decode(latent, skip_connections, encoded_shape)
@@ -271,7 +273,7 @@ class ImageDCAE(nn.Module):
 
         # Encode to latent space
         latent, skip_connections, encoded_shape = self.encode(data)
-
+        latent = self.forward(data)  # forward call required for DDP compatibility
         # Decode back to image
         decoded = self.decode(latent, skip_connections, encoded_shape)
 


### PR DESCRIPTION
Closes issue #1009. DDP compatibility requires calling `self()` or `self.forward()` in the `*_batch` methods, so I have updated the existing models to do that.