### PR TITLE
Streaming data provider uses getter methods to retrieve data

### DIFF
--- a/src/hyrax/datasets/streaming_data_provider.py
+++ b/src/hyrax/datasets/streaming_data_provider.py
@@ -47,6 +47,7 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
     def __init__(self, config: dict, request: dict):
         self.config = config
         self.data_request = request
+        self.dataset_getters = {}  # field_name -> callable
 
         if len(request) != 1:
             raise RuntimeError(
@@ -96,6 +97,24 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
 
         self.prepped_datasets = {friendly_name: self._stream}
 
+        # If no fields were specifically requested, we'll assume that the user
+        # wants _all_ the available fields - user defined and dynamically created!
+        if not self.fields:
+            self.fields = [method[4:] for method in dir(self._stream) if method.startswith("get_")]
+
+        # Cache all of the `get_<field_name>` methods in the dataset instance
+        # so that we don't have to look them up each time we call `resolve_data`.
+        for method in dir(self._stream):
+            if method.startswith("get_"):
+                field_name = method[4:]  # Remove the "get_" prefix
+                self.dataset_getters[field_name] = getattr(self._stream, method)
+
+        if len(self.dataset_getters) == 0:
+            logger.error(
+                f"No `get_*` methods were found in the class: {type(self._stream)}. "
+                "This is likely an error in the dataset class definition."
+            )
+
         # Collation wiring consumed by CollationMixin.collate.
         self.custom_collate_functions: dict = {}
         self.field_collate_functions: dict = {friendly_name: {}}
@@ -104,10 +123,10 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
             # A user subclass may define a dataset-level collate; honor it.
             self.custom_collate_functions[friendly_name] = stream_collate
 
-        # If fields are known up front, register per-field collate hooks now; otherwise
-        # this happens lazily once the first sample reveals the field names.
-        if self.fields:
-            self._register_field_collate_hooks()
+        # The user will define the fields they want, or if none are defined,
+        # we'll derive them from the getters in the dataset instance. Either way,
+        # we need to register any field-level collate hooks.
+        self._register_field_collate_hooks()
 
     def _register_field_collate_hooks(self):
         """Detect ``collate_<field>`` methods on the wrapped stream for each field."""
@@ -118,20 +137,24 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
 
     def _structure(self, sample: dict) -> dict:
         """Turn a flat decoded sample into the per-sample shape ``collate`` expects."""
-        if not self.fields:
-            self.fields = [key for key in sample if key != self.primary_id_field]
-            self._register_field_collate_hooks()
         data = {}
         for field in self.fields:
-            arr = np.asarray(sample[field])
+            arr = np.asarray(self.dataset_getters[field](sample))
             data[field] = arr.astype(np.float32, copy=False) if np.issubdtype(arr.dtype, np.floating) else arr
 
-        return {"object_id": str(sample[self.primary_id_field]), self.friendly_name: data}
+        return {"object_id": self.get_object_id(sample), self.friendly_name: data}
 
     def __iter__(self):
         """Yield ``list[dict]`` batches of structured samples for ``collate_fn``."""
         for batch in self._stream:
             yield [self._structure(sample) for sample in batch]
+
+    def get_object_id(self, sample: dict) -> str:
+        """Returns the ID for a given sample.
+
+        IDs are provided by the primary dataset's primary ID column.
+        """
+        return str(sample[self.primary_id_field])
 
     def sample_data(self) -> dict:
         """Return one structured sample for model pre-flighting (``setup_model``).

--- a/src/hyrax/datasets/streaming_data_provider.py
+++ b/src/hyrax/datasets/streaming_data_provider.py
@@ -47,7 +47,7 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
     def __init__(self, config: dict, request: dict):
         self.config = config
         self.data_request = request
-        self.dataset_getters = {}  # field_name -> callable
+        self.dataset_getters = {}  # friendly_name -> field_name -> callable
 
         if len(request) != 1:
             raise RuntimeError(
@@ -103,13 +103,14 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
             self.fields = [method[4:] for method in dir(self._stream) if method.startswith("get_")]
 
         # Cache all of the `get_<field_name>` methods in the dataset instance
-        # so that we don't have to look them up each time we call `resolve_data`.
+        # so that we don't have to look them up each time we call `_structure`.
+        self.dataset_getters = {self.friendly_name: {}}
         for method in dir(self._stream):
             if method.startswith("get_"):
                 field_name = method[4:]  # Remove the "get_" prefix
-                self.dataset_getters[field_name] = getattr(self._stream, method)
+                self.dataset_getters[self.friendly_name][field_name] = getattr(self._stream, method)
 
-        if len(self.dataset_getters) == 0:
+        if len(self.dataset_getters[self.friendly_name]) == 0:
             logger.error(
                 f"No `get_*` methods were found in the class: {type(self._stream)}. "
                 "This is likely an error in the dataset class definition."
@@ -117,11 +118,11 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
 
         # Collation wiring consumed by CollationMixin.collate.
         self.custom_collate_functions: dict = {}
-        self.field_collate_functions: dict = {friendly_name: {}}
+        self.field_collate_functions: dict = {self.friendly_name: {}}
         stream_collate = getattr(self._stream, "collate", None)
         if callable(stream_collate):
             # A user subclass may define a dataset-level collate; honor it.
-            self.custom_collate_functions[friendly_name] = stream_collate
+            self.custom_collate_functions[self.friendly_name] = stream_collate
 
         # The user will define the fields they want, or if none are defined,
         # we'll derive them from the getters in the dataset instance. Either way,
@@ -139,22 +140,16 @@ class StreamingDataProvider(CollationMixin, torch.utils.data.IterableDataset):
         """Turn a flat decoded sample into the per-sample shape ``collate`` expects."""
         data = {}
         for field in self.fields:
-            arr = np.asarray(self.dataset_getters[field](sample))
+            arr = np.asarray(self.dataset_getters[self.friendly_name][field](sample))
             data[field] = arr.astype(np.float32, copy=False) if np.issubdtype(arr.dtype, np.floating) else arr
 
-        return {"object_id": self.get_object_id(sample), self.friendly_name: data}
+        object_id = self.dataset_getters[self.friendly_name][self.primary_id_field](sample)
+        return {"object_id": object_id, self.friendly_name: data}
 
     def __iter__(self):
         """Yield ``list[dict]`` batches of structured samples for ``collate_fn``."""
         for batch in self._stream:
             yield [self._structure(sample) for sample in batch]
-
-    def get_object_id(self, sample: dict) -> str:
-        """Returns the ID for a given sample.
-
-        IDs are provided by the primary dataset's primary ID column.
-        """
-        return str(sample[self.primary_id_field])
 
     def sample_data(self) -> dict:
         """Return one structured sample for model pre-flighting (``setup_model``).

--- a/stream_test/producer.py
+++ b/stream_test/producer.py
@@ -80,6 +80,7 @@ def make_message(index: int) -> dict:
         "value": round(random.uniform(0, 100), 4),
         "image": np.random.rand(4, 4).tolist(),
         "label": np.random.randint(0, 9),
+        "time_series": [round(random.uniform(0, 1), 4) for _ in range(random.randint(2, 10))],
         "timestamp": datetime.now(UTC).isoformat(),
     }
 

--- a/tests/hyrax/test_infer_stream.py
+++ b/tests/hyrax/test_infer_stream.py
@@ -26,6 +26,10 @@ class _ImageStream(KafkaStreamDataset):
         """Return the image payload of one decoded sample."""
         return sample["image"]
 
+    def get_object_id(self, sample):
+        """Return the object id of one decoded sample."""
+        return str(sample["object_id"])
+
 
 def _msg(object_id, image):
     return FakeMessage(json.dumps({"object_id": object_id, "image": image}))

--- a/tests/hyrax/test_infer_stream.py
+++ b/tests/hyrax/test_infer_stream.py
@@ -15,6 +15,18 @@ import hyrax
 from hyrax.datasets.kafka_stream_dataset import KafkaStreamDataset
 
 
+class _ImageStream(KafkaStreamDataset):
+    """KafkaStreamDataset subclass exposing the `get_<field>` accessors the provider needs.
+
+    ``StreamingDataProvider`` reads each requested field through ``get_<field>(sample)`` on
+    the wrapped dataset, so a stream must define one getter per field it offers.
+    """
+
+    def get_image(self, sample):
+        """Return the image payload of one decoded sample."""
+        return sample["image"]
+
+
 def _msg(object_id, image):
     return FakeMessage(json.dumps({"object_id": object_id, "image": image}))
 
@@ -40,7 +52,7 @@ def test_infer_stream_iterates_streaming_dataset(tmp_path, monkeypatch):
     h.config["data_request"] = {
         "infer_stream": {
             "data": {
-                "dataset_class": "KafkaStreamDataset",
+                "dataset_class": "_ImageStream",
                 "data_location": "./",
                 "primary_id_field": "object_id",
                 "fields": ["image"],

--- a/tests/hyrax/test_streaming_data_provider.py
+++ b/tests/hyrax/test_streaming_data_provider.py
@@ -2,7 +2,13 @@
 
 Reuses the FakeConsumer pattern from ``test_kafka_stream_dataset.py``: the provider builds
 a KafkaStreamDataset internally, so tests patch ``provider._stream._make_consumer``.
+
+The provider reads every field through a ``get_<field>(sample)`` method on the wrapped
+dataset rather than indexing the decoded sample dict, so the streams used here are
+KafkaStreamDataset subclasses that define those getters.
 """
+
+import logging
 
 import numpy as np
 import pytest
@@ -16,8 +22,33 @@ from hyrax.datasets.streaming_data_provider import StreamingDataProvider
 from hyrax.pytorch_ignite import dist_data_loader, setup_dataset
 
 
+class _GetterStream(KafkaStreamDataset):
+    """KafkaStreamDataset subclass exposing ``get_<field>`` accessors over flat samples.
+
+    ``get_flux`` is deliberately *derived* — the decoded messages carry no ``flux`` key —
+    so tests can tell getter-mediated access apart from a plain dict lookup.
+    """
+
+    def get_image(self, sample):
+        """Return the image payload of one decoded sample."""
+        return sample["image"]
+
+    def get_flux(self, sample):
+        """Compute a scalar flux from the image; there is no `flux` key in the message."""
+        return float(np.sum(sample["image"]))
+
+
+class _HookedStream(_GetterStream):
+    """Getter stream that also defines a per-field collate hook for `image`."""
+
+    def collate_image(self, samples):
+        """Stack images and also emit a boolean mask of the same shape."""
+        arr = np.stack([s["image"] for s in samples], axis=0)
+        return {"image": arr, "image_mask": np.ones_like(arr, dtype=bool)}
+
+
 def _build_provider(
-    batch_size=5, flush=100.0, fields=("image",), primary_id="object_id", dataset_class="KafkaStreamDataset"
+    batch_size=5, flush=100.0, fields=("image",), primary_id="object_id", dataset_class="_GetterStream"
 ):
     """Construct a StreamingDataProvider wrapping a KafkaStreamDataset."""
     h = hyrax.Hyrax()
@@ -55,6 +86,71 @@ def test_structure_shapes_a_flat_sample():
     assert structured["data"]["image"].dtype == np.float32
 
 
+def test_structure_reads_fields_through_dataset_getters():
+    """Field values come from `get_<field>(sample)`, not from indexing the sample dict."""
+    provider = _build_provider(fields=("image", "flux"))
+    # The decoded message has no `flux` key — only `_GetterStream.get_flux` can produce it.
+    structured = provider._structure({"object_id": "abc", "image": [[1.0, 2.0], [3.0, 4.0]]})
+
+    assert structured["data"]["flux"] == np.float32(10.0)
+    assert structured["data"]["image"].shape == (2, 2)
+
+
+def test_getters_are_cached_from_the_stream_instance():
+    """Every `get_*` method on the stream is cached as a bound method, regardless of `fields`."""
+    provider = _build_provider(fields=("image",))
+
+    # All getters are cached, even though only `image` was requested...
+    assert set(provider.dataset_getters) == {"image", "flux"}
+    # ...and each one is bound to the wrapped stream instance.
+    for getter in provider.dataset_getters.values():
+        assert getter.__self__ is provider._stream
+
+    # The requested `fields` still control what `_structure` emits.
+    assert provider.fields == ["image"]
+    assert set(provider._structure({"object_id": "a", "image": [[1.0]]})["data"]) == {"image"}
+
+
+def test_fields_derived_from_getters_when_not_configured():
+    """With no `fields` in the request, they are derived from the stream's `get_*` methods."""
+    provider = _build_provider(fields=())
+
+    # Derived at construction time — no sample needed. `dir()` orders them alphabetically.
+    assert provider.fields == ["flux", "image"]
+
+    structured = provider._structure({"object_id": "x", "image": [[2.0]]})
+    assert set(structured["data"]) == {"flux", "image"}
+
+
+def test_requested_field_without_a_getter_raises():
+    """A requested field with no matching `get_<field>` method fails when structuring."""
+    provider = _build_provider(fields=("image", "no_such_field"))
+
+    with pytest.raises(KeyError, match="no_such_field"):
+        provider._structure({"object_id": "a", "image": [[1.0]]})
+
+
+def test_error_logged_when_stream_has_no_getters(caplog):
+    """A stream with no `get_*` methods is a dataset-definition error and is logged as one."""
+    with caplog.at_level(logging.ERROR, logger="hyrax.datasets.streaming_data_provider"):
+        provider = _build_provider(fields=(), dataset_class="KafkaStreamDataset")
+
+    assert provider.dataset_getters == {}
+    assert provider.fields == []
+    assert "No `get_*` methods were found" in caplog.text
+    assert "KafkaStreamDataset" in caplog.text
+
+
+def test_get_object_id_stringifies_primary_id_field():
+    """get_object_id reads the configured primary id field and returns it as a string."""
+    provider = _build_provider(fields=("image",))
+    assert provider.get_object_id({"object_id": 12345, "image": [[1.0]]}) == "12345"
+
+    renamed = _build_provider(fields=("image",), primary_id="objectId")
+    assert renamed.get_object_id({"objectId": 7, "image": [[1.0]]}) == "7"
+    assert renamed._structure({"objectId": 7, "image": [[1.0]]})["object_id"] == "7"
+
+
 def test_collate_matches_infer_contract():
     """collate (from CollationMixin) yields object_id ndarray + grouped data fields."""
     provider = _build_provider(fields=("image",))
@@ -66,14 +162,6 @@ def test_collate_matches_infer_contract():
     assert list(collated["object_id"]) == ["id0", "id1", "id2", "id3"]
     assert collated["object_id"].dtype.kind in ("U", "S")
     assert collated["data"]["image"].shape == (4, 1, 2)
-
-
-def test_fields_derived_when_not_configured(monkeypatch):
-    """With no `fields` in the request, they are derived from the first sample."""
-    provider = _build_provider(fields=())
-    provider._structure({"object_id": "x", "image": [[1.0]], "flux": 3.0})
-
-    assert provider.fields == ["image", "flux"]
 
 
 def test_sample_data_returns_structured_and_is_not_lost(monkeypatch):
@@ -93,7 +181,7 @@ def test_sample_data_returns_structured_and_is_not_lost(monkeypatch):
 
 def test_dist_data_loader_end_to_end(monkeypatch):
     """The provider flows through dist_data_loader and yields collated batch dicts."""
-    provider = _build_provider(batch_size=2, fields=("image",))
+    provider = _build_provider(batch_size=2, fields=("image", "flux"))
     messages = [_make_message(f"id{i}", [[float(i)]]) for i in range(2)]
     _patch_stream(monkeypatch, provider, messages)
 
@@ -107,6 +195,8 @@ def test_dist_data_loader_end_to_end(monkeypatch):
     batch = batches[0]
     assert list(batch["object_id"]) == ["id0", "id1"]
     assert batch["data"]["image"].shape == (2, 1, 1)
+    # The derived (getter-only) field survives the whole path to the batch dict.
+    assert list(batch["data"]["flux"]) == [0.0, 1.0]
 
 
 def test_requires_single_dataset():
@@ -114,8 +204,8 @@ def test_requires_single_dataset():
     h = hyrax.Hyrax()
     h.config["data_set"]["KafkaStreamDataset"]["topics"] = "t"
     request = {
-        "a": {"dataset_class": "KafkaStreamDataset", "primary_id_field": "object_id"},
-        "b": {"dataset_class": "KafkaStreamDataset", "primary_id_field": "object_id"},
+        "a": {"dataset_class": "_GetterStream", "primary_id_field": "object_id"},
+        "b": {"dataset_class": "_GetterStream", "primary_id_field": "object_id"},
     }
     with pytest.raises(RuntimeError, match="exactly one"):
         StreamingDataProvider(h.config, request)
@@ -133,18 +223,9 @@ def test_requires_primary_id_field():
     """The request must declare which field is the object id."""
     h = hyrax.Hyrax()
     h.config["data_set"]["KafkaStreamDataset"]["topics"] = "t"
-    request = {"data": {"dataset_class": "KafkaStreamDataset"}}
+    request = {"data": {"dataset_class": "_GetterStream"}}
     with pytest.raises(RuntimeError, match="primary_id_field"):
         StreamingDataProvider(h.config, request)
-
-
-class _HookedStream(KafkaStreamDataset):
-    """KafkaStreamDataset subclass with a per-field collate hook for `image`."""
-
-    def collate_image(self, samples):
-        """Stack images and also emit a boolean mask of the same shape."""
-        arr = np.stack([s["image"] for s in samples], axis=0)
-        return {"image": arr, "image_mask": np.ones_like(arr, dtype=bool)}
 
 
 def test_field_collate_hook_is_honored():
@@ -159,6 +240,20 @@ def test_field_collate_hook_is_honored():
     assert collated["data"]["image_mask"].dtype == bool
 
 
+def test_field_collate_hooks_registered_for_derived_fields():
+    """Hooks are registered for getter-derived fields too, not just configured ones."""
+    provider = _build_provider(fields=(), dataset_class="_HookedStream")
+    hooks = provider.field_collate_functions["data"]
+
+    assert set(hooks) == {"flux", "image"}
+    assert hooks["image"] == provider._stream.collate_image
+    assert hooks["flux"] is None
+
+    collated = provider.collate([provider._structure({"object_id": "a", "image": [[3.0]]})])
+    assert "image_mask" in collated["data"]
+    assert collated["data"]["flux"] == np.float32(3.0)
+
+
 def test_setup_dataset_routes_streaming_vs_map():
     """setup_dataset picks StreamingDataProvider for iterable datasets, DataProvider otherwise."""
     h = hyrax.Hyrax()
@@ -166,7 +261,7 @@ def test_setup_dataset_routes_streaming_vs_map():
     h.config["data_request"] = {
         "stream": {
             "data": {
-                "dataset_class": "KafkaStreamDataset",
+                "dataset_class": "_GetterStream",
                 "primary_id_field": "object_id",
                 "fields": ["image"],
             }

--- a/tests/hyrax/test_streaming_data_provider.py
+++ b/tests/hyrax/test_streaming_data_provider.py
@@ -37,6 +37,10 @@ class _GetterStream(KafkaStreamDataset):
         """Compute a scalar flux from the image; there is no `flux` key in the message."""
         return float(np.sum(sample["image"]))
 
+    def get_object_id(self, sample):
+        """Return the object id as a string, regardless of its original type."""
+        return str(sample["object_id"])
+
 
 class _HookedStream(_GetterStream):
     """Getter stream that also defines a per-field collate hook for `image`."""
@@ -101,9 +105,9 @@ def test_getters_are_cached_from_the_stream_instance():
     provider = _build_provider(fields=("image",))
 
     # All getters are cached, even though only `image` was requested...
-    assert set(provider.dataset_getters) == {"image", "flux"}
+    assert set(provider.dataset_getters["data"]) == {"image", "flux", "object_id"}
     # ...and each one is bound to the wrapped stream instance.
-    for getter in provider.dataset_getters.values():
+    for getter in provider.dataset_getters["data"].values():
         assert getter.__self__ is provider._stream
 
     # The requested `fields` still control what `_structure` emits.
@@ -116,10 +120,10 @@ def test_fields_derived_from_getters_when_not_configured():
     provider = _build_provider(fields=())
 
     # Derived at construction time — no sample needed. `dir()` orders them alphabetically.
-    assert provider.fields == ["flux", "image"]
+    assert provider.fields == ["flux", "image", "object_id"]
 
     structured = provider._structure({"object_id": "x", "image": [[2.0]]})
-    assert set(structured["data"]) == {"flux", "image"}
+    assert set(structured["data"]) == {"flux", "image", "object_id"}
 
 
 def test_requested_field_without_a_getter_raises():
@@ -135,20 +139,10 @@ def test_error_logged_when_stream_has_no_getters(caplog):
     with caplog.at_level(logging.ERROR, logger="hyrax.datasets.streaming_data_provider"):
         provider = _build_provider(fields=(), dataset_class="KafkaStreamDataset")
 
-    assert provider.dataset_getters == {}
+    assert provider.dataset_getters["data"] == {}
     assert provider.fields == []
     assert "No `get_*` methods were found" in caplog.text
     assert "KafkaStreamDataset" in caplog.text
-
-
-def test_get_object_id_stringifies_primary_id_field():
-    """get_object_id reads the configured primary id field and returns it as a string."""
-    provider = _build_provider(fields=("image",))
-    assert provider.get_object_id({"object_id": 12345, "image": [[1.0]]}) == "12345"
-
-    renamed = _build_provider(fields=("image",), primary_id="objectId")
-    assert renamed.get_object_id({"objectId": 7, "image": [[1.0]]}) == "7"
-    assert renamed._structure({"objectId": 7, "image": [[1.0]]})["object_id"] == "7"
 
 
 def test_collate_matches_infer_contract():
@@ -245,7 +239,7 @@ def test_field_collate_hooks_registered_for_derived_fields():
     provider = _build_provider(fields=(), dataset_class="_HookedStream")
     hooks = provider.field_collate_functions["data"]
 
-    assert set(hooks) == {"flux", "image"}
+    assert set(hooks) == {"flux", "image", "object_id"}
     assert hooks["image"] == provider._stream.collate_image
     assert hooks["flux"] is None
 


### PR DESCRIPTION
Previously streaming_data_provider expected a dictionary representation of a data sample from a stream and would filter out keys that were not requested by the user. 

Now it will use get_* methods defined in and inherited by the dataset class to extract data from streaming samples. This means that StreamingDataProvider doesn't have to _assume_ that a sample will be a dict. And it means that explicitly defined message schemas can be supported by the streaming dataset classes. 

Additionally this brings the overall behavior in line with what is defined in the DataProvider class. 

Note that the biggest difference is that DataProvider will call `get_*` methods and provide an integer index, the StreamingDataProvider will call it's `get_*` methods and provide a specific message or sample. i.e.
`DataProvider -> get_image(index)`
`StreamingDataProvider -> get_image(sample)`
