### PR TITLE
update cache key to contain date

### DIFF
--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -47,13 +47,18 @@ jobs:
           # move results from self-hosted runner to current working dir
           mv ../gondor_results .
         fi
+    - name: Get nightly dates under comparison
+      id: nightly-dates
+      run: |
+        echo "yesterday=$(date -d yesterday +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
     - name: Use last nightly commit hash from cache
       uses: actions/cache/restore@v6
       with:
         path: ${{env.WORKING_DIR}}
         # Exact match should be a cache miss.
-        # Search for prefix partial matches, it will get the most recent one from cache.
-        key: nightly-results-
+        # Search for prefix partial matches, it will get the most recent cache from yesterday.
+        key: nightly-results-${{steps.nightly-dates.outputs.yesterday}}-
     - name: Run comparison of main against last nightly build
       id: benchmark-run
       run: |
@@ -84,7 +89,7 @@ jobs:
       uses: actions/cache/save@v6
       with:
         path: ${{env.WORKING_DIR}}
-        key: nightly-results-${{github.sha}}
+        key: nightly-results-${{steps.nightly-dates.outputs.today}}-${{github.sha}}
     - name: Generate dashboard HTML
       run: |
         asv publish

--- a/.github/workflows/asv-nightly.yml
+++ b/.github/workflows/asv-nightly.yml
@@ -58,7 +58,7 @@ jobs:
         path: ${{env.WORKING_DIR}}
         # Exact match should be a cache miss.
         # Search for prefix partial matches, it will get the most recent cache from yesterday.
-        key: nightly-results-${{steps.nightly-dates.outputs.yesterday}}-
+        key: nightly-results-
     - name: Run comparison of main against last nightly build
       id: benchmark-run
       run: |


### PR DESCRIPTION
## Change Description
Follow-up to PR #1007.

This PR updates the cache key naming convention to `nightly-results-<date>-<commit>`.

Including the date ensures that a new cache entry is created each day, even if no new commits have been made. This allows the nightly benchmark workflow to persist new results for every scheduled run while still distinguishing caches by commit.