### PR TITLE
Fix interpreter hang on training failure by daemonizing GpuMonitor

### DIFF
--- a/src/hyrax/gpu_monitor.py
+++ b/src/hyrax/gpu_monitor.py
@@ -13,7 +13,9 @@ class GpuMonitor(Thread):
     """
 
     def __init__(self, interval_seconds=1):
-        super().__init__()
+        # daemon=True so this thread can never block interpreter shutdown if
+        # `stop()` is skipped (e.g. an exception during training).
+        super().__init__(daemon=True)
         self.stopped = False
         self.delay = interval_seconds  # Seconds between calls to GPUtil
         self.start_time = time.time()

--- a/src/hyrax/verbs/train.py
+++ b/src/hyrax/verbs/train.py
@@ -162,30 +162,32 @@ class Train(Verb):
 
         monitor = GpuMonitor()
 
-        # Go up to the parent of the results dir so all mlflow results show up in the same directory.
-        results_root_dir = Path(config["general"]["results_dir"]).expanduser().resolve()
-        (results_root_dir / "mlflow").mkdir(parents=True, exist_ok=True)
-        mlflow.set_tracking_uri("sqlite:///" + str(results_root_dir / "mlflow" / "mlflow.db"))
+        try:
+            # Go up to the parent of the results dir so all mlflow results show up in the same directory.
+            results_root_dir = Path(config["general"]["results_dir"]).expanduser().resolve()
+            (results_root_dir / "mlflow").mkdir(parents=True, exist_ok=True)
+            mlflow.set_tracking_uri("sqlite:///" + str(results_root_dir / "mlflow" / "mlflow.db"))
 
-        # Get experiment_name and cast to string (it's a tomlkit.string by default)
-        experiment_name = str(config["train"]["experiment_name"])
+            # Get experiment_name and cast to string (it's a tomlkit.string by default)
+            experiment_name = str(config["train"]["experiment_name"])
 
-        # This will create the experiment if it doesn't exist
-        mlflow.set_experiment(experiment_name)
+            # This will create the experiment if it doesn't exist
+            mlflow.set_experiment(experiment_name)
 
-        # If run_name is not `false` in the config, use it as the MLFlow run name in
-        # this experiment. Otherwise use the name of the results directory
-        run_name = str(config["train"]["run_name"]) if config["train"]["run_name"] else results_dir.name
+            # If run_name is not `false` in the config, use it as the MLFlow run name in
+            # this experiment. Otherwise use the name of the results directory
+            run_name = str(config["train"]["run_name"]) if config["train"]["run_name"] else results_dir.name
 
-        with mlflow.start_run(log_system_metrics=True, run_name=run_name):
-            Train._log_params(config, results_dir)
+            with mlflow.start_run(log_system_metrics=True, run_name=run_name):
+                Train._log_params(config, results_dir)
 
-            # Run the training process
-            trainer.run(train_data_loader, max_epochs=config["train"]["epochs"])
+                # Run the training process
+                trainer.run(train_data_loader, max_epochs=config["train"]["epochs"])
 
-        # Save the trained model
-        model.save(results_dir / config["train"]["weights_filename"])
-        monitor.stop()
+            # Save the trained model
+            model.save(results_dir / config["train"]["weights_filename"])
+        finally:
+            monitor.stop()
 
         logger.info("Finished Training")
         close_tensorboard_logger()


### PR DESCRIPTION
## Change Description
GpuMonitor was a non-daemon thread started on every train() call, and its stop() was only called after trainer.run()/model.save() succeeded, with no try/finally. Any exception during training (bad config, OOM, a real model bug) skipped stop() entirely, leaving an immortal background thread that blocks the interpreter forever at shutdown while it waits to join it.

Mark GpuMonitor as daemon=True so it can never block process exit, and wrap the training body in train.py in try/finally so stop() is always called promptly regardless of the daemon flag.

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
